### PR TITLE
chore: decompose on rundocker.sh exit

### DIFF
--- a/docker/scripts/rundocker.sh
+++ b/docker/scripts/rundocker.sh
@@ -35,5 +35,12 @@ ${reporoot}/gradlew -p "${reporoot}" deb4docker
 echo "||> Killing all running docker containers"
 docker compose -f "${dockerfile}" down | tee docker.log
 
+function cleanup {
+  echo "||> Killing all running docker containers"
+  docker compose -f "${dockerfile}" down | tee docker.log
+}
+
+trap cleanup EXIT
+
 echo "||> Starting up new docker containers"
 docker compose -f "${dockerfile}" up --build | tee docker.log


### PR DESCRIPTION
This change runs the cleanup handler on exit (e.g. SIGINT), so docker won't eat all my battery when I forget to shut it down manually.