### PR TITLE
Enable pattern matching for Option and Result

### DIFF
--- a/common/src/main/java/com/radixdlt/lang/Option.java
+++ b/common/src/main/java/com/radixdlt/lang/Option.java
@@ -69,7 +69,6 @@ import com.radixdlt.lang.Option.None;
 import com.radixdlt.lang.Option.Some;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -368,13 +367,7 @@ public sealed interface Option<T> permits Some, None {
     return new Some<>(value);
   }
 
-  final class Some<T> implements Option<T> {
-    private final T value;
-
-    private Some(T value) {
-      this.value = value;
-    }
-
+  record Some<T>(T value) implements Option<T> {
     @Override
     public <R> R fold(
         Supplier<? extends R> emptyMapper, FN1<? extends R, ? super T> presentMapper) {
@@ -382,26 +375,12 @@ public sealed interface Option<T> permits Some, None {
     }
 
     @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-
-      return o instanceof Some<?> some && value.equals(some.value);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(value);
-    }
-
-    @Override
     public String toString() {
-      return "Some(" + value.toString() + ")";
+      return "Some(" + value + ")";
     }
   }
 
-  final class None<T> implements Option<T> {
+  record None<T>() implements Option<T> {
     @Override
     public <R> R fold(
         Supplier<? extends R> emptyMapper, FN1<? extends R, ? super T> presentMapper) {

--- a/common/src/main/java/com/radixdlt/lang/Result.java
+++ b/common/src/main/java/com/radixdlt/lang/Result.java
@@ -71,7 +71,6 @@ import com.radixdlt.lang.Result.Failure;
 import com.radixdlt.lang.Result.Success;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -431,31 +430,11 @@ public sealed interface Result<T> permits Success, Failure {
     return new Success<>(value);
   }
 
-  final class Success<T> implements Result<T> {
-    private final T value;
-
-    private Success(T value) {
-      this.value = value;
-    }
-
+  record Success<T>(T value) implements Result<T> {
     @Override
     public <R> R fold(
         FN1<? extends R, ? super Cause> failureMapper, FN1<? extends R, ? super T> successMapper) {
       return successMapper.apply(value);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-
-      return o instanceof Success<?> success && value.equals(success.value);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(value);
     }
 
     @Override
@@ -478,36 +457,16 @@ public sealed interface Result<T> permits Success, Failure {
     return new Failure<>(value);
   }
 
-  final class Failure<T> implements Result<T> {
-    private final Cause value;
-
-    private Failure(Cause value) {
-      this.value = value;
-    }
-
+  record Failure<T>(Cause cause) implements Result<T> {
     @Override
     public <R> R fold(
         FN1<? extends R, ? super Cause> failureMapper, FN1<? extends R, ? super T> successMapper) {
-      return failureMapper.apply(value);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-
-      return o instanceof Failure<?> failure && value.equals(failure.value);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(value);
+      return failureMapper.apply(cause);
     }
 
     @Override
     public String toString() {
-      return "Failure(" + value + ")";
+      return "Failure(" + cause + ")";
     }
   }
 


### PR DESCRIPTION
This PR enables use of pattern matching for Option and Result as shown below:
```java
var httpMethod = HttpMethod.lookup(input, lookup, index - lookup);

if (httpMethod instanceof Some<HttpMethod> some) {
    method = some.value();
} else {
    return BAD_MSG;
}
```
(also can be used with switch expressions)