### PR TITLE
Build .deb in docker

### DIFF
--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -33,7 +33,7 @@ ENV RADIXDLT_HOME=/home/radixdlt \
     RADIXDLT_NETWORK_ID=99
 
 # install the radixdlt package
-COPY *.deb /tmp/
+COPY distrib/*.deb /tmp/
 RUN dpkg -i /tmp/*.deb
 
 # create configuration automatically when starting

--- a/docker/Dockerfile.deb4docker
+++ b/docker/Dockerfile.deb4docker
@@ -1,0 +1,32 @@
+FROM ubuntu:21.04 AS build-stage
+MAINTAINER radixdlt <devops@radixdlt.com>
+LABEL Description="Java + Ubuntu 21.04 (OpenJDK)"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+CMD /bin/bash
+
+RUN apt-get -y update > /dev/null && \
+    apt-get -y --no-install-recommends install wget unzip apt-utils net-tools iptables iproute2 gettext-base curl tcpdump strace attr software-properties-common daemontools > /dev/null
+
+RUN apt-get -y --no-install-recommends install openjdk-17-jdk clang > /dev/null
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+#install Gradle
+RUN wget -q https://services.gradle.org/distributions/gradle-7.2-bin.zip > /dev/null \
+    && unzip gradle-7.2-bin.zip -d /opt \
+    && rm gradle-7.2-bin.zip
+
+# Set Gradle in the environment variables
+ENV GRADLE_HOME=/opt/gradle-7.2
+ENV PATH=/root/.cargo/bin:/opt/gradle-7.2/bin:$PATH
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+
+COPY . /radixdlt
+WORKDIR /radixdlt
+USER root
+RUN gradle clean deb4docker -x test > /dev/null
+
+FROM scratch AS export-stage
+COPY --from=build-stage /radixdlt/core/build/distributions/*.deb /

--- a/docker/scripts/rundocker.sh
+++ b/docker/scripts/rundocker.sh
@@ -22,6 +22,8 @@ reporoot="${scriptdir}/../.."
 eval $(${reporoot}/gradlew -q -P "validators=${validators}" ":cli-tools:generateDevUniverse")
 
 # Launch
-${reporoot}/gradlew -p "${reporoot}" deb4docker && \
+rm docker/distrib/*.deb || true
+
+docker build -f ${scriptdir}/../Dockerfile.deb4docker -o docker/distrib . &&
   (docker kill $(docker ps -q) || true) 2>/dev/null && \
   docker-compose -f "${dockerfile}" up --build | tee docker.log


### PR DESCRIPTION
Now that we have native code, we cannot have the luxury of build the project in the host.

The following PR creates a Dockerfile.deb4docker, leaving Dockerfile.core simple and dedicated to the creation of the running environment. Another option would be to change Dockerfile.core to a multistage build, but it would complicate it a bit too much I believe.

While this makes docker scripts work, further work is needed: both the rust intallation and the gradle installation are non-cached as they require input from the network. This means that the project is rebuilt every time we run docker scripts.

A solution to this should be to create our own, published docker image of our build environment, and start from there in Docker.deb4docker.