### PR TITLE
Added extra capability tests to AuthHandshakerTest

### DIFF
--- a/core/src/test/java/com/radixdlt/p2p/transport/handshake/AuthHandshakerTest.java
+++ b/core/src/test/java/com/radixdlt/p2p/transport/handshake/AuthHandshakerTest.java
@@ -490,7 +490,7 @@ public final class AuthHandshakerTest {
     AuthHandshakerField.setAccessible(true);
     ECKeyPair ephemeralKey = (ECKeyPair) AuthHandshakerField.get(authHandshaker);
 
-    var ecKeyOps = ECKeyOps.fromKeyPair(remoteKey);ß
+    var ecKeyOps = ECKeyOps.fromKeyPair(remoteKey);
     var remotePubKey = remoteKey.getPublicKey();
 
     final var sharedSecret = bigIntegerToBytes(ecKeyOps.ecdhAgreement(remotePubKey), 32);


### PR DESCRIPTION
Added some extra unit tests to AuthHandshakerTest.

The extra tests cover scenarios where the values of remote peer capabilities (in an incoming initial message) exceed the allowed maximum.

In order to do this, I had to take a local copy of AuthHandshaker initiate and createAuthInitiateMessage methods, so I could bypass the validation and populate the remote peer capabilities set with values that exceed the specified limits.  I couldn't think of any other way to do this, but I'm happy to change the code if someone knows of a better approach :)