### PR TITLE
Fix/prevent commit of duplicate payloads

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
@@ -75,8 +75,9 @@ import java.util.List;
 public record PrepareRequest(
     List<RawLedgerTransaction> previous,
     List<RawNotarizedTransaction> proposed,
+    UInt64 epoch,
     UInt64 roundNumber,
-    UInt64 proposerTimestamp) {
+    UInt64 proposerTimestampMs) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PrepareRequest.class,
@@ -87,7 +88,9 @@ public record PrepareRequest(
                 codecs.of(new TypeToken<>() {}),
                 codecs.of(new TypeToken<>() {}),
                 codecs.of(new TypeToken<>() {}),
+                codecs.of(new TypeToken<>() {}),
                 (t, encoder) ->
-                    encoder.encode(t.previous, t.proposed, t.roundNumber, t.proposerTimestamp)));
+                    encoder.encode(
+                        t.previous, t.proposed, t.epoch, t.roundNumber, t.proposerTimestampMs)));
   }
 }

--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -3015,20 +3015,24 @@ components:
         - $ref: "#/components/schemas/ValidatorTransactionBase"
         - type: object
           required:
-            - epoch
+            - scrypto_epoch
           properties:
-            epoch:
+            scrypto_epoch:
               type: integer
               format: int64
               minimum: 0
               maximum: 10000000000
-              description: An integer between `0` and `10^10`, marking the new epoch
+              description: |
+                An integer between `0` and `10^10`, marking the new epoch.
+                Note that currently this is not the same as `consensus_epoch`, but eventually will be.
     TimeUpdateValidatorTransaction:
       allOf:
         - $ref: "#/components/schemas/ValidatorTransactionBase"
         - type: object
           required:
             - proposer_timestamp_ms
+            - consensus_epoch
+            - round_in_epoch
           properties:
             proposer_timestamp_ms:
               type: integer
@@ -3036,6 +3040,20 @@ components:
               minimum: 0
               maximum: 100000000000000
               description: An integer between `0` and `10^14`, marking the round proposer's unix timestamp in ms
+            consensus_epoch:
+              type: integer
+              format: int64
+              minimum: 0
+              maximum: 10000000000
+              description: |
+                An integer between `0` and `10^10`, marking the consensus epoch.
+                Note that currently this is not the same as `scrypto_epoch`, but eventually will be.
+            round_in_epoch:
+              type: integer
+              format: int64
+              minimum: 0
+              maximum: 10000000000
+              description: An integer between `0` and `10^10`, marking the consensus round in the epoch
 ############################################################################################################
 # V0
 ###################################

--- a/core-rust/core-api-server/src/core_api/conversions/numerics.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/numerics.rs
@@ -8,6 +8,7 @@ use super::*;
 // If mapped to i64, these need to be below 9223372036854775807 = 2^63 - 1 to ensure they fit into an i64 on the OAS.
 
 const MAX_API_EPOCH: u64 = 10000000000;
+const MAX_API_ROUND: u64 = 10000000000;
 const MAX_API_STATE_VERSION: u64 = 100000000000000;
 const MAX_API_SUBSTATE_VERSION: u64 = 100000000000000;
 const MAX_API_TIMESTAMP_MS: u64 = 100000000000000;
@@ -20,6 +21,16 @@ pub fn to_api_epoch(epoch: u64) -> Result<i64, MappingError> {
         });
     }
     Ok(epoch.try_into().expect("Epoch too large somehow"))
+}
+
+#[tracing::instrument(skip_all)]
+pub fn to_api_round(round: u64) -> Result<i64, MappingError> {
+    if round > MAX_API_ROUND {
+        return Err(MappingError::IntegerError {
+            message: "Round larger than max api round".to_owned(),
+        });
+    }
+    Ok(round.try_into().expect("Round too large somehow"))
 }
 
 #[tracing::instrument(skip_all)]

--- a/core-rust/core-api-server/src/core_api/generated/models/epoch_update_validator_transaction.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/epoch_update_validator_transaction.rs
@@ -15,16 +15,16 @@
 pub struct EpochUpdateValidatorTransaction {
     #[serde(rename = "type")]
     pub _type: crate::core_api::generated::models::ValidatorTransactionType,
-    /// An integer between `0` and `10^10`, marking the new epoch
-    #[serde(rename = "epoch")]
-    pub epoch: i64,
+    /// An integer between `0` and `10^10`, marking the new epoch. Note that currently this is not the same as `consensus_epoch`, but eventually will be. 
+    #[serde(rename = "scrypto_epoch")]
+    pub scrypto_epoch: i64,
 }
 
 impl EpochUpdateValidatorTransaction {
-    pub fn new(_type: crate::core_api::generated::models::ValidatorTransactionType, epoch: i64) -> EpochUpdateValidatorTransaction {
+    pub fn new(_type: crate::core_api::generated::models::ValidatorTransactionType, scrypto_epoch: i64) -> EpochUpdateValidatorTransaction {
         EpochUpdateValidatorTransaction {
             _type,
-            epoch,
+            scrypto_epoch,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/epoch_update_validator_transaction_all_of.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/epoch_update_validator_transaction_all_of.rs
@@ -13,15 +13,15 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct EpochUpdateValidatorTransactionAllOf {
-    /// An integer between `0` and `10^10`, marking the new epoch
-    #[serde(rename = "epoch")]
-    pub epoch: i64,
+    /// An integer between `0` and `10^10`, marking the new epoch. Note that currently this is not the same as `consensus_epoch`, but eventually will be. 
+    #[serde(rename = "scrypto_epoch")]
+    pub scrypto_epoch: i64,
 }
 
 impl EpochUpdateValidatorTransactionAllOf {
-    pub fn new(epoch: i64) -> EpochUpdateValidatorTransactionAllOf {
+    pub fn new(scrypto_epoch: i64) -> EpochUpdateValidatorTransactionAllOf {
         EpochUpdateValidatorTransactionAllOf {
-            epoch,
+            scrypto_epoch,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/time_update_validator_transaction.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/time_update_validator_transaction.rs
@@ -18,13 +18,21 @@ pub struct TimeUpdateValidatorTransaction {
     /// An integer between `0` and `10^14`, marking the round proposer's unix timestamp in ms
     #[serde(rename = "proposer_timestamp_ms")]
     pub proposer_timestamp_ms: i64,
+    /// An integer between `0` and `10^10`, marking the consensus epoch. Note that currently this is not the same as `scrypto_epoch`, but eventually will be. 
+    #[serde(rename = "consensus_epoch")]
+    pub consensus_epoch: i64,
+    /// An integer between `0` and `10^10`, marking the consensus round in the epoch
+    #[serde(rename = "round_in_epoch")]
+    pub round_in_epoch: i64,
 }
 
 impl TimeUpdateValidatorTransaction {
-    pub fn new(_type: crate::core_api::generated::models::ValidatorTransactionType, proposer_timestamp_ms: i64) -> TimeUpdateValidatorTransaction {
+    pub fn new(_type: crate::core_api::generated::models::ValidatorTransactionType, proposer_timestamp_ms: i64, consensus_epoch: i64, round_in_epoch: i64) -> TimeUpdateValidatorTransaction {
         TimeUpdateValidatorTransaction {
             _type,
             proposer_timestamp_ms,
+            consensus_epoch,
+            round_in_epoch,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/time_update_validator_transaction_all_of.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/time_update_validator_transaction_all_of.rs
@@ -16,12 +16,20 @@ pub struct TimeUpdateValidatorTransactionAllOf {
     /// An integer between `0` and `10^14`, marking the round proposer's unix timestamp in ms
     #[serde(rename = "proposer_timestamp_ms")]
     pub proposer_timestamp_ms: i64,
+    /// An integer between `0` and `10^10`, marking the consensus epoch. Note that currently this is not the same as `scrypto_epoch`, but eventually will be. 
+    #[serde(rename = "consensus_epoch")]
+    pub consensus_epoch: i64,
+    /// An integer between `0` and `10^10`, marking the consensus round in the epoch
+    #[serde(rename = "round_in_epoch")]
+    pub round_in_epoch: i64,
 }
 
 impl TimeUpdateValidatorTransactionAllOf {
-    pub fn new(proposer_timestamp_ms: i64) -> TimeUpdateValidatorTransactionAllOf {
+    pub fn new(proposer_timestamp_ms: i64, consensus_epoch: i64, round_in_epoch: i64) -> TimeUpdateValidatorTransactionAllOf {
         TimeUpdateValidatorTransactionAllOf {
             proposer_timestamp_ms,
+            consensus_epoch,
+            round_in_epoch,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/validator_transaction.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/validator_transaction.rs
@@ -15,15 +15,21 @@
 pub enum ValidatorTransaction {
     #[serde(rename="EpochUpdate")]
     EpochUpdateValidatorTransaction {
-        /// An integer between `0` and `10^10`, marking the new epoch
-        #[serde(rename = "epoch")]
-        epoch: i64,
+        /// An integer between `0` and `10^10`, marking the new epoch. Note that currently this is not the same as `consensus_epoch`, but eventually will be. 
+        #[serde(rename = "scrypto_epoch")]
+        scrypto_epoch: i64,
     },
     #[serde(rename="TimeUpdate")]
     TimeUpdateValidatorTransaction {
         /// An integer between `0` and `10^14`, marking the round proposer's unix timestamp in ms
         #[serde(rename = "proposer_timestamp_ms")]
         proposer_timestamp_ms: i64,
+        /// An integer between `0` and `10^10`, marking the consensus epoch. Note that currently this is not the same as `scrypto_epoch`, but eventually will be. 
+        #[serde(rename = "consensus_epoch")]
+        consensus_epoch: i64,
+        /// An integer between `0` and `10^10`, marking the consensus round in the epoch
+        #[serde(rename = "round_in_epoch")]
+        round_in_epoch: i64,
     },
 }
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_stream.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_stream.rs
@@ -285,15 +285,19 @@ pub fn to_api_validator_transaction(
     _network: &NetworkDefinition,
 ) -> Result<models::ValidatorTransaction, MappingError> {
     Ok(match validator_transaction {
-        ValidatorTransaction::EpochUpdate(epoch) => {
+        ValidatorTransaction::EpochUpdate { scrypto_epoch } => {
             models::ValidatorTransaction::EpochUpdateValidatorTransaction {
-                epoch: to_api_epoch(*epoch)?,
+                scrypto_epoch: to_api_epoch(*scrypto_epoch)?,
             }
         }
-        ValidatorTransaction::TimeUpdate(proposer_timestamp_ms) => {
-            models::ValidatorTransaction::TimeUpdateValidatorTransaction {
-                proposer_timestamp_ms: to_api_timestamp_ms(*proposer_timestamp_ms)?,
-            }
-        }
+        ValidatorTransaction::RoundUpdate {
+            proposer_timestamp_ms,
+            consensus_epoch,
+            round_in_epoch,
+        } => models::ValidatorTransaction::TimeUpdateValidatorTransaction {
+            proposer_timestamp_ms: to_api_timestamp_ms(*proposer_timestamp_ms)?,
+            consensus_epoch: to_api_epoch(*consensus_epoch)?,
+            round_in_epoch: to_api_round(*round_in_epoch)?,
+        },
     })
 }

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -220,8 +220,9 @@ impl From<JavaCommitRequest> for CommitRequest {
 pub struct JavaPrepareRequest {
     pub already_prepared: Vec<JavaRawTransaction>,
     pub proposed: Vec<JavaRawTransaction>,
+    pub consensus_epoch: u64,
     pub round_number: u64,
-    pub proposer_timestamp: u64,
+    pub proposer_timestamp_ms: u64,
 }
 
 impl From<JavaPrepareRequest> for PrepareRequest {
@@ -237,8 +238,9 @@ impl From<JavaPrepareRequest> for PrepareRequest {
                 .into_iter()
                 .map(|t| t.payload)
                 .collect(),
+            consensus_epoch: prepare_request.consensus_epoch,
             round_number: prepare_request.round_number,
-            proposer_timestamp: prepare_request.proposer_timestamp,
+            proposer_timestamp_ms: prepare_request.proposer_timestamp_ms,
         }
     }
 }

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -585,7 +585,9 @@ where
                 &self.scrypto_interpreter,
                 &self.fee_reserve_config,
                 &self.execution_config,
-                ValidatorTransaction::EpochUpdate(new_epoch),
+                ValidatorTransaction::EpochUpdate {
+                    scrypto_epoch: new_epoch,
+                },
                 &mut staged_store,
             )
             .expect("Epoch update txn failed");
@@ -597,7 +599,11 @@ where
             &self.scrypto_interpreter,
             &self.fee_reserve_config,
             &self.execution_config,
-            ValidatorTransaction::TimeUpdate(prepare_request.proposer_timestamp),
+            ValidatorTransaction::RoundUpdate {
+                proposer_timestamp_ms: prepare_request.proposer_timestamp_ms,
+                consensus_epoch: prepare_request.consensus_epoch,
+                round_in_epoch: prepare_request.round_number,
+            },
             &mut staged_store,
         )
         .expect("Time update txn failed");

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -139,7 +139,9 @@ impl StateManagerDatabase {
                     .expect("Failed to convert genesis receipt to LedgerTransactionReceipt");
 
                 let mock_genesis =
-                    LedgerTransaction::Validator(ValidatorTransaction::EpochUpdate(0)); // Mocked
+                    LedgerTransaction::Validator(ValidatorTransaction::EpochUpdate {
+                        scrypto_epoch: 0,
+                    }); // Mocked genesis transaction for the purposes of ledger state
                 let payload_hash = mock_genesis.get_hash();
                 let identifiers = CommittedTransactionIdentifiers {
                     state_version: 1,

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -395,8 +395,9 @@ pub struct CommitRequest {
 pub struct PrepareRequest {
     pub already_prepared_payloads: Vec<Vec<u8>>,
     pub proposed_payloads: Vec<Vec<u8>>,
+    pub consensus_epoch: u64,
     pub round_number: u64,
-    pub proposer_timestamp: u64,
+    pub proposer_timestamp_ms: u64,
 }
 
 #[derive(Debug, Decode, Encode, TypeId)]

--- a/core/src/main/java/com/radixdlt/rev1/RadixEngineStateComputer.java
+++ b/core/src/main/java/com/radixdlt/rev1/RadixEngineStateComputer.java
@@ -339,7 +339,7 @@ public final class RadixEngineStateComputer implements StateComputer {
           new NextRound(
               roundDetails.roundNumber(),
               roundDetails.roundWasTimeout(),
-              roundDetails.consensusParentRoundTimestamp(),
+              roundDetails.consensusParentRoundTimestampMs(),
               getValidatorMapping()));
     } else {
       // We shouldn't record the outcome of rounds beyond the end of the epoch, BUT we do need to
@@ -351,10 +351,10 @@ public final class RadixEngineStateComputer implements StateComputer {
             new NextRound(
                 epochMaxRoundNumber,
                 true,
-                roundDetails.consensusParentRoundTimestamp(),
+                roundDetails.consensusParentRoundTimestampMs(),
                 getValidatorMapping()));
       }
-      systemActions.action(new NextEpoch(roundDetails.consensusParentRoundTimestamp()));
+      systemActions.action(new NextEpoch(roundDetails.consensusParentRoundTimestampMs()));
     }
 
     try {

--- a/core/src/main/java/com/radixdlt/rev1/RoundDetails.java
+++ b/core/src/main/java/com/radixdlt/rev1/RoundDetails.java
@@ -73,8 +73,8 @@ public record RoundDetails(
     long previousQcRoundNumber,
     BFTNode roundProposer,
     boolean roundWasTimeout,
-    long consensusParentRoundTimestamp,
-    long proposerTimestamp) {
+    long consensusParentRoundTimestampMs,
+    long proposerTimestampMs) {
 
   public static RoundDetails fromVertex(VertexWithHash vertexWithHash) {
     final var vertex = vertexWithHash.vertex();

--- a/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
@@ -156,8 +156,9 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
         new PrepareRequest(
             previousTransactions,
             proposedTransactions,
+            UInt64.fromNonNegativeLong(roundDetails.epoch()),
             UInt64.fromNonNegativeLong(roundDetails.roundNumber()),
-            UInt64.fromNonNegativeLong(roundDetails.proposerTimestamp()));
+            UInt64.fromNonNegativeLong(roundDetails.proposerTimestampMs()));
 
     var result = stateComputer.prepare(prepareRequest);
     var committableTransactions =

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/EpochUpdateValidatorTransaction.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/EpochUpdateValidatorTransaction.java
@@ -35,15 +35,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   EpochUpdateValidatorTransaction.JSON_PROPERTY_TYPE,
-  EpochUpdateValidatorTransaction.JSON_PROPERTY_EPOCH
+  EpochUpdateValidatorTransaction.JSON_PROPERTY_SCRYPTO_EPOCH
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class EpochUpdateValidatorTransaction {
   public static final String JSON_PROPERTY_TYPE = "type";
   private ValidatorTransactionType type;
 
-  public static final String JSON_PROPERTY_EPOCH = "epoch";
-  private Long epoch;
+  public static final String JSON_PROPERTY_SCRYPTO_EPOCH = "scrypto_epoch";
+  private Long scryptoEpoch;
 
   public EpochUpdateValidatorTransaction() { 
   }
@@ -74,31 +74,31 @@ public class EpochUpdateValidatorTransaction {
   }
 
 
-  public EpochUpdateValidatorTransaction epoch(Long epoch) {
-    this.epoch = epoch;
+  public EpochUpdateValidatorTransaction scryptoEpoch(Long scryptoEpoch) {
+    this.scryptoEpoch = scryptoEpoch;
     return this;
   }
 
    /**
-   * An integer between &#x60;0&#x60; and &#x60;10^10&#x60;, marking the new epoch
+   * An integer between &#x60;0&#x60; and &#x60;10^10&#x60;, marking the new epoch. Note that currently this is not the same as &#x60;consensus_epoch&#x60;, but eventually will be. 
    * minimum: 0
    * maximum: 10000000000
-   * @return epoch
+   * @return scryptoEpoch
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "An integer between `0` and `10^10`, marking the new epoch")
-  @JsonProperty(JSON_PROPERTY_EPOCH)
+  @ApiModelProperty(required = true, value = "An integer between `0` and `10^10`, marking the new epoch. Note that currently this is not the same as `consensus_epoch`, but eventually will be. ")
+  @JsonProperty(JSON_PROPERTY_SCRYPTO_EPOCH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
-  public Long getEpoch() {
-    return epoch;
+  public Long getScryptoEpoch() {
+    return scryptoEpoch;
   }
 
 
-  @JsonProperty(JSON_PROPERTY_EPOCH)
+  @JsonProperty(JSON_PROPERTY_SCRYPTO_EPOCH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setEpoch(Long epoch) {
-    this.epoch = epoch;
+  public void setScryptoEpoch(Long scryptoEpoch) {
+    this.scryptoEpoch = scryptoEpoch;
   }
 
 
@@ -115,12 +115,12 @@ public class EpochUpdateValidatorTransaction {
     }
     EpochUpdateValidatorTransaction epochUpdateValidatorTransaction = (EpochUpdateValidatorTransaction) o;
     return Objects.equals(this.type, epochUpdateValidatorTransaction.type) &&
-        Objects.equals(this.epoch, epochUpdateValidatorTransaction.epoch);
+        Objects.equals(this.scryptoEpoch, epochUpdateValidatorTransaction.scryptoEpoch);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, epoch);
+    return Objects.hash(type, scryptoEpoch);
   }
 
   @Override
@@ -128,7 +128,7 @@ public class EpochUpdateValidatorTransaction {
     StringBuilder sb = new StringBuilder();
     sb.append("class EpochUpdateValidatorTransaction {\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
-    sb.append("    epoch: ").append(toIndentedString(epoch)).append("\n");
+    sb.append("    scryptoEpoch: ").append(toIndentedString(scryptoEpoch)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/EpochUpdateValidatorTransactionAllOf.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/EpochUpdateValidatorTransactionAllOf.java
@@ -31,41 +31,41 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * EpochUpdateValidatorTransactionAllOf
  */
 @JsonPropertyOrder({
-  EpochUpdateValidatorTransactionAllOf.JSON_PROPERTY_EPOCH
+  EpochUpdateValidatorTransactionAllOf.JSON_PROPERTY_SCRYPTO_EPOCH
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class EpochUpdateValidatorTransactionAllOf {
-  public static final String JSON_PROPERTY_EPOCH = "epoch";
-  private Long epoch;
+  public static final String JSON_PROPERTY_SCRYPTO_EPOCH = "scrypto_epoch";
+  private Long scryptoEpoch;
 
   public EpochUpdateValidatorTransactionAllOf() { 
   }
 
-  public EpochUpdateValidatorTransactionAllOf epoch(Long epoch) {
-    this.epoch = epoch;
+  public EpochUpdateValidatorTransactionAllOf scryptoEpoch(Long scryptoEpoch) {
+    this.scryptoEpoch = scryptoEpoch;
     return this;
   }
 
    /**
-   * An integer between &#x60;0&#x60; and &#x60;10^10&#x60;, marking the new epoch
+   * An integer between &#x60;0&#x60; and &#x60;10^10&#x60;, marking the new epoch. Note that currently this is not the same as &#x60;consensus_epoch&#x60;, but eventually will be. 
    * minimum: 0
    * maximum: 10000000000
-   * @return epoch
+   * @return scryptoEpoch
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "An integer between `0` and `10^10`, marking the new epoch")
-  @JsonProperty(JSON_PROPERTY_EPOCH)
+  @ApiModelProperty(required = true, value = "An integer between `0` and `10^10`, marking the new epoch. Note that currently this is not the same as `consensus_epoch`, but eventually will be. ")
+  @JsonProperty(JSON_PROPERTY_SCRYPTO_EPOCH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
-  public Long getEpoch() {
-    return epoch;
+  public Long getScryptoEpoch() {
+    return scryptoEpoch;
   }
 
 
-  @JsonProperty(JSON_PROPERTY_EPOCH)
+  @JsonProperty(JSON_PROPERTY_SCRYPTO_EPOCH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setEpoch(Long epoch) {
-    this.epoch = epoch;
+  public void setScryptoEpoch(Long scryptoEpoch) {
+    this.scryptoEpoch = scryptoEpoch;
   }
 
 
@@ -81,19 +81,19 @@ public class EpochUpdateValidatorTransactionAllOf {
       return false;
     }
     EpochUpdateValidatorTransactionAllOf epochUpdateValidatorTransactionAllOf = (EpochUpdateValidatorTransactionAllOf) o;
-    return Objects.equals(this.epoch, epochUpdateValidatorTransactionAllOf.epoch);
+    return Objects.equals(this.scryptoEpoch, epochUpdateValidatorTransactionAllOf.scryptoEpoch);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(epoch);
+    return Objects.hash(scryptoEpoch);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class EpochUpdateValidatorTransactionAllOf {\n");
-    sb.append("    epoch: ").append(toIndentedString(epoch)).append("\n");
+    sb.append("    scryptoEpoch: ").append(toIndentedString(scryptoEpoch)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TimeUpdateValidatorTransaction.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TimeUpdateValidatorTransaction.java
@@ -35,7 +35,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   TimeUpdateValidatorTransaction.JSON_PROPERTY_TYPE,
-  TimeUpdateValidatorTransaction.JSON_PROPERTY_PROPOSER_TIMESTAMP_MS
+  TimeUpdateValidatorTransaction.JSON_PROPERTY_PROPOSER_TIMESTAMP_MS,
+  TimeUpdateValidatorTransaction.JSON_PROPERTY_CONSENSUS_EPOCH,
+  TimeUpdateValidatorTransaction.JSON_PROPERTY_ROUND_IN_EPOCH
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class TimeUpdateValidatorTransaction {
@@ -44,6 +46,12 @@ public class TimeUpdateValidatorTransaction {
 
   public static final String JSON_PROPERTY_PROPOSER_TIMESTAMP_MS = "proposer_timestamp_ms";
   private Long proposerTimestampMs;
+
+  public static final String JSON_PROPERTY_CONSENSUS_EPOCH = "consensus_epoch";
+  private Long consensusEpoch;
+
+  public static final String JSON_PROPERTY_ROUND_IN_EPOCH = "round_in_epoch";
+  private Long roundInEpoch;
 
   public TimeUpdateValidatorTransaction() { 
   }
@@ -102,6 +110,62 @@ public class TimeUpdateValidatorTransaction {
   }
 
 
+  public TimeUpdateValidatorTransaction consensusEpoch(Long consensusEpoch) {
+    this.consensusEpoch = consensusEpoch;
+    return this;
+  }
+
+   /**
+   * An integer between &#x60;0&#x60; and &#x60;10^10&#x60;, marking the consensus epoch. Note that currently this is not the same as &#x60;scrypto_epoch&#x60;, but eventually will be. 
+   * minimum: 0
+   * maximum: 10000000000
+   * @return consensusEpoch
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "An integer between `0` and `10^10`, marking the consensus epoch. Note that currently this is not the same as `scrypto_epoch`, but eventually will be. ")
+  @JsonProperty(JSON_PROPERTY_CONSENSUS_EPOCH)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getConsensusEpoch() {
+    return consensusEpoch;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CONSENSUS_EPOCH)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setConsensusEpoch(Long consensusEpoch) {
+    this.consensusEpoch = consensusEpoch;
+  }
+
+
+  public TimeUpdateValidatorTransaction roundInEpoch(Long roundInEpoch) {
+    this.roundInEpoch = roundInEpoch;
+    return this;
+  }
+
+   /**
+   * An integer between &#x60;0&#x60; and &#x60;10^10&#x60;, marking the consensus round in the epoch
+   * minimum: 0
+   * maximum: 10000000000
+   * @return roundInEpoch
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "An integer between `0` and `10^10`, marking the consensus round in the epoch")
+  @JsonProperty(JSON_PROPERTY_ROUND_IN_EPOCH)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getRoundInEpoch() {
+    return roundInEpoch;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_ROUND_IN_EPOCH)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setRoundInEpoch(Long roundInEpoch) {
+    this.roundInEpoch = roundInEpoch;
+  }
+
+
   /**
    * Return true if this TimeUpdateValidatorTransaction object is equal to o.
    */
@@ -115,12 +179,14 @@ public class TimeUpdateValidatorTransaction {
     }
     TimeUpdateValidatorTransaction timeUpdateValidatorTransaction = (TimeUpdateValidatorTransaction) o;
     return Objects.equals(this.type, timeUpdateValidatorTransaction.type) &&
-        Objects.equals(this.proposerTimestampMs, timeUpdateValidatorTransaction.proposerTimestampMs);
+        Objects.equals(this.proposerTimestampMs, timeUpdateValidatorTransaction.proposerTimestampMs) &&
+        Objects.equals(this.consensusEpoch, timeUpdateValidatorTransaction.consensusEpoch) &&
+        Objects.equals(this.roundInEpoch, timeUpdateValidatorTransaction.roundInEpoch);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, proposerTimestampMs);
+    return Objects.hash(type, proposerTimestampMs, consensusEpoch, roundInEpoch);
   }
 
   @Override
@@ -129,6 +195,8 @@ public class TimeUpdateValidatorTransaction {
     sb.append("class TimeUpdateValidatorTransaction {\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    proposerTimestampMs: ").append(toIndentedString(proposerTimestampMs)).append("\n");
+    sb.append("    consensusEpoch: ").append(toIndentedString(consensusEpoch)).append("\n");
+    sb.append("    roundInEpoch: ").append(toIndentedString(roundInEpoch)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TimeUpdateValidatorTransactionAllOf.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TimeUpdateValidatorTransactionAllOf.java
@@ -31,12 +31,20 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * TimeUpdateValidatorTransactionAllOf
  */
 @JsonPropertyOrder({
-  TimeUpdateValidatorTransactionAllOf.JSON_PROPERTY_PROPOSER_TIMESTAMP_MS
+  TimeUpdateValidatorTransactionAllOf.JSON_PROPERTY_PROPOSER_TIMESTAMP_MS,
+  TimeUpdateValidatorTransactionAllOf.JSON_PROPERTY_CONSENSUS_EPOCH,
+  TimeUpdateValidatorTransactionAllOf.JSON_PROPERTY_ROUND_IN_EPOCH
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class TimeUpdateValidatorTransactionAllOf {
   public static final String JSON_PROPERTY_PROPOSER_TIMESTAMP_MS = "proposer_timestamp_ms";
   private Long proposerTimestampMs;
+
+  public static final String JSON_PROPERTY_CONSENSUS_EPOCH = "consensus_epoch";
+  private Long consensusEpoch;
+
+  public static final String JSON_PROPERTY_ROUND_IN_EPOCH = "round_in_epoch";
+  private Long roundInEpoch;
 
   public TimeUpdateValidatorTransactionAllOf() { 
   }
@@ -69,6 +77,62 @@ public class TimeUpdateValidatorTransactionAllOf {
   }
 
 
+  public TimeUpdateValidatorTransactionAllOf consensusEpoch(Long consensusEpoch) {
+    this.consensusEpoch = consensusEpoch;
+    return this;
+  }
+
+   /**
+   * An integer between &#x60;0&#x60; and &#x60;10^10&#x60;, marking the consensus epoch. Note that currently this is not the same as &#x60;scrypto_epoch&#x60;, but eventually will be. 
+   * minimum: 0
+   * maximum: 10000000000
+   * @return consensusEpoch
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "An integer between `0` and `10^10`, marking the consensus epoch. Note that currently this is not the same as `scrypto_epoch`, but eventually will be. ")
+  @JsonProperty(JSON_PROPERTY_CONSENSUS_EPOCH)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getConsensusEpoch() {
+    return consensusEpoch;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CONSENSUS_EPOCH)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setConsensusEpoch(Long consensusEpoch) {
+    this.consensusEpoch = consensusEpoch;
+  }
+
+
+  public TimeUpdateValidatorTransactionAllOf roundInEpoch(Long roundInEpoch) {
+    this.roundInEpoch = roundInEpoch;
+    return this;
+  }
+
+   /**
+   * An integer between &#x60;0&#x60; and &#x60;10^10&#x60;, marking the consensus round in the epoch
+   * minimum: 0
+   * maximum: 10000000000
+   * @return roundInEpoch
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "An integer between `0` and `10^10`, marking the consensus round in the epoch")
+  @JsonProperty(JSON_PROPERTY_ROUND_IN_EPOCH)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getRoundInEpoch() {
+    return roundInEpoch;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_ROUND_IN_EPOCH)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setRoundInEpoch(Long roundInEpoch) {
+    this.roundInEpoch = roundInEpoch;
+  }
+
+
   /**
    * Return true if this TimeUpdateValidatorTransaction_allOf object is equal to o.
    */
@@ -81,12 +145,14 @@ public class TimeUpdateValidatorTransactionAllOf {
       return false;
     }
     TimeUpdateValidatorTransactionAllOf timeUpdateValidatorTransactionAllOf = (TimeUpdateValidatorTransactionAllOf) o;
-    return Objects.equals(this.proposerTimestampMs, timeUpdateValidatorTransactionAllOf.proposerTimestampMs);
+    return Objects.equals(this.proposerTimestampMs, timeUpdateValidatorTransactionAllOf.proposerTimestampMs) &&
+        Objects.equals(this.consensusEpoch, timeUpdateValidatorTransactionAllOf.consensusEpoch) &&
+        Objects.equals(this.roundInEpoch, timeUpdateValidatorTransactionAllOf.roundInEpoch);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(proposerTimestampMs);
+    return Objects.hash(proposerTimestampMs, consensusEpoch, roundInEpoch);
   }
 
   @Override
@@ -94,6 +160,8 @@ public class TimeUpdateValidatorTransactionAllOf {
     StringBuilder sb = new StringBuilder();
     sb.append("class TimeUpdateValidatorTransactionAllOf {\n");
     sb.append("    proposerTimestampMs: ").append(toIndentedString(proposerTimestampMs)).append("\n");
+    sb.append("    consensusEpoch: ").append(toIndentedString(consensusEpoch)).append("\n");
+    sb.append("    roundInEpoch: ").append(toIndentedString(roundInEpoch)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
Fixes issue we saw today by ensuring the time update transactions are all unique, and panicking with an error message if this has the potential to come up again

**Breaking changes:**
* DB persistence models have changed - so this needs a ledger wipe
* Core API models have changed for Validator transactions - we now also return `consensus_epoch` and `round_in_epoch` on the `RoundUpdate` (replaces `TimeUpdate`) note that for now, `consensus_epoch` isn't the same as `scrypto_epoch`.