### PR TITLE
Adds Int128 codecs for decoding UInt128 (and potentially IInt128)

### DIFF
--- a/common/src/main/java/com/radixdlt/sbor/codec/CodecMap.java
+++ b/common/src/main/java/com/radixdlt/sbor/codec/CodecMap.java
@@ -71,6 +71,8 @@ import com.radixdlt.lang.*;
 import com.radixdlt.sbor.codec.constants.TypeId;
 import com.radixdlt.sbor.codec.core.*;
 import com.radixdlt.sbor.exceptions.SborCodecException;
+import com.radixdlt.utils.Int128Codec;
+import com.radixdlt.utils.UInt128;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -170,6 +172,8 @@ public final class CodecMap {
         UnsignedLong.class,
         Codec.wrap(
             UnsignedLong::longValue, new LongCodec(false, false), UnsignedLong::fromLongBits));
+
+    storeCodec(UInt128.class, new Int128Codec(false));
 
     storeCodec(byte[].class, new ByteArrayCodec(sborTypeIdForArrayType));
     storeCodec(short[].class, new ShortArrayCodec(sborTypeIdForArrayType));

--- a/common/src/main/java/com/radixdlt/utils/Int128Codec.java
+++ b/common/src/main/java/com/radixdlt/utils/Int128Codec.java
@@ -1,0 +1,124 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+package com.radixdlt.utils;
+
+import static com.radixdlt.sbor.codec.constants.TypeId.*;
+
+import com.radixdlt.sbor.codec.Codec;
+import com.radixdlt.sbor.codec.constants.TypeId;
+import com.radixdlt.sbor.coding.DecoderApi;
+import com.radixdlt.sbor.coding.EncoderApi;
+import com.radixdlt.sbor.exceptions.SborDecodeException;
+
+public final class Int128Codec implements Codec<UInt128> {
+  private final TypeId typeId;
+  private final boolean assertNotInTypedByteRangeOnDecode;
+
+  public Int128Codec() {
+    this(false, false);
+  }
+
+  public Int128Codec(boolean signed) {
+    this(signed, false);
+  }
+
+  /**
+   * Note that Longs are always signed in Java. If signed is false, you may have a positive SBOR
+   * value mapping to a negative Java value. assertNonNegativeOnDecode protects against this.
+   *
+   * @param signed - whether to map to the signed SBOR type or not
+   * @param assertNotPossiblyNegative - if true, raises an exception on decoding a value which would
+   *     be negative if interpreted as signed
+   */
+  public Int128Codec(boolean signed, boolean assertNotPossiblyNegative) {
+    typeId = signed ? TYPE_I128 : TYPE_U128;
+    this.assertNotInTypedByteRangeOnDecode = assertNotPossiblyNegative;
+  }
+
+  @Override
+  public TypeId getTypeId() {
+    return typeId;
+  }
+
+  @Override
+  public void encodeWithoutTypeId(EncoderApi encoder, UInt128 value) {
+    encoder.writeLong(value.getLow());
+    encoder.writeLong(value.getHigh());
+  }
+
+  @Override
+  public UInt128 decodeWithoutTypeId(DecoderApi decoder) {
+    var lowLong = decoder.readLong();
+    var highLong = decoder.readLong();
+    var value = UInt128.from(highLong, lowLong);
+
+    if (assertNotInTypedByteRangeOnDecode && highLong < 0) {
+      throw new SborDecodeException(
+          String.format(
+              "Decoded 128 bit integer %s could be negative if interpreted as signed", value));
+    }
+    return value;
+  }
+}

--- a/common/src/test/java/com/radixdlt/sbor/SborTest.java
+++ b/common/src/test/java/com/radixdlt/sbor/SborTest.java
@@ -76,7 +76,10 @@ import com.radixdlt.lang.*;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.constants.TypeId;
 import com.radixdlt.sbor.dto.SimpleRecord;
+import com.radixdlt.sbor.exceptions.SborDecodeException;
 import com.radixdlt.testclasses.SimpleEnum;
+import com.radixdlt.utils.Int128Codec;
+import com.radixdlt.utils.UInt128;
 import java.util.*;
 import org.junit.Test;
 
@@ -204,6 +207,91 @@ public class SborTest {
 
     assertEquals(UnsignedLong.MAX_VALUE, decodedMaxValue);
     assertEquals(UnsignedLong.ZERO, decodedMinValue);
+  }
+
+  @Test
+  public void unsignedInteger128EncodedCorrectly() {
+    var value = UInt128.THREE;
+
+    var encoded = DefaultTypedSbor.encode(value);
+
+    assertArrayEquals(
+        new byte[] {
+          11, // UINT128 Type
+          3,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0, // The lower long of the value in little endian
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0 // The upper long of the value in little endian
+        },
+        encoded);
+
+    var decoded = DefaultTypedSbor.decode(encoded, UInt128.class);
+    assertEquals(value, decoded);
+  }
+
+  @Test
+  public void unsignedInteger128EdgeCasesCanBeEncodedAndDecoded() {
+    var encodedMaxValue = DefaultTypedSbor.encode(UInt128.MAX_VALUE);
+    var encodedMinValue = DefaultTypedSbor.encode(UInt128.ZERO);
+
+    var decodedMaxValue = DefaultTypedSbor.decode(encodedMaxValue, UInt128.class);
+    var decodedMinValue = DefaultTypedSbor.decode(encodedMinValue, UInt128.class);
+
+    assertEquals(UInt128.MAX_VALUE, decodedMaxValue);
+    assertEquals(UInt128.ZERO, decodedMinValue);
+  }
+
+  @Test
+  public void signedInteger128EncodedCorrectly() {
+    // Interpreted as signed, this would be negative as its top bit is 1.
+    // But because we subtract -1L (all 1s), it has a 0 lower long, which makes the test more
+    // specific.
+    var negativeValue = UInt128.MAX_VALUE.subtract(UInt128.from(-1L));
+
+    var signedCodecWithNoAsserts = new Int128Codec(true, false);
+    var encodedNegativeValue = DefaultTypedSbor.encode(negativeValue, signedCodecWithNoAsserts);
+
+    assertArrayEquals(
+        new byte[] {
+          6, // Signed Int128 Type
+          0, 0, 0, 0, 0, 0, 0, 0, // The lower long in little endian
+          -1, -1, -1, -1, -1, -1, -1, -1, // The upper long in little endian
+          // NB - the upper-most bit is negative, indicating this number is negative if interpreted
+          // as signed
+        },
+        encodedNegativeValue);
+
+    var decodedNegativeValue =
+        DefaultTypedSbor.decode(encodedNegativeValue, signedCodecWithNoAsserts);
+    assertEquals(negativeValue, decodedNegativeValue);
+  }
+
+  @Test
+  public void negativeSignedInteger128TriggersAssertIfDecodedWithAssertsOn() {
+    // Interpreted as signed, this would be negative as its top bit is 1.
+    // But because we subtract -1L (all 1s), it has a 0 lower long, which makes the test more
+    // specific.
+    var negativeValue = UInt128.MAX_VALUE.subtract(UInt128.from(Long.MAX_VALUE));
+
+    // Put assertions on for possibly-negative values
+    var signedCodecWithAsserts = new Int128Codec(true, true);
+    var encodedNegativeValue = DefaultTypedSbor.encode(negativeValue, signedCodecWithAsserts);
+
+    assertThrows(
+        SborDecodeException.class,
+        () -> DefaultTypedSbor.decode(encodedNegativeValue, signedCodecWithAsserts));
   }
 
   @Test


### PR DESCRIPTION
NB - builds on top of #39, so just review the last commit if reviewed before #39 has been merged.

Note - for the signed version, it decodes the IInt128 type into an UInt128 -> this probably shouldn't be used, but I added it for completeness; and works in the opposite way to the Codecs which map into signedshort/int/long