### PR TITLE
refactor: replace ::get_bytes with AsRef<[u8]>::as_ref

### DIFF
--- a/core-rust/core-api-server/src/core_api/conversions/hashes.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/hashes.rs
@@ -4,15 +4,15 @@ use crate::core_api::*;
 
 #[allow(dead_code)]
 pub fn to_api_intent_hash(intent_hash: &IntentHash) -> String {
-    to_hex(intent_hash.get_bytes())
+    to_hex(intent_hash)
 }
 
 pub fn to_api_signed_intent_hash(signatures_hash: &SignaturesHash) -> String {
-    to_hex(signatures_hash.get_bytes())
+    to_hex(signatures_hash)
 }
 
 pub fn to_api_payload_hash(payload_hash: &UserPayloadHash) -> String {
-    to_hex(payload_hash.get_bytes())
+    to_hex(payload_hash)
 }
 
 pub fn extract_intent_hash(intent_hash_str: String) -> Result<IntentHash, ExtractionError> {

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -121,15 +121,15 @@ pub struct RocksDBStore {
 }
 
 fn get_transaction_key(payload_hash: &TransactionPayloadHash) -> Vec<u8> {
-    db_key!(Transactions, payload_hash.get_bytes())
+    db_key!(Transactions, payload_hash.as_ref())
 }
 
 fn get_user_transaction_payload_key(payload_hash: &UserPayloadHash) -> Vec<u8> {
-    db_key!(UserPayloadHashLookup, payload_hash.get_bytes())
+    db_key!(UserPayloadHashLookup, payload_hash.as_ref())
 }
 
 fn get_transaction_intent_key(intent_hash: &IntentHash) -> Vec<u8> {
-    db_key!(TransactionIntentLookup, intent_hash.get_bytes())
+    db_key!(TransactionIntentLookup, intent_hash.as_ref())
 }
 
 impl RocksDBStore {
@@ -195,7 +195,7 @@ impl<'db> RocksDBCommitTransaction<'db> {
             self.db_txn
                 .put(
                     get_transaction_intent_key(&notarized_transaction.intent_hash()),
-                    transaction.get_hash().get_bytes(),
+                    transaction.get_hash().as_ref(),
                 )
                 .expect("RocksDB: failure to put intent hash");
         }
@@ -259,9 +259,7 @@ impl<'db> WriteableProofStore for RocksDBCommitTransaction<'db> {
             for (index, payload_hash) in ids.into_iter().enumerate() {
                 let txn_state_version = first_state_version + index as u64;
                 let version_key = db_key!(StateVersions, &txn_state_version.to_be_bytes());
-                self.db_txn
-                    .put(version_key, payload_hash.get_bytes())
-                    .unwrap();
+                self.db_txn.put(version_key, payload_hash.as_ref()).unwrap();
             }
         }
     }

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -87,8 +87,10 @@ impl TransactionPayloadHash {
     pub fn into_bytes(self) -> [u8; Self::LENGTH] {
         self.0
     }
+}
 
-    pub fn get_bytes(&self) -> &[u8; Self::LENGTH] {
+impl AsRef<[u8]> for TransactionPayloadHash {
+    fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
@@ -130,8 +132,10 @@ impl UserPayloadHash {
     pub fn into_bytes(self) -> [u8; Self::LENGTH] {
         self.0
     }
+}
 
-    pub fn get_bytes(&self) -> &[u8; Self::LENGTH] {
+impl AsRef<[u8]> for UserPayloadHash {
+    fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
@@ -183,8 +187,10 @@ impl SignaturesHash {
     pub fn into_bytes(self) -> [u8; Self::LENGTH] {
         self.0
     }
+}
 
-    pub fn get_bytes(&self) -> &[u8; Self::LENGTH] {
+impl AsRef<[u8]> for SignaturesHash {
+    fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
@@ -236,8 +242,10 @@ impl IntentHash {
     pub fn into_bytes(self) -> [u8; Self::LENGTH] {
         self.0
     }
+}
 
-    pub fn get_bytes(&self) -> &[u8; Self::LENGTH] {
+impl AsRef<[u8]> for IntentHash {
+    fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }


### PR DESCRIPTION
This change allows us to call `to_hex` directly, so some of the conversions are no longer explicitly needed.