### PR TITLE
Specify in method name that SHA-256 is being applied twice

### DIFF
--- a/common/src/main/java/com/radixdlt/crypto/ECKeyPair.java
+++ b/common/src/main/java/com/radixdlt/crypto/ECKeyPair.java
@@ -137,7 +137,7 @@ public final class ECKeyPair implements Signing<ECDSASignature> {
     }
 
     try {
-      return fromPrivateKey(HashUtils.sha256(seed).asBytes());
+      return fromPrivateKey(HashUtils.sha256Twice(seed).asBytes());
     } catch (PrivateKeyException | PublicKeyException e) {
       throw new IllegalStateException("Should always be able to create private key from seed", e);
     }

--- a/common/src/main/java/com/radixdlt/crypto/HashUtils.java
+++ b/common/src/main/java/com/radixdlt/crypto/HashUtils.java
@@ -89,7 +89,7 @@ public final class HashUtils {
 
   private static final SecureRandom secureRandom = new SecureRandom();
 
-  private static final HashHandler shaHashHandler = new SHAHashHandler();
+  private static final SHAHashHandler shaHashHandler = new SHAHashHandler();
 
   private static final HashCode ZERO_256 = zero(32);
 
@@ -107,7 +107,7 @@ public final class HashUtils {
   public static HashCode random256() {
     byte[] randomBytes = new byte[32];
     secureRandom.nextBytes(randomBytes);
-    return HashCode.fromBytes(shaHashHandler.hash256(randomBytes));
+    return HashCode.fromBytes(shaHashHandler.sha256Twice(randomBytes, 0, randomBytes.length));
   }
 
   /**
@@ -116,8 +116,8 @@ public final class HashUtils {
    * @param dataToBeHashed The data to hash
    * @return The digest by applying the 256-bit/32-byte hash function
    */
-  public static HashCode sha256(byte[] dataToBeHashed) {
-    return sha256(dataToBeHashed, 0, dataToBeHashed.length);
+  public static HashCode sha256Twice(byte[] dataToBeHashed) {
+    return sha256Twice(dataToBeHashed, 0, dataToBeHashed.length);
   }
 
   /**
@@ -128,8 +128,8 @@ public final class HashUtils {
    * @param length The number of bytes in the array to hash
    * @return The digest by applying the 256-bit/32-byte hash function.
    */
-  public static HashCode sha256(byte[] dataToBeHashed, int offset, int length) {
-    return HashCode.fromBytes(shaHashHandler.hash256(dataToBeHashed, offset, length));
+  public static HashCode sha256Twice(byte[] dataToBeHashed, int offset, int length) {
+    return HashCode.fromBytes(shaHashHandler.sha256Twice(dataToBeHashed, offset, length));
   }
 
   /**
@@ -138,8 +138,8 @@ public final class HashUtils {
    * @param dataToBeHashed The data to hash
    * @return The 512-bit/64-byte hash
    */
-  public static HashCode sha512(byte[] dataToBeHashed) {
-    return HashCode.fromBytes(shaHashHandler.hash512(dataToBeHashed));
+  public static HashCode sha512Twice(byte[] dataToBeHashed) {
+    return HashCode.fromBytes(shaHashHandler.sha512Twice(dataToBeHashed, 0, dataToBeHashed.length));
   }
 
   public static byte[] kec256(byte[]... input) {
@@ -169,7 +169,7 @@ public final class HashUtils {
    * @return calculated hash
    */
   public static HashCode transactionIdHash(byte[] payload) {
-    return sha256(payload);
+    return sha256Twice(payload);
   }
 
   private HashUtils() {

--- a/common/src/main/java/com/radixdlt/crypto/SHAHashHandler.java
+++ b/common/src/main/java/com/radixdlt/crypto/SHAHashHandler.java
@@ -93,7 +93,7 @@ class SHAHashHandler implements HashHandler {
    */
   @Override
   public byte[] hash256(byte[] data, int offset, int length) {
-    return hash256Twice(data, offset, length);
+    return sha256Twice(data, offset, length);
   }
 
   /**
@@ -104,10 +104,10 @@ class SHAHashHandler implements HashHandler {
    */
   @Override
   public byte[] hash512(byte[] data, int offset, int length) {
-    return hash512Twice(data, offset, length);
+    return sha512Twice(data, offset, length);
   }
 
-  private byte[] hash256Twice(byte[] data, int offset, int length) {
+  public byte[] sha256Twice(byte[] data, int offset, int length) {
     final MessageDigest hash256DigesterOuterLocal = hash256DigesterOuter.get();
     final MessageDigest hash256DigesterInnerLocal = hash256DigesterInner.get();
     hash256DigesterOuterLocal.reset();
@@ -116,7 +116,7 @@ class SHAHashHandler implements HashHandler {
     return hash256DigesterOuterLocal.digest(hash256DigesterInnerLocal.digest());
   }
 
-  private byte[] hash512Twice(byte[] data, int offset, int length) {
+  public byte[] sha512Twice(byte[] data, int offset, int length) {
     final MessageDigest hash512DigesterLocal = hash512Digester.get();
     hash512DigesterLocal.reset();
     hash512DigesterLocal.update(data, offset, length);

--- a/common/src/main/java/com/radixdlt/identifiers/EUID.java
+++ b/common/src/main/java/com/radixdlt/identifiers/EUID.java
@@ -153,7 +153,7 @@ public final class EUID implements Comparable<EUID> {
    * @return An EUID by taking the 256-bit digest of provided {@code bytes}.
    */
   public static EUID sha256(byte[] bytes) {
-    return new EUID(HashUtils.sha256(bytes));
+    return new EUID(HashUtils.sha256Twice(bytes));
   }
 
   /**

--- a/common/src/main/java/com/radixdlt/identifiers/REAddr.java
+++ b/common/src/main/java/com/radixdlt/identifiers/REAddr.java
@@ -202,7 +202,7 @@ public final class REAddr {
     var dataToHash = new byte[33 + nameBytes.length];
     System.arraycopy(publicKey.getCompressedBytes(), 0, dataToHash, 0, 33);
     System.arraycopy(nameBytes, 0, dataToHash, 33, nameBytes.length);
-    var hash = HashUtils.sha256(dataToHash);
+    var hash = HashUtils.sha256Twice(dataToHash);
     return Arrays.copyOfRange(hash.asBytes(), 32 - HASHED_KEY_BYTES, 32);
   }
 

--- a/common/src/main/java/com/radixdlt/serialization/ApiSerializationModifier.java
+++ b/common/src/main/java/com/radixdlt/serialization/ApiSerializationModifier.java
@@ -112,7 +112,7 @@ public class ApiSerializationModifier extends BeanSerializerModifier {
         jsonGenerator.writeStartObject();
         serializer.unwrappingSerializer(null).serialize(o, jsonGenerator, serializerProvider);
         byte[] bytesToHash = hashDsonMapper.writeValueAsBytes(o);
-        HashCode hash = HashUtils.sha256(bytesToHash);
+        HashCode hash = HashUtils.sha256Twice(bytesToHash);
         jsonGenerator.writeObjectField("hid", hash);
         jsonGenerator.writeEndObject();
       } else {

--- a/common/src/test/java/com/radixdlt/crypto/ECKeyPairTest.java
+++ b/common/src/test/java/com/radixdlt/crypto/ECKeyPairTest.java
@@ -118,12 +118,14 @@ public class ECKeyPairTest {
 
       var keyPair = ECKeyPair.fromPrivateKey(priv);
       var signature =
-          keyPair.sign(HashUtils.sha256(helloWorld.getBytes(StandardCharsets.UTF_8)).asBytes());
+          keyPair.sign(
+              HashUtils.sha256Twice(helloWorld.getBytes(StandardCharsets.UTF_8)).asBytes());
 
       var pubKey = ECPublicKey.fromBytes(pub);
       assertTrue(
           pubKey.verify(
-              HashUtils.sha256(helloWorld.getBytes(StandardCharsets.UTF_8)).asBytes(), signature));
+              HashUtils.sha256Twice(helloWorld.getBytes(StandardCharsets.UTF_8)).asBytes(),
+              signature));
     }
   }
 

--- a/common/src/test/java/com/radixdlt/crypto/HashUtilsTest.java
+++ b/common/src/test/java/com/radixdlt/crypto/HashUtilsTest.java
@@ -109,19 +109,19 @@ public class HashUtilsTest {
   public void testHashValues256() {
     assertArrayEquals(
         Bytes.fromHexString("7ef0ca626bbb058dd443bb78e33b888bdec8295c96e51f5545f96370870c10b9"),
-        HashUtils.sha256(Longs.toByteArray(0L)).asBytes());
+        HashUtils.sha256Twice(Longs.toByteArray(0L)).asBytes());
     assertArrayEquals(
         Bytes.fromHexString("3ae5c198d17634e79059c2cd735491553d22c4e09d1d9fea3ecf214565df2284"),
-        HashUtils.sha256(Longs.toByteArray(1L)).asBytes());
+        HashUtils.sha256Twice(Longs.toByteArray(1L)).asBytes());
     assertArrayEquals(
         Bytes.fromHexString("d03524a98786b780bd640979dc49316702799f46bb8029e29aaf3e7d3b8b7c3e"),
-        HashUtils.sha256(Longs.toByteArray(10L)).asBytes());
+        HashUtils.sha256Twice(Longs.toByteArray(10L)).asBytes());
     assertArrayEquals(
         Bytes.fromHexString("43c1dd54b91ef646f74dc83f2238292bc3340e34cfdb2057aba0193a662409c5"),
-        HashUtils.sha256(Longs.toByteArray(100L)).asBytes());
+        HashUtils.sha256Twice(Longs.toByteArray(100L)).asBytes());
     assertArrayEquals(
         Bytes.fromHexString("4bba9cc5d36a21b9d09cd16bbd83d0472f9b95afd2d7aa1621bb6fa580c99bfc"),
-        HashUtils.sha256(Longs.toByteArray(1_000L)).asBytes());
+        HashUtils.sha256Twice(Longs.toByteArray(1_000L)).asBytes());
   }
 
   @Test
@@ -130,27 +130,27 @@ public class HashUtilsTest {
         Bytes.fromHexString(
             "d6f117761cef5715fcb3fe49a3cf2ebb268acec9e9d87a1e8812a8aa811a1d02ed636b9d04694c160fd071e687772d0cc2e1"
                 + "c3990da4435409c7b1f7b87fa632"),
-        HashUtils.sha512(Longs.toByteArray(0L)).asBytes());
+        HashUtils.sha512Twice(Longs.toByteArray(0L)).asBytes());
     assertArrayEquals(
         Bytes.fromHexString(
             "ec9d8eba8da254c20b3681454bdb3425ba144b7d36421ceffa796bad78d7e66c3439c73a6bbb2d985883b0ff081cfa3ebbac"
                 + "90c580065bad0eb1e9bee74eb0c9"),
-        HashUtils.sha512(Longs.toByteArray(1L)).asBytes());
+        HashUtils.sha512Twice(Longs.toByteArray(1L)).asBytes());
     assertArrayEquals(
         Bytes.fromHexString(
             "78a037d80204606de0f166a625d3fdc81de417da21bf0f5d7c9b756d73a4decd770c349f21fd5141329d0f2a639c143b3094"
                 + "2cc044ff7d0d95209107c38e045c"),
-        HashUtils.sha512(Longs.toByteArray(10L)).asBytes());
+        HashUtils.sha512Twice(Longs.toByteArray(10L)).asBytes());
     assertArrayEquals(
         Bytes.fromHexString(
             "1cb75a3020fda027b89157eebde70134c281e719f700e84b9f12607b3ab3ae286c34c144e8b444eb0fd163948d00bcae900b"
                 + "2c08d263c7127fc1bf85f43c28a0"),
-        HashUtils.sha512(Longs.toByteArray(100L)).asBytes());
+        HashUtils.sha512Twice(Longs.toByteArray(100L)).asBytes());
     assertArrayEquals(
         Bytes.fromHexString(
             "66c0a8301d6a3cc9ad2151af74ad748d10ecfe83a5b1c765a5e31c72916f238f1de2006f2fcb12f634948e13200f354c6f47"
                 + "fc183c7208c1a022575e761c4222"),
-        HashUtils.sha512(Longs.toByteArray(1_000L)).asBytes());
+        HashUtils.sha512Twice(Longs.toByteArray(1_000L)).asBytes());
   }
 
   @Test
@@ -158,7 +158,7 @@ public class HashUtilsTest {
     byte[] data = "Hello Radix".getBytes(StandardCharsets.UTF_8);
 
     byte[] singleHash = sha2bits256Once(data).asBytes();
-    byte[] doubleHash = HashUtils.sha256(data).asBytes();
+    byte[] doubleHash = HashUtils.sha256Twice(data).asBytes();
 
     // These hashes as just the result of running the sha256 once and output the values
     // These are then used as reference for other libraries, especially Swift which
@@ -183,7 +183,7 @@ public class HashUtilsTest {
   public void verify_hash256_twice() {
     testEncodeToHashedBytesFromString(
         "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
-        HashUtils::sha256,
+        HashUtils::sha256Twice,
         "0cffe17f68954dac3a84fb1458bd5ec99209449749b2b308b7cb55812f9563af");
   }
 

--- a/core/src/main/java/com/radixdlt/consensus/Sha256Hasher.java
+++ b/core/src/main/java/com/radixdlt/consensus/Sha256Hasher.java
@@ -86,11 +86,11 @@ public class Sha256Hasher implements Hasher {
 
   @Override
   public HashCode hashDsonEncoded(Object o) {
-    return HashUtils.sha256(serialization.toDson(o, DsonOutput.Output.HASH));
+    return HashUtils.sha256Twice(serialization.toDson(o, DsonOutput.Output.HASH));
   }
 
   @Override
   public HashCode hashBytes(byte[] bytes) {
-    return HashUtils.sha256(bytes);
+    return HashUtils.sha256Twice(bytes);
   }
 }

--- a/core/src/main/java/com/radixdlt/rev1/forks/CandidateForkVote.java
+++ b/core/src/main/java/com/radixdlt/rev1/forks/CandidateForkVote.java
@@ -81,7 +81,7 @@ public record CandidateForkVote(HashCode payload) {
    * nonce, but it is not taken into account when the system counts the votes.
    */
   public static final HashCode FORK_VOTE_NONCE =
-      HashUtils.sha256("olympia".getBytes(StandardCharsets.US_ASCII));
+      HashUtils.sha256Twice("olympia".getBytes(StandardCharsets.US_ASCII));
 
   public static final int NAME_LEN = 16;
   public static final int CANDIDATE_FORK_HASH_LEN = 8;
@@ -138,7 +138,7 @@ public record CandidateForkVote(HashCode payload) {
   }
 
   private static byte[] nonceHash(ECPublicKey publicKey) {
-    return HashUtils.sha256(Bytes.concat(FORK_VOTE_NONCE.asBytes(), publicKey.getBytes()))
+    return HashUtils.sha256Twice(Bytes.concat(FORK_VOTE_NONCE.asBytes(), publicKey.getBytes()))
         .asBytes();
   }
 
@@ -154,7 +154,7 @@ public record CandidateForkVote(HashCode payload) {
             .reduce(new byte[0], Bytes::concat);
 
     final var fullHash =
-        HashUtils.sha256(
+        HashUtils.sha256Twice(
             Bytes.concat(
                 nameBytes,
                 thresholdsBytes,

--- a/core/src/test/java/com/radixdlt/sanitytestsuite/scenario/radixhashing/RadixHashingTestScenarioRunner.java
+++ b/core/src/test/java/com/radixdlt/sanitytestsuite/scenario/radixhashing/RadixHashingTestScenarioRunner.java
@@ -85,7 +85,8 @@ public final class RadixHashingTestScenarioRunner
 
   @Override
   public void doRunTestVector(RadixHashingTestVector testVector) throws AssertionError {
-    var hashHex = Bytes.toHexString(HashUtils.sha256(testVector.input.bytesToHash()).asBytes());
+    var hashHex =
+        Bytes.toHexString(HashUtils.sha256Twice(testVector.input.bytesToHash()).asBytes());
 
     assertEquals(testVector.expected.hashOfHash, hashHex);
   }

--- a/core/src/test/java/com/radixdlt/serialization/DummyTestObject.java
+++ b/core/src/test/java/com/radixdlt/serialization/DummyTestObject.java
@@ -135,7 +135,7 @@ public final class DummyTestObject extends BasicContainer {
       this.bfalse = false;
       this.num = 0x123456789abcdefL;
       this.id = new EUID(UInt128.from(r.nextLong(), r.nextLong()));
-      this.theHash = HashUtils.sha256(randomData);
+      this.theHash = HashUtils.sha256Twice(randomData);
       this.bytes = randomData.clone();
       this.string = getClass().getName();
       this.array = new ArrayList<>(Collections.nCopies(10, id));

--- a/olympia-engine/src/main/java/com/radixdlt/engine/parser/REParser.java
+++ b/olympia-engine/src/main/java/com/radixdlt/engine/parser/REParser.java
@@ -261,7 +261,7 @@ public final class REParser {
   }
 
   private HashCode calculatePayloadHash(RawTransaction transaction, int sigPosition) {
-    return HashUtils.sha256(transaction.getPayload(), 0, sigPosition); // This is a double hash
+    return HashUtils.sha256Twice(transaction.getPayload(), 0, sigPosition); // This is a double hash
   }
 
   private REInstruction readInstruction(ParserState parserState, ByteBuffer buf)

--- a/olympia-engine/src/main/java/com/radixdlt/substate/TxLowLevelBuilder.java
+++ b/olympia-engine/src/main/java/com/radixdlt/substate/TxLowLevelBuilder.java
@@ -361,7 +361,7 @@ public final class TxLowLevelBuilder {
   }
 
   public HashCode hashToSign() {
-    return HashUtils.sha256(blob()); // this is a double hash
+    return HashUtils.sha256Twice(blob()); // this is a double hash
   }
 
   public TxLowLevelBuilder sig(ECDSASignature signature) {


### PR DESCRIPTION
Fix the fact that `HashUtils.sha256()` isnt' actually SHA-256 but SHA-256 applied twice! The fix is just renaming the method to `HashUtils.sha256twice()`