### PR TITLE
feat: Update scrypto version for Hammunet release

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -335,6 +335,7 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "radix-engine",
+ "radix-engine-constants",
  "radix-engine-stores",
  "sbor",
  "scrypto",
@@ -1385,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "0.7.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-801e7be77#801e7be7774849c24d8edded0d31401e0f2b84a5"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
 dependencies = [
  "bitflags",
  "colored",
@@ -1393,6 +1394,7 @@ dependencies = [
  "indexmap",
  "moka",
  "parity-wasm",
+ "radix-engine-constants",
  "sbor",
  "scrypto",
  "transaction",
@@ -1402,9 +1404,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix-engine-constants"
+version = "0.7.0"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
+
+[[package]]
 name = "radix-engine-stores"
 version = "0.7.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-801e7be77#801e7be7774849c24d8edded0d31401e0f2b84a5"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
 dependencies = [
  "radix-engine",
  "sbor",
@@ -1564,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "sbor"
 version = "0.7.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-801e7be77#801e7be7774849c24d8edded0d31401e0f2b84a5"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
 dependencies = [
  "hex",
  "sbor-derive",
@@ -1574,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive"
 version = "0.7.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-801e7be77#801e7be7774849c24d8edded0d31401e0f2b84a5"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1600,7 +1607,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "scrypto"
 version = "0.7.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-801e7be77#801e7be7774849c24d8edded0d31401e0f2b84a5"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
 dependencies = [
  "bech32",
  "forward_ref",
@@ -1619,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "scrypto-abi"
 version = "0.7.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-801e7be77#801e7be7774849c24d8edded0d31401e0f2b84a5"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
 dependencies = [
  "sbor",
  "serde",
@@ -1628,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "scrypto-derive"
 version = "0.7.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-801e7be77#801e7be7774849c24d8edded0d31401e0f2b84a5"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1844,6 +1851,7 @@ dependencies = [
  "parking_lot",
  "prometheus",
  "radix-engine",
+ "radix-engine-constants",
  "radix-engine-stores",
  "rocksdb",
  "sbor",
@@ -2162,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "transaction"
 version = "0.7.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-801e7be77#801e7be7774849c24d8edded0d31401e0f2b84a5"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=2022-11-14-v1#b633adc1752fce154229aeb03e4a567f12a4f79c"
 dependencies = [
  "clap",
  "ed25519-dalek",

--- a/core-rust/core-api-server/Cargo.toml
+++ b/core-rust/core-api-server/Cargo.toml
@@ -23,11 +23,12 @@ parking_lot = { version = "0.12" }
 #
 # Ensure this version is also identically updated in ../state-manager/Cargo.toml
 #
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77", features = ["serde"] }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
-radix-engine-stores = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1", features = ["serde"] }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+radix-engine-stores = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
 
 jni = "0.19.0"
 

--- a/core-rust/state-manager/Cargo.toml
+++ b/core-rust/state-manager/Cargo.toml
@@ -25,11 +25,12 @@ prometheus = { version = "0.13.2", default-features = false, features = [] }
 # 
 # Ensure this version is also identically updated in ../core-api-server/Cargo.toml
 #
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
-radix-engine-stores = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-801e7be77" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
+radix-engine-stores = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "2022-11-14-v1" }
 
 # Non-Radix Engine Dependencies:
 rocksdb = { version = "0.19.0" }

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -73,7 +73,7 @@ use crate::{
 };
 use prometheus::core::Collector;
 use prometheus::{IntCounter, IntCounterVec, IntGauge, Registry};
-use radix_engine::constants::DEFAULT_MAX_CALL_DEPTH;
+use radix_engine_constants::DEFAULT_MAX_CALL_DEPTH;
 use radix_engine::engine::ScryptoInterpreter;
 use radix_engine::fee::SystemLoanFeeReserve;
 use radix_engine::state_manager::StagedSubstateStoreManager;
@@ -235,6 +235,7 @@ impl<S> StateManager<S> {
             execution_config: ExecutionConfig {
                 max_call_depth: DEFAULT_MAX_CALL_DEPTH,
                 trace: logging_config.engine_trace,
+                max_sys_call_trace_depth: 1,
             },
             scrypto_interpreter: ScryptoInterpreter {
                 wasm_engine: DefaultWasmEngine::default(),


### PR DESCRIPTION
(This will be changed to merge into main in due course when its parent branch is merged)

Pulls in [2022-11-14-v1](https://github.com/radixdlt/radixdlt-scrypto/tree/2022-11-14-v1)