### PR TITLE
refactor: inline `core_api_handler`

### DIFF
--- a/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
@@ -1,19 +1,11 @@
 use crate::core_api::*;
 
-use state_manager::jni::state_manager::ActualStateManager;
-
+#[tracing::instrument(level = "debug", skip(state), err(Debug))]
 pub(crate) async fn handle_mempool_list(
-    state: Extension<CoreApiState>,
-    request: Json<models::MempoolListRequest>,
+    Extension(state): Extension<CoreApiState>,
+    Json(request): Json<models::MempoolListRequest>,
 ) -> Result<Json<models::MempoolListResponse>, RequestHandlingError> {
-    core_api_handler(state, request, handle_mempool_list_internal)
-}
-
-#[tracing::instrument(level = "debug", skip(state_manager), err(Debug))]
-fn handle_mempool_list_internal(
-    state_manager: &mut ActualStateManager,
-    request: models::MempoolListRequest,
-) -> Result<models::MempoolListResponse, RequestHandlingError> {
+    let state_manager = state.state_manager.read();
     assert_matching_network(&request.network, &state_manager.network)?;
 
     Ok(models::MempoolListResponse {
@@ -29,4 +21,5 @@ fn handle_mempool_list_internal(
             )
             .collect(),
     })
+    .map(Json)
 }

--- a/core-rust/core-api-server/src/core_api/helpers.rs
+++ b/core-rust/core-api-server/src/core_api/helpers.rs
@@ -15,17 +15,6 @@ pub(crate) fn core_api_handler_empty_request<Response>(
 }
 
 #[tracing::instrument(skip_all)]
-pub(crate) fn core_api_handler<Request, Response>(
-    Extension(state): Extension<CoreApiState>,
-    Json(request_body): Json<Request>,
-    method: impl FnOnce(&mut ActualStateManager, Request) -> Result<Response, RequestHandlingError>,
-) -> Result<Json<Response>, RequestHandlingError> {
-    let mut state_manager = state.state_manager.write();
-
-    method(&mut state_manager, request_body).map(Json)
-}
-
-#[tracing::instrument(skip_all)]
 pub(crate) fn core_api_read_handler<Request, Response>(
     Extension(state): Extension<CoreApiState>,
     Json(request_body): Json<Request>,


### PR DESCRIPTION
This PR is a basic inline which allows us to reduce the critical
section of the state_manager lock in the future.
