### PR TITLE
refactor: pass vertices instead of transaction list to State Manager

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
@@ -69,7 +69,9 @@ import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt64;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public record PrepareRequest(
     byte[] parentAccumulator,
@@ -98,5 +100,47 @@ public record PrepareRequest(
                         t.epoch,
                         t.roundNumber,
                         t.proposerTimestampMs)));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PrepareRequest that = (PrepareRequest) o;
+    return Arrays.equals(parentAccumulator, that.parentAccumulator)
+        && Objects.equals(previous, that.previous)
+        && Objects.equals(proposed, that.proposed)
+        && Objects.equals(epoch, that.epoch)
+        && Objects.equals(roundNumber, that.roundNumber)
+        && Objects.equals(proposerTimestampMs, that.proposerTimestampMs);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(parentAccumulator);
+    result = 31 * result + Objects.hashCode(previous);
+    result = 31 * result + Objects.hashCode(proposed);
+    result = 31 * result + Objects.hashCode(epoch);
+    result = 31 * result + Objects.hashCode(roundNumber);
+    result = 31 * result + Objects.hashCode(proposerTimestampMs);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "PrepareRequest{"
+        + "parentAccumulator="
+        + Arrays.toString(parentAccumulator)
+        + ", previous="
+        + previous
+        + ", proposed="
+        + proposed
+        + ", epoch="
+        + epoch
+        + ", roundNumber="
+        + roundNumber
+        + ", proposerTimestampMs="
+        + proposerTimestampMs
+        + '}';
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
@@ -64,18 +64,17 @@
 
 package com.radixdlt.statecomputer.commit;
 
+import com.google.common.hash.HashCode;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt64;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 public record PrepareRequest(
-    byte[] parentAccumulator,
-    List<PreviousVertex> previous,
+    HashCode parentAccumulatorHash,
+    List<PreviousVertex> previousVertices,
     List<RawNotarizedTransaction> proposed,
     UInt64 epoch,
     UInt64 roundNumber,
@@ -86,7 +85,7 @@ public record PrepareRequest(
         codecs ->
             StructCodec.with(
                 PrepareRequest::new,
-                codecs.of(new TypeToken<>() {}),
+                codecs.of(HashCode.class),
                 codecs.of(new TypeToken<>() {}),
                 codecs.of(new TypeToken<>() {}),
                 codecs.of(new TypeToken<>() {}),
@@ -94,53 +93,11 @@ public record PrepareRequest(
                 codecs.of(new TypeToken<>() {}),
                 (t, encoder) ->
                     encoder.encode(
-                        t.parentAccumulator,
-                        t.previous,
+                        t.parentAccumulatorHash,
+                        t.previousVertices,
                         t.proposed,
                         t.epoch,
                         t.roundNumber,
                         t.proposerTimestampMs)));
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    PrepareRequest that = (PrepareRequest) o;
-    return Arrays.equals(parentAccumulator, that.parentAccumulator)
-        && Objects.equals(previous, that.previous)
-        && Objects.equals(proposed, that.proposed)
-        && Objects.equals(epoch, that.epoch)
-        && Objects.equals(roundNumber, that.roundNumber)
-        && Objects.equals(proposerTimestampMs, that.proposerTimestampMs);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = Arrays.hashCode(parentAccumulator);
-    result = 31 * result + Objects.hashCode(previous);
-    result = 31 * result + Objects.hashCode(proposed);
-    result = 31 * result + Objects.hashCode(epoch);
-    result = 31 * result + Objects.hashCode(roundNumber);
-    result = 31 * result + Objects.hashCode(proposerTimestampMs);
-    return result;
-  }
-
-  @Override
-  public String toString() {
-    return "PrepareRequest{"
-        + "parentAccumulator="
-        + Arrays.toString(parentAccumulator)
-        + ", previous="
-        + previous
-        + ", proposed="
-        + proposed
-        + ", epoch="
-        + epoch
-        + ", roundNumber="
-        + roundNumber
-        + ", proposerTimestampMs="
-        + proposerTimestampMs
-        + '}';
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
@@ -67,13 +67,12 @@ package com.radixdlt.statecomputer.commit;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
-import com.radixdlt.transactions.RawLedgerTransaction;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt64;
 import java.util.List;
 
 public record PrepareRequest(
-    List<RawLedgerTransaction> previous,
+    List<PreviousVertex> previous,
     List<RawNotarizedTransaction> proposed,
     UInt64 epoch,
     UInt64 roundNumber,

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
@@ -72,6 +72,7 @@ import com.radixdlt.utils.UInt64;
 import java.util.List;
 
 public record PrepareRequest(
+    byte[] parentAccumulator,
     List<PreviousVertex> previous,
     List<RawNotarizedTransaction> proposed,
     UInt64 epoch,
@@ -88,8 +89,14 @@ public record PrepareRequest(
                 codecs.of(new TypeToken<>() {}),
                 codecs.of(new TypeToken<>() {}),
                 codecs.of(new TypeToken<>() {}),
+                codecs.of(new TypeToken<>() {}),
                 (t, encoder) ->
                     encoder.encode(
-                        t.previous, t.proposed, t.epoch, t.roundNumber, t.proposerTimestampMs)));
+                        t.parentAccumulator,
+                        t.previous,
+                        t.proposed,
+                        t.epoch,
+                        t.roundNumber,
+                        t.proposerTimestampMs)));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
@@ -68,7 +68,9 @@ import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawLedgerTransaction;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public record PreviousVertex(List<RawLedgerTransaction> transactions, byte[] resultantAccumulator) {
   public static void registerCodec(CodecMap codecMap) {
@@ -80,5 +82,31 @@ public record PreviousVertex(List<RawLedgerTransaction> transactions, byte[] res
                 codecs.of(new TypeToken<>() {}),
                 codecs.of(new TypeToken<>() {}),
                 (t, encoder) -> encoder.encode(t.transactions, t.resultantAccumulator)));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    PreviousVertex that = (PreviousVertex) o;
+    return Objects.equals(transactions, that.transactions)
+        && Arrays.equals(resultantAccumulator, that.resultantAccumulator);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(transactions);
+    result = 31 * result + Arrays.hashCode(resultantAccumulator);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "PreviousVertex{"
+        + "transactions="
+        + transactions
+        + ", resultantAccumulator="
+        + Arrays.toString(resultantAccumulator)
+        + '}';
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
@@ -64,15 +64,15 @@
 
 package com.radixdlt.statecomputer.commit;
 
+import com.google.common.hash.HashCode;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawLedgerTransaction;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
-public record PreviousVertex(List<RawLedgerTransaction> transactions, byte[] resultantAccumulator) {
+public record PreviousVertex(
+    List<RawLedgerTransaction> transactions, HashCode resultantAccumulatorHash) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PreviousVertex.class,
@@ -80,33 +80,7 @@ public record PreviousVertex(List<RawLedgerTransaction> transactions, byte[] res
             StructCodec.with(
                 PreviousVertex::new,
                 codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) -> encoder.encode(t.transactions, t.resultantAccumulator)));
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    PreviousVertex that = (PreviousVertex) o;
-    return Objects.equals(transactions, that.transactions)
-        && Arrays.equals(resultantAccumulator, that.resultantAccumulator);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = Objects.hash(transactions);
-    result = 31 * result + Arrays.hashCode(resultantAccumulator);
-    return result;
-  }
-
-  @Override
-  public String toString() {
-    return "PreviousVertex{"
-        + "transactions="
-        + transactions
-        + ", resultantAccumulator="
-        + Arrays.toString(resultantAccumulator)
-        + '}';
+                codecs.of(HashCode.class),
+                (t, encoder) -> encoder.encode(t.transactions, t.resultantAccumulatorHash)));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
@@ -62,106 +62,28 @@
  * permissions under this License.
  */
 
-package com.radixdlt.sbor;
+package com.radixdlt.statecomputer.commit;
 
-import com.google.common.hash.HashCode;
 import com.google.common.reflect.TypeToken;
-import com.radixdlt.crypto.*;
-import com.radixdlt.exceptions.StateManagerRuntimeError;
-import com.radixdlt.identifiers.TID;
-import com.radixdlt.mempool.MempoolError;
-import com.radixdlt.mempool.RustMempoolConfig;
-import com.radixdlt.rev2.*;
-import com.radixdlt.sbor.codec.Codec;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
-import com.radixdlt.statecomputer.commit.*;
-import com.radixdlt.statemanager.*;
-import com.radixdlt.transaction.CommittedTransactionStatus;
-import com.radixdlt.transaction.ExecutedTransaction;
 import com.radixdlt.transactions.RawLedgerTransaction;
-import com.radixdlt.transactions.RawNotarizedTransaction;
-import com.radixdlt.utils.UInt16;
-import com.radixdlt.utils.UInt32;
-import com.radixdlt.utils.UInt64;
+import java.util.List;
 
-public final class StateManagerSbor {
-  private static final ScryptoSbor sbor = createSborForStateManager();
-
-  private static ScryptoSbor createSborForStateManager() {
-    return new ScryptoSbor(
-        new CodecMap()
-            .register(StateManagerSbor::registerCodecsWithCodecMap)
-            .register(StateManagerSbor::registerCodecsForExistingTypes));
-  }
-
-  public static <T> byte[] encode(T value, Codec<T> codec) {
-    return sbor.encode_payload(value, codec);
-  }
-
-  public static <T> T decode(byte[] sborBytes, Codec<T> codec) {
-    return sbor.decode_payload(sborBytes, codec);
-  }
-
-  public static <T> Codec<T> resolveCodec(TypeToken<T> typeToken) {
-    return sbor.resolveCodec(typeToken);
-  }
-
-  public static void registerCodecsWithCodecMap(CodecMap codecMap) {
-    UInt16.registerCodec(codecMap);
-    UInt32.registerCodec(codecMap);
-    UInt64.registerCodec(codecMap);
-    RustMempoolConfig.registerCodec(codecMap);
-    NetworkDefinition.registerCodec(codecMap);
-    LoggingConfig.registerCodec(codecMap);
-    StateManagerLoggingConfig.registerCodec(codecMap);
-    StateManagerConfig.registerCodec(codecMap);
-    RawLedgerTransaction.registerCodec(codecMap);
-    RawNotarizedTransaction.registerCodec(codecMap);
-    TransactionStatus.registerCodec(codecMap);
-    Decimal.registerCodec(codecMap);
-    LogLevel.registerCodec(codecMap);
-    ComponentAddress.registerCodec(codecMap);
-    PackageAddress.registerCodec(codecMap);
-    ResourceAddress.registerCodec(codecMap);
-    TID.registerCodec(codecMap);
-    StateManagerRuntimeError.registerCodec(codecMap);
-    MempoolError.registerCodec(codecMap);
-    CommittedTransactionStatus.registerCodec(codecMap);
-    ExecutedTransaction.registerCodec(codecMap);
-    PublicKey.registerCodec(codecMap);
-    ECDSASecp256k1PublicKey.registerCodec(codecMap);
-    EdDSAEd25519PublicKey.registerCodec(codecMap);
-    Signature.registerCodec(codecMap);
-    ECDSASecp256k1Signature.registerCodec(codecMap);
-    EdDSAEd25519Signature.registerCodec(codecMap);
-    SignatureWithPublicKey.registerCodec(codecMap);
-    PrepareGenesisRequest.registerCodec(codecMap);
-    PrepareGenesisResult.registerCodec(codecMap);
-    PreviousVertex.registerCodec(codecMap);
-    PrepareRequest.registerCodec(codecMap);
-    PrepareResult.registerCodec(codecMap);
-    NextEpoch.registerCodec(codecMap);
-    ActiveValidatorInfo.registerCodec(codecMap);
-    CommitRequest.registerCodec(codecMap);
-    CommitError.registerCodec(codecMap);
-    REv2DatabaseConfig.registerCodec(codecMap);
-    TransactionHeader.registerCodec(codecMap);
-    CoreApiServerConfig.registerCodec(codecMap);
-    ValidatorInfo.registerCodec(codecMap);
-  }
-
-  public static void registerCodecsForExistingTypes(CodecMap codecMap) {
-    registerCodecForHashCode(codecMap);
-  }
-
-  public static void registerCodecForHashCode(CodecMap codecMap) {
+public record PreviousVertex(
+    List<RawLedgerTransaction> transactions,
+    byte[] parentAccumulator,
+    byte[] resultantAccumulator) {
+  public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
-        HashCode.class,
+        PreviousVertex.class,
         codecs ->
             StructCodec.with(
-                HashCode::fromBytes,
-                codecs.of(byte[].class),
-                (t, encoder) -> encoder.encode(t.asBytes())));
+                PreviousVertex::new,
+                codecs.of(new TypeToken<>() {}),
+                codecs.of(new TypeToken<>() {}),
+                codecs.of(new TypeToken<>() {}),
+                (t, encoder) ->
+                    encoder.encode(t.transactions, t.parentAccumulator, t.resultantAccumulator)));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
@@ -70,10 +70,7 @@ import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawLedgerTransaction;
 import java.util.List;
 
-public record PreviousVertex(
-    List<RawLedgerTransaction> transactions,
-    byte[] parentAccumulator,
-    byte[] resultantAccumulator) {
+public record PreviousVertex(List<RawLedgerTransaction> transactions, byte[] resultantAccumulator) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PreviousVertex.class,
@@ -82,8 +79,6 @@ public record PreviousVertex(
                 PreviousVertex::new,
                 codecs.of(new TypeToken<>() {}),
                 codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) ->
-                    encoder.encode(t.transactions, t.parentAccumulator, t.resultantAccumulator)));
+                (t, encoder) -> encoder.encode(t.transactions, t.resultantAccumulator)));
   }
 }

--- a/core-rust/state-manager/src/jni/mempool.rs
+++ b/core-rust/state-manager/src/jni/mempool.rs
@@ -96,7 +96,7 @@ extern "system" fn Java_com_radixdlt_mempool_RustMempool_add(
 fn do_add(
     state_manager: &mut ActualStateManager,
     transaction: JavaRawTransaction,
-) -> Result<JavaPayloadHash, MempoolAddErrorJava> {
+) -> Result<JavaHashCode, MempoolAddErrorJava> {
     let notarized_transaction =
         UserTransactionValidator::parse_unvalidated_user_transaction_from_slice(
             &transaction.payload,
@@ -132,7 +132,7 @@ fn do_get_transactions_for_proposal(
     (max_count, max_payload_size_bytes, transaction_hashes_to_exclude): (
         u32,
         u32,
-        Vec<JavaPayloadHash>,
+        Vec<JavaHashCode>,
     ),
 ) -> Vec<JavaRawTransaction> {
     let user_payload_hashes_to_exclude: HashSet<UserPayloadHash> = transaction_hashes_to_exclude
@@ -203,27 +203,27 @@ fn do_get_transactions_to_relay(
 // DTO Models + Mapping
 //
 
-/// Corresponds to the payload_hash
+/// Corresponds to HashCode from Java
 #[derive(Debug, PartialEq, Eq, Categorize, Encode, Decode)]
-pub struct JavaPayloadHash(Vec<u8>);
+pub struct JavaHashCode(pub Vec<u8>);
 
-impl From<LedgerPayloadHash> for JavaPayloadHash {
+impl From<LedgerPayloadHash> for JavaHashCode {
     fn from(payload_hash: LedgerPayloadHash) -> Self {
-        JavaPayloadHash(payload_hash.into_bytes().to_vec())
+        JavaHashCode(payload_hash.into_bytes().to_vec())
     }
 }
 
 #[derive(Debug, Categorize, Encode, Decode)]
 pub struct JavaRawTransaction {
     pub payload: Vec<u8>,
-    pub payload_hash: JavaPayloadHash,
+    pub payload_hash: JavaHashCode,
 }
 
 impl From<PendingTransaction> for JavaRawTransaction {
     fn from(transaction: PendingTransaction) -> Self {
         JavaRawTransaction {
             payload: scrypto_encode(&transaction.payload).unwrap(),
-            payload_hash: JavaPayloadHash(transaction.payload_hash.into_bytes().to_vec()),
+            payload_hash: JavaHashCode(transaction.payload_hash.into_bytes().to_vec()),
         }
     }
 }

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -266,6 +266,7 @@ impl From<JavaCommitRequest> for CommitRequest {
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct JavaPrepareRequest {
+    pub parent_accumulator: Vec<u8>,
     pub prepared_vertices: Vec<JavaPreviousVertex>,
     pub proposed: Vec<JavaRawTransaction>,
     pub consensus_epoch: u64,
@@ -276,6 +277,7 @@ pub struct JavaPrepareRequest {
 impl From<JavaPrepareRequest> for PrepareRequest {
     fn from(prepare_request: JavaPrepareRequest) -> Self {
         PrepareRequest {
+            parent_accumulator: prepare_request.parent_accumulator,
             prepared_vertices: prepare_request
                 .prepared_vertices
                 .into_iter()
@@ -296,7 +298,6 @@ impl From<JavaPrepareRequest> for PrepareRequest {
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct JavaPreviousVertex {
     pub transactions: Vec<JavaRawTransaction>,
-    pub parent_accumulator: Vec<u8>,
     pub resultant_accumulator: Vec<u8>,
 }
 
@@ -308,7 +309,6 @@ impl From<JavaPreviousVertex> for PreviousVertex {
                 .into_iter()
                 .map(|v| v.payload)
                 .collect(),
-            parent_accumulator: previous_vertex.parent_accumulator,
             resultant_accumulator: previous_vertex.resultant_accumulator,
         }
     }

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -278,7 +278,7 @@ pub struct JavaPrepareRequest {
 impl From<JavaPrepareRequest> for PrepareRequest {
     fn from(prepare_request: JavaPrepareRequest) -> Self {
         PrepareRequest {
-            parent_accumulator: prepare_request.parent_accumulator_hash.0,
+            parent_accumulator: prepare_request.parent_accumulator_hash.into(),
             prepared_vertices: prepare_request
                 .previous_vertices
                 .into_iter()
@@ -310,7 +310,7 @@ impl From<JavaPreviousVertex> for PreviousVertex {
                 .into_iter()
                 .map(|v| v.payload)
                 .collect(),
-            resultant_accumulator: previous_vertex.resultant_accumulator_hash.0,
+            resultant_accumulator: previous_vertex.resultant_accumulator_hash.into(),
         }
     }
 }

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -76,6 +76,7 @@ use crate::jni::utils::*;
 use crate::types::{CommitRequest, PrepareRequest, PrepareResult};
 use crate::{CommitError, NextEpoch, PrepareGenesisRequest, PrepareGenesisResult};
 
+use super::mempool::JavaHashCode;
 use super::state_manager::ActualStateManager;
 
 //
@@ -264,10 +265,10 @@ impl From<JavaCommitRequest> for CommitRequest {
     }
 }
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Decode, Encode, Categorize)]
 pub struct JavaPrepareRequest {
-    pub parent_accumulator: Vec<u8>,
-    pub prepared_vertices: Vec<JavaPreviousVertex>,
+    pub parent_accumulator_hash: JavaHashCode,
+    pub previous_vertices: Vec<JavaPreviousVertex>,
     pub proposed: Vec<JavaRawTransaction>,
     pub consensus_epoch: u64,
     pub round_number: u64,
@@ -277,9 +278,9 @@ pub struct JavaPrepareRequest {
 impl From<JavaPrepareRequest> for PrepareRequest {
     fn from(prepare_request: JavaPrepareRequest) -> Self {
         PrepareRequest {
-            parent_accumulator: prepare_request.parent_accumulator,
+            parent_accumulator: prepare_request.parent_accumulator_hash.0,
             prepared_vertices: prepare_request
-                .prepared_vertices
+                .previous_vertices
                 .into_iter()
                 .map(|t| t.into())
                 .collect(),
@@ -295,10 +296,10 @@ impl From<JavaPrepareRequest> for PrepareRequest {
     }
 }
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Decode, Encode, Categorize)]
 pub struct JavaPreviousVertex {
     pub transactions: Vec<JavaRawTransaction>,
-    pub resultant_accumulator: Vec<u8>,
+    pub resultant_accumulator_hash: JavaHashCode,
 }
 
 impl From<JavaPreviousVertex> for PreviousVertex {
@@ -309,7 +310,7 @@ impl From<JavaPreviousVertex> for PreviousVertex {
                 .into_iter()
                 .map(|v| v.payload)
                 .collect(),
-            resultant_accumulator: previous_vertex.resultant_accumulator,
+            resultant_accumulator: previous_vertex.resultant_accumulator_hash.0,
         }
     }
 }

--- a/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
+++ b/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
@@ -451,8 +451,8 @@ impl PendingTransactionResultCache {
         }
     }
 
-    pub fn get_pending_transaction_record<'a>(
-        &'a mut self,
+    pub fn get_pending_transaction_record(
+        &mut self,
         intent_hash: &IntentHash,
         payload_hash: &UserPayloadHash,
         invalid_from_epoch: u64,

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -592,7 +592,13 @@ where
 
         let mut parent_accumulator_hash = self.store.get_top_accumulator_hash();
 
-        for prepared in prepare_request.already_prepared_payloads {
+        let already_prepared_payloads: Vec<_> = prepare_request
+            .prepared_vertices
+            .into_iter()
+            .flat_map(|v| v.transaction_payloads)
+            .collect();
+
+        for prepared in already_prepared_payloads {
             let parsed_transaction =
                 LedgerTransactionValidator::parse_unvalidated_transaction_from_slice(&prepared)
                     .expect("Already prepared transactions should be decodeable");

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -432,6 +432,7 @@ pub struct CommitRequest {
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PrepareRequest {
+    pub parent_accumulator: Vec<u8>,
     pub prepared_vertices: Vec<PreviousVertex>,
     pub proposed_payloads: Vec<Vec<u8>>,
     pub consensus_epoch: u64,
@@ -442,7 +443,6 @@ pub struct PrepareRequest {
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PreviousVertex {
     pub transaction_payloads: Vec<Vec<u8>>,
-    pub parent_accumulator: Vec<u8>,
     pub resultant_accumulator: Vec<u8>,
 }
 

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::transaction::LedgerTransaction;
+use crate::{jni::mempool::JavaHashCode, transaction::LedgerTransaction};
 use radix_engine::blueprints::epoch_manager::Validator;
 use radix_engine::types::*;
 use std::collections::BTreeMap;
@@ -159,6 +159,12 @@ impl AsRef<[u8]> for LedgerPayloadHash {
 impl From<Hash> for LedgerPayloadHash {
     fn from(hash: Hash) -> Self {
         LedgerPayloadHash(hash.0)
+    }
+}
+
+impl From<JavaHashCode> for AccumulatorHash {
+    fn from(java_hash_code: JavaHashCode) -> Self {
+        AccumulatorHash::from_raw_bytes(java_hash_code.0.as_slice().try_into().unwrap())
     }
 }
 
@@ -432,7 +438,7 @@ pub struct CommitRequest {
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PrepareRequest {
-    pub parent_accumulator: Vec<u8>,
+    pub parent_accumulator: AccumulatorHash,
     pub prepared_vertices: Vec<PreviousVertex>,
     pub proposed_payloads: Vec<Vec<u8>>,
     pub consensus_epoch: u64,
@@ -443,7 +449,7 @@ pub struct PrepareRequest {
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PreviousVertex {
     pub transaction_payloads: Vec<Vec<u8>>,
-    pub resultant_accumulator: Vec<u8>,
+    pub resultant_accumulator: AccumulatorHash,
 }
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -430,13 +430,20 @@ pub struct CommitRequest {
     pub vertex_store: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Decode, Encode, Categorize)]
+#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PrepareRequest {
-    pub already_prepared_payloads: Vec<Vec<u8>>,
+    pub prepared_vertices: Vec<PreviousVertex>,
     pub proposed_payloads: Vec<Vec<u8>>,
     pub consensus_epoch: u64,
     pub round_number: u64,
     pub proposer_timestamp_ms: i64,
+}
+
+#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+pub struct PreviousVertex {
+    pub transaction_payloads: Vec<Vec<u8>>,
+    pub parent_accumulator: Vec<u8>,
+    pub resultant_accumulator: Vec<u8>,
 }
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]

--- a/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
+++ b/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
@@ -226,7 +226,7 @@ public final class StateComputerLedger implements Ledger, ProposalGenerator {
                 timeSupplier.currentTime()));
       }
 
-      // It's possibly that this function is called with a list of vertices which starts with some
+      // It's possible that this function is called with a list of vertices which starts with some
       // committed vertices
       // By matching on the accumulator, we remove the already committed vertices from the
       // "previous" list

--- a/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
+++ b/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
@@ -66,6 +66,7 @@ package com.radixdlt.ledger;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
 import com.google.inject.Inject;
 import com.radixdlt.consensus.*;
 import com.radixdlt.consensus.bft.*;
@@ -128,6 +129,7 @@ public final class StateComputerLedger implements Ledger, ProposalGenerator {
         List<ExecutedTransaction> executedTransactions);
 
     StateComputerResult prepare(
+        HashCode parentAccumulator,
         List<ExecutedVertex> previous,
         List<RawNotarizedTransaction> proposedTransactions,
         RoundDetails roundDetails);
@@ -272,6 +274,7 @@ public final class StateComputerLedger implements Ledger, ProposalGenerator {
 
       final StateComputerResult result =
           stateComputer.prepare(
+              committedAccumulatorHash,
               verticesInExtension,
               vertex.getTransactions(),
               RoundDetails.fromVertex(vertexWithHash));

--- a/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
@@ -65,6 +65,7 @@
 package com.radixdlt.rev2;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
+import com.google.common.hash.HashCode;
 import com.radixdlt.consensus.*;
 import com.radixdlt.consensus.bft.*;
 import com.radixdlt.consensus.epoch.EpochChange;
@@ -174,6 +175,7 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
 
   @Override
   public StateComputerLedger.StateComputerResult prepare(
+      HashCode parentAccumulator,
       List<ExecutedVertex> previousVertices,
       List<RawNotarizedTransaction> proposedTransactions,
       RoundDetails roundDetails) {
@@ -185,16 +187,11 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
                         v.successfulTransactions()
                             .map(StateComputerLedger.ExecutedTransaction::transaction)
                             .toList(),
-                        v.vertex()
-                            .getParentHeader()
-                            .getLedgerHeader()
-                            .getAccumulatorState()
-                            .getAccumulatorHash()
-                            .asBytes(),
                         v.getLedgerHeader().getAccumulatorState().getAccumulatorHash().asBytes()))
             .toList();
     var prepareRequest =
         new PrepareRequest(
+            parentAccumulator.asBytes(),
             mappedPreviousVertices,
             proposedTransactions,
             UInt64.fromNonNegativeLong(roundDetails.epoch()),

--- a/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
@@ -175,7 +175,7 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
 
   @Override
   public StateComputerLedger.StateComputerResult prepare(
-      HashCode parentAccumulator,
+      HashCode parentAccumulatorHash,
       List<ExecutedVertex> previousVertices,
       List<RawNotarizedTransaction> proposedTransactions,
       RoundDetails roundDetails) {
@@ -187,11 +187,11 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
                         v.successfulTransactions()
                             .map(StateComputerLedger.ExecutedTransaction::transaction)
                             .toList(),
-                        v.getLedgerHeader().getAccumulatorState().getAccumulatorHash().asBytes()))
+                        v.getLedgerHeader().getAccumulatorState().getAccumulatorHash()))
             .toList();
     var prepareRequest =
         new PrepareRequest(
-            parentAccumulator.asBytes(),
+            parentAccumulatorHash,
             mappedPreviousVertices,
             proposedTransactions,
             UInt64.fromNonNegativeLong(roundDetails.epoch()),

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
@@ -66,6 +66,7 @@ package com.radixdlt.statecomputer;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.inject.*;
+import com.radixdlt.consensus.bft.ExecutedVertex;
 import com.radixdlt.consensus.bft.VertexStoreState;
 import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.ledger.CommittedTransactionsWithProof;
@@ -143,7 +144,7 @@ public class MockedMempoolStateComputerModule extends AbstractModule {
 
       @Override
       public StateComputerLedger.StateComputerResult prepare(
-          List<StateComputerLedger.ExecutedTransaction> previous,
+          List<ExecutedVertex> previousVertices,
           List<RawNotarizedTransaction> proposedTransactions,
           RoundDetails roundDetails) {
         return new StateComputerLedger.StateComputerResult(

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
@@ -65,6 +65,7 @@
 package com.radixdlt.statecomputer;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
+import com.google.common.hash.HashCode;
 import com.google.inject.*;
 import com.radixdlt.consensus.bft.ExecutedVertex;
 import com.radixdlt.consensus.bft.VertexStoreState;
@@ -144,6 +145,7 @@ public class MockedMempoolStateComputerModule extends AbstractModule {
 
       @Override
       public StateComputerLedger.StateComputerResult prepare(
+          HashCode parentAccumulator,
           List<ExecutedVertex> previousVertices,
           List<RawNotarizedTransaction> proposedTransactions,
           RoundDetails roundDetails) {

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputer.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputer.java
@@ -74,6 +74,7 @@ import com.radixdlt.consensus.QuorumCertificate;
 import com.radixdlt.consensus.Vertex;
 import com.radixdlt.consensus.VertexWithHash;
 import com.radixdlt.consensus.bft.BFTValidatorSet;
+import com.radixdlt.consensus.bft.ExecutedVertex;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.consensus.bft.VertexStoreState;
 import com.radixdlt.consensus.epoch.EpochChange;
@@ -115,9 +116,11 @@ public final class MockedStateComputer implements StateComputer {
 
   @Override
   public StateComputerLedger.StateComputerResult prepare(
-      List<StateComputerLedger.ExecutedTransaction> previous,
+      List<ExecutedVertex> previousVertices,
       List<RawNotarizedTransaction> proposedTransactions,
       RoundDetails roundDetails) {
+    final var previousTransactions =
+        previousVertices.stream().flatMap(ExecutedVertex::successfulTransactions).toList();
     return new StateComputerLedger.StateComputerResult(
         proposedTransactions.stream()
             .map(tx -> new MockExecuted(tx.INCORRECTInterpretDirectlyAsRawLedgerTransaction()))

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputer.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputer.java
@@ -65,6 +65,7 @@
 package com.radixdlt.statecomputer;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
+import com.google.common.hash.HashCode;
 import com.google.inject.Inject;
 import com.radixdlt.consensus.BFTConfiguration;
 import com.radixdlt.consensus.HighQC;
@@ -116,6 +117,7 @@ public final class MockedStateComputer implements StateComputer {
 
   @Override
   public StateComputerLedger.StateComputerResult prepare(
+      HashCode parentAccumulator,
       List<ExecutedVertex> previousVertices,
       List<RawNotarizedTransaction> proposedTransactions,
       RoundDetails roundDetails) {

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputerWithEpochs.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputerWithEpochs.java
@@ -65,6 +65,7 @@
 package com.radixdlt.statecomputer;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
 import com.google.inject.Inject;
 import com.radixdlt.consensus.NextEpoch;
 import com.radixdlt.consensus.bft.*;
@@ -114,6 +115,7 @@ public final class MockedStateComputerWithEpochs implements StateComputer {
 
   @Override
   public StateComputerResult prepare(
+      HashCode parentAccumulator,
       List<ExecutedVertex> previousVertices,
       List<RawNotarizedTransaction> proposedTransactions,
       RoundDetails roundDetails) {
@@ -127,7 +129,8 @@ public final class MockedStateComputerWithEpochs implements StateComputer {
               roundDetails.epoch() + 1,
               validatorSetMapping.apply(roundDetails.epoch() + 1).getValidators()));
     } else {
-      return stateComputer.prepare(previousVertices, proposedTransactions, roundDetails);
+      return stateComputer.prepare(
+          parentAccumulator, previousVertices, proposedTransactions, roundDetails);
     }
   }
 

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputerWithEpochs.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputerWithEpochs.java
@@ -114,7 +114,7 @@ public final class MockedStateComputerWithEpochs implements StateComputer {
 
   @Override
   public StateComputerResult prepare(
-      List<ExecutedTransaction> previous,
+      List<ExecutedVertex> previousVertices,
       List<RawNotarizedTransaction> proposedTransactions,
       RoundDetails roundDetails) {
     if (roundDetails.roundNumber() >= epochMaxRound.number()) {
@@ -127,7 +127,7 @@ public final class MockedStateComputerWithEpochs implements StateComputer {
               roundDetails.epoch() + 1,
               validatorSetMapping.apply(roundDetails.epoch() + 1).getValidators()));
     } else {
-      return stateComputer.prepare(previous, proposedTransactions, roundDetails);
+      return stateComputer.prepare(previousVertices, proposedTransactions, roundDetails);
     }
   }
 

--- a/core/src/test-core/java/com/radixdlt/statecomputer/StatelessComputer.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/StatelessComputer.java
@@ -65,6 +65,7 @@
 package com.radixdlt.statecomputer;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
+import com.google.common.hash.HashCode;
 import com.radixdlt.consensus.*;
 import com.radixdlt.consensus.bft.BFTValidatorSet;
 import com.radixdlt.consensus.bft.ExecutedVertex;
@@ -126,6 +127,7 @@ public final class StatelessComputer implements StateComputerLedger.StateCompute
 
   @Override
   public StateComputerLedger.StateComputerResult prepare(
+      HashCode parentAccumulator,
       List<ExecutedVertex> previousVertices,
       List<RawNotarizedTransaction> proposedTransactions,
       RoundDetails roundDetails) {

--- a/core/src/test-core/java/com/radixdlt/statecomputer/StatelessComputer.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/StatelessComputer.java
@@ -67,6 +67,7 @@ package com.radixdlt.statecomputer;
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.radixdlt.consensus.*;
 import com.radixdlt.consensus.bft.BFTValidatorSet;
+import com.radixdlt.consensus.bft.ExecutedVertex;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.consensus.bft.VertexStoreState;
 import com.radixdlt.consensus.epoch.EpochChange;
@@ -125,7 +126,7 @@ public final class StatelessComputer implements StateComputerLedger.StateCompute
 
   @Override
   public StateComputerLedger.StateComputerResult prepare(
-      List<StateComputerLedger.ExecutedTransaction> previous,
+      List<ExecutedVertex> previousVertices,
       List<RawNotarizedTransaction> proposedTransactions,
       RoundDetails roundDetails) {
     var successfulTransactions = new ArrayList<StateComputerLedger.ExecutedTransaction>();

--- a/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
@@ -147,7 +147,7 @@ public class EpochManagerTest {
 
         @Override
         public StateComputerResult prepare(
-            List<ExecutedTransaction> previous,
+            List<ExecutedVertex> previousVertices,
             List<RawNotarizedTransaction> proposedTransactions,
             RoundDetails roundDetails) {
           return new StateComputerResult(List.of(), Map.of());

--- a/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.HashCode;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.*;
 import com.google.inject.Module;
@@ -147,6 +148,7 @@ public class EpochManagerTest {
 
         @Override
         public StateComputerResult prepare(
+            HashCode parentAccumulator,
             List<ExecutedVertex> previousVertices,
             List<RawNotarizedTransaction> proposedTransactions,
             RoundDetails roundDetails) {

--- a/core/src/test/java/com/radixdlt/ledger/StateComputerLedgerTest.java
+++ b/core/src/test/java/com/radixdlt/ledger/StateComputerLedgerTest.java
@@ -193,7 +193,7 @@ public class StateComputerLedgerTest {
   public void should_not_change_accumulator_when_there_is_no_transaction() {
     // Arrange
     genesisIsEndOfEpoch(false);
-    when(stateComputer.prepare(any(), any(), any()))
+    when(stateComputer.prepare(any(), any(), any(), any()))
         .thenReturn(new StateComputerResult(ImmutableList.of(), ImmutableMap.of()));
     var proposedVertex =
         Vertex.create(initialEpochQC, Round.of(1), List.of(), BFTValidatorId.random(), 0L)
@@ -216,7 +216,7 @@ public class StateComputerLedgerTest {
   public void should_not_change_header_when_past_end_of_epoch_even_with_transaction() {
     // Arrange
     genesisIsEndOfEpoch(true);
-    when(stateComputer.prepare(any(), any(), any()))
+    when(stateComputer.prepare(any(), any(), any(), any()))
         .thenReturn(
             new StateComputerResult(
                 ImmutableList.of(successfulNextTransaction), ImmutableMap.of()));
@@ -242,7 +242,7 @@ public class StateComputerLedgerTest {
   public void should_accumulate_when_next_transaction_valid() {
     // Arrange
     genesisIsEndOfEpoch(false);
-    when(stateComputer.prepare(any(), any(), any()))
+    when(stateComputer.prepare(any(), any(), any(), any()))
         .thenReturn(
             new StateComputerResult(
                 ImmutableList.of(successfulNextTransaction), ImmutableMap.of()));
@@ -272,7 +272,7 @@ public class StateComputerLedgerTest {
   public void should_do_nothing_if_committing_lower_state_version() {
     // Arrange
     genesisIsEndOfEpoch(false);
-    when(stateComputer.prepare(any(), any(), any()))
+    when(stateComputer.prepare(any(), any(), any(), any()))
         .thenReturn(
             new StateComputerResult(
                 ImmutableList.of(successfulNextTransaction), ImmutableMap.of()));

--- a/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
@@ -140,12 +140,18 @@ public class REv2StateComputerTest {
     var injector = createInjector();
     var stateComputer = injector.getInstance(StateComputerLedger.StateComputer.class);
     var accumulator = injector.getInstance(LedgerAccumulator.class);
-    stateComputer.commit(buildGenesis(accumulator), null);
+    var genesis = buildGenesis(accumulator);
+    stateComputer.commit(genesis, null);
     var validTransaction = REv2TestTransactions.constructValidRawTransaction(0, 0);
 
     // Act
     var roundDetails = new RoundDetails(1, 1, 0, BFTValidatorId.random(), false, 1000, 1000);
-    var result = stateComputer.prepare(List.of(), List.of(validTransaction), roundDetails);
+    var result =
+        stateComputer.prepare(
+            genesis.getProof().getAccumulatorState().getAccumulatorHash(),
+            List.of(),
+            List.of(validTransaction),
+            roundDetails);
 
     // Assert
     assertThat(result.getFailedTransactions()).isEmpty();
@@ -157,12 +163,18 @@ public class REv2StateComputerTest {
     var injector = createInjector();
     var stateComputer = injector.getInstance(StateComputerLedger.StateComputer.class);
     var accumulator = injector.getInstance(LedgerAccumulator.class);
-    stateComputer.commit(buildGenesis(accumulator), null);
+    var genesis = buildGenesis(accumulator);
+    stateComputer.commit(genesis, null);
     var invalidTransaction = RawNotarizedTransaction.create(new byte[1]);
 
     // Act
     var roundDetails = new RoundDetails(1, 1, 0, BFTValidatorId.random(), false, 1000, 1000);
-    var result = stateComputer.prepare(List.of(), List.of(invalidTransaction), roundDetails);
+    var result =
+        stateComputer.prepare(
+            genesis.getProof().getAccumulatorState().getAccumulatorHash(),
+            List.of(),
+            List.of(invalidTransaction),
+            roundDetails);
 
     // Assert
     assertThat(result.getFailedTransactions()).hasSize(1);


### PR DESCRIPTION
Working with @malexandru-rdx 

This is still a work in progress :)