### PR TITLE
Add Codecs for Guava UnsignedInteger and UnsignedLong

### DIFF
--- a/common/src/main/java/com/radixdlt/sbor/codec/Codec.java
+++ b/common/src/main/java/com/radixdlt/sbor/codec/Codec.java
@@ -64,6 +64,7 @@
 
 package com.radixdlt.sbor.codec;
 
+import com.radixdlt.lang.Functions;
 import com.radixdlt.sbor.codec.constants.TypeId;
 import com.radixdlt.sbor.coding.DecoderApi;
 import com.radixdlt.sbor.coding.EncoderApi;
@@ -94,6 +95,16 @@ public interface Codec<T> extends UntypedCodec<T> {
 
   static <T> Codec<T> from(TypeId typeId, UntypedCodec<T> untypedCodec) {
     return of(typeId, untypedCodec::encodeWithoutTypeId, untypedCodec::decodeWithoutTypeId);
+  }
+
+  static <TOuter, TInner> Codec<TOuter> wrap(
+      Functions.Func1<TOuter, TInner> wrap,
+      Codec<TInner> codec1,
+      Functions.Func1<TInner, TOuter> unwrap) {
+    return Codec.of(
+        codec1.getTypeId(),
+        (encoder, value) -> codec1.encodeWithTypeId(encoder, wrap.apply(value)),
+        decoder -> unwrap.apply(codec1.decodeWithTypeId(decoder)));
   }
 
   @FunctionalInterface

--- a/common/src/main/java/com/radixdlt/sbor/codec/CodecMap.java
+++ b/common/src/main/java/com/radixdlt/sbor/codec/CodecMap.java
@@ -64,6 +64,8 @@
 
 package com.radixdlt.sbor.codec;
 
+import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.*;
 import com.radixdlt.sbor.codec.constants.TypeId;
@@ -155,9 +157,19 @@ public final class CodecMap {
 
     storeCodec(Integer.class, new IntegerCodec(true));
     storeCodec(int.class, new IntegerCodec(true));
+    storeCodec(
+        UnsignedInteger.class,
+        Codec.wrap(
+            UnsignedInteger::intValue,
+            new IntegerCodec(false, false),
+            UnsignedInteger::fromIntBits));
 
     storeCodec(Long.class, new LongCodec(true));
     storeCodec(long.class, new LongCodec(true));
+    storeCodec(
+        UnsignedLong.class,
+        Codec.wrap(
+            UnsignedLong::longValue, new LongCodec(false, false), UnsignedLong::fromLongBits));
 
     storeCodec(byte[].class, new ByteArrayCodec(sborTypeIdForArrayType));
     storeCodec(short[].class, new ShortArrayCodec(sborTypeIdForArrayType));

--- a/common/src/test/java/com/radixdlt/sbor/SborTest.java
+++ b/common/src/test/java/com/radixdlt/sbor/SborTest.java
@@ -69,6 +69,8 @@ import static com.radixdlt.lang.Option.some;
 import static com.radixdlt.lang.Tuple.*;
 import static org.junit.Assert.*;
 
+import com.google.common.primitives.UnsignedInteger;
+import com.google.common.primitives.UnsignedLong;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.*;
 import com.radixdlt.sbor.codec.CodecMap;
@@ -161,6 +163,18 @@ public class SborTest {
   }
 
   @Test
+  public void unsignedIntEdgeCasesCanBeEncodedAndDecoded() {
+    var encodedMaxValue = DefaultTypedSbor.encode(UnsignedInteger.MAX_VALUE);
+    var encodedMinValue = DefaultTypedSbor.encode(UnsignedInteger.ZERO);
+
+    var decodedMaxValue = DefaultTypedSbor.decode(encodedMaxValue, UnsignedInteger.class);
+    var decodedMinValue = DefaultTypedSbor.decode(encodedMinValue, UnsignedInteger.class);
+
+    assertEquals(UnsignedInteger.MAX_VALUE, decodedMaxValue);
+    assertEquals(UnsignedInteger.ZERO, decodedMinValue);
+  }
+
+  @Test
   public void longCanBeEncodedAndDecoded() {
     var r0 = DefaultTypedSbor.encode(0x0123_4567_89AB_CDEFL, long.class);
 
@@ -178,6 +192,18 @@ public class SborTest {
     var r1 = DefaultTypedSbor.decode(r0, long.class);
 
     assertEquals(0x0123_4567_89AB_CDEFL, (long) r1);
+  }
+
+  @Test
+  public void unsignedLongEdgeCasesCanBeEncodedAndDecoded() {
+    var encodedMaxValue = DefaultTypedSbor.encode(UnsignedLong.MAX_VALUE);
+    var encodedMinValue = DefaultTypedSbor.encode(UnsignedLong.ZERO);
+
+    var decodedMaxValue = DefaultTypedSbor.decode(encodedMaxValue, UnsignedLong.class);
+    var decodedMinValue = DefaultTypedSbor.decode(encodedMinValue, UnsignedLong.class);
+
+    assertEquals(UnsignedLong.MAX_VALUE, decodedMaxValue);
+    assertEquals(UnsignedLong.ZERO, decodedMinValue);
   }
 
   @Test
@@ -515,7 +541,6 @@ public class SborTest {
   }
 
   private record SborTestCase<T>(T value, TypeToken<T> type) {}
-  ;
 
   @Test
   @SuppressWarnings("Convert2Diamond") // Otherwise we get a compiler error :'(


### PR DESCRIPTION
As discussed... :)

Note that:
* This wraps the integer with an object on the heap always, so it’s not ideal for high performance code (but lol if you want high performance don’t use Java... And besides, the IntegerCodec also sadly has to create a box, so it's not exactly a world of performance even without UnsignedInteger.
* The Java way of doing this since Java 1.8 is to just store unsigned ints as ints (perhaps with an _unsigned suffix) and then be sure to use unsigned comparison and operator utility class methods provided by the Integer/Long static families; eg:
  * Integer.divideUnsigned(int, int) 
  * Long.divideUnsigned(long, long)

If you wish to use "The Java way" then you can explicitly opt into using eg a `new LongCodec(false, false)` for that codec.