### PR TITLE
refactor: introduce `tracing` as a logging crate

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1269,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -1274,6 +1298,8 @@ dependencies = [
  "rocksdb",
  "sbor",
  "scrypto",
+ "tracing",
+ "tracing-subscriber",
  "transaction",
 ]
 
@@ -1354,6 +1380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "tokio"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,7 +1460,19 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1435,6 +1482,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+dependencies = [
+ "ansi_term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1482,6 +1555,12 @@ checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom 0.2.7",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/core-rust/state-manager/Cargo.toml
+++ b/core-rust/state-manager/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 jni = "0.19.0"
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3" }
 
 # DEPENDENCIES ON RADIXDLT-SCRYPTO
 #

--- a/core-rust/state-manager/src/jni/state_manager.rs
+++ b/core-rust/state-manager/src/jni/state_manager.rs
@@ -113,6 +113,9 @@ pub struct JNIStateManager {
 
 impl JNIStateManager {
     pub fn init(env: &JNIEnv, j_state_manager: JObject, j_config: jbyteArray) {
+        // Trying to initialize a global logger here, and carry on if this fails.
+        let _ = tracing_subscriber::fmt::try_init();
+
         let config_bytes: Vec<u8> = jni_jbytearray_to_vector(env, j_config).unwrap();
         let config = StateManagerConfig::from_java(&config_bytes).unwrap();
 

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -81,6 +81,7 @@ use radix_engine::wasm::{DefaultWasmEngine, WasmInstrumenter};
 use scrypto::engine::types::RENodeId;
 use scrypto::prelude::*;
 use std::collections::HashMap;
+use tracing::info;
 use transaction::errors::TransactionValidationError;
 use transaction::model::{
     PreviewFlags, PreviewIntent, TransactionHeader, TransactionIntent, ValidatedTransaction,
@@ -275,7 +276,7 @@ where
                         TransactionResult::Reject(reject_result) => {
                             rejected_txns.insert(proposed, format!("{:?}", reject_result));
                             if self.logging_config.log_on_transaction_rejection {
-                                println!("TXN REJECTED: {:?}", reject_result);
+                                info!("TXN REJECTED: {:?}", reject_result);
                             }
                         }
                     }
@@ -283,7 +284,7 @@ where
                 Err(validation_error) => {
                     rejected_txns.insert(proposed, format!("{:?}", validation_error));
                     if self.logging_config.log_on_transaction_rejection {
-                        println!("TXN INVALID: {:?}", validation_error);
+                        info!("TXN INVALID: {:?}", validation_error);
                     }
                 }
             }


### PR DESCRIPTION
This crate work quite similar to the `log` crate, and is the spiritual successor of `slog`.

This introduction works as an intermediate step for collecting metrics and events, so when we introduce a different backend like https://crates.io/crates/tracing-opentelemetry , we can actually collect these somewhere remote.
Also, switching to a different backend should be absolute painless.

Prior art: #114 . (@KrzysztofLabus-RDX as the original PR was yours, I would love to hear your opinion about this approach.)

This is how it looks like right now:
<img width="2056" alt="Screenshot 2022-09-14 at 15 30 15" src="https://user-images.githubusercontent.com/112897642/190183290-7aadc13f-d382-488b-bd19-f2c6fee5a77d.png">
(The TRACE and the DEBUG levels are not visible, I had to override the `RUST_LOG` to make them visible.)

References: jira NODE-360
