### PR TITLE
Obey gradlew, make it spotless

### DIFF
--- a/state-manager/src/main/java/com/radixdlt/mempool/REv2Mempool.java
+++ b/state-manager/src/main/java/com/radixdlt/mempool/REv2Mempool.java
@@ -65,10 +65,6 @@
 package com.radixdlt.mempool;
 
 import com.google.common.collect.Lists;
-import com.radixdlt.mempool.Mempool;
-import com.radixdlt.mempool.MempoolDuplicateException;
-import com.radixdlt.mempool.MempoolFullException;
-import com.radixdlt.mempool.MempoolMetadata;
 import com.radixdlt.monitoring.SystemCounters;
 import com.radixdlt.transactions.Transaction;
 import java.util.*;


### PR DESCRIPTION
Current main branch fails gradlew spotless java check. This fixes it.