### PR TITLE
Improve the error message when docker compose errors

### DIFF
--- a/state-manager/build.gradle
+++ b/state-manager/build.gradle
@@ -115,10 +115,16 @@ task buildRustForDocker(type: Exec) {
 
     doLast {
         if (executionResult.get().getExitValue() != 0) {
-            throw new RuntimeException(String.format(
-                    "%s failed with non-zero exit value %s", commandLine,
-                    executionResult.get().getExitValue()
+            logger.error(String.format(
+                    "\n!!! SPECIFIC HELP FOR THIS ERROR" +
+                            "\n!!!\n!!! The docker compose command failed. If the above error suggests that compose is not a command," +
+                            "\n!!! ensure you have `docker --version 20.10.10` or newer installed." +
+                            "\n!!!\n!!! The following command failed with exit value %s:" +
+                            "\n!!! %s",
+                    executionResult.get().getExitValue(),
+                    commandLine
             ))
+            executionResult.get().assertNormalExitValue()
         }
     }
 }


### PR DESCRIPTION
Basically adds this:
![Screenshot 2022-08-12 at 10 12 25](https://user-images.githubusercontent.com/8008816/184323588-ae28459b-7eb7-48dc-b848-9a75e54ab5dd.png)

