### PR TITLE
Introduce "getter gauge" + Use it for remaining manually-rendered metrics

### DIFF
--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -66,6 +66,7 @@ package com.radixdlt.monitoring;
 
 import com.google.common.base.Preconditions;
 import io.prometheus.client.*;
+import java.util.function.DoubleSupplier;
 import javax.annotation.Nullable;
 
 /**
@@ -83,6 +84,10 @@ import javax.annotation.Nullable;
  *   <li>{@link Gauge}: a Prometheus-native indicator of an arbitrarily changing value. Its name
  *       should be a noun describing the value - may be singular (e.g. "versionNumber") or plural
  *       (e.g. "activeClients").
+ *   <li>{@link GetterGauge}: our getter-based counterpart of the {@link Gauge}, for which a direct
+ *       "sample provider" needs to be {@link GetterGauge#initialize(DoubleSupplier) initialized}.
+ *       <b>Note:</b> such approach goes against Prometheus' conventions, and we only use it in
+ *       legacy cases (which could not be easily migrated to regular "{@link Gauge} update" style).
  *   <li>{@link Timer}: our duration-specific wrapper for a {@link Summary} without quantiles. It
  *       effectively represents a pair of [occurrence count, cumulative elapsed seconds],
  *       appropriate for tracking an average latency of an operation. Its name should be a verb
@@ -241,8 +246,7 @@ public record Metrics(
   public record Peers(
       GetterGauge peerCount, GetterGauge validatorCount, GetterGauge inValidatorSet) {}
 
-  public record Misc(
-      TypedInfo<Config> config, Timer applicationStart, Counter vertexStoreSaved) {}
+  public record Misc(TypedInfo<Config> config, Timer applicationStart, Counter vertexStoreSaved) {}
 
   public record RejectedConsensusEvent(
       Type type, Invalidity invalidity, @Nullable TimestampIssue timestampIssue) {

--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -145,6 +145,8 @@ public record Metrics(
     Messages messages,
     Networking networking,
     Crypto crypto,
+    EpochManager epochManager,
+    Peers peers,
     Misc misc) {
 
   public record Bft(
@@ -235,11 +237,14 @@ public record Metrics(
 
   public record Crypto(Counter bytesHashed, Counter signaturesSigned, Counter signaturesVerified) {}
 
+  public record EpochManager(
+      GetterGauge currentEpoch, GetterGauge currentRound, Counter enqueuedConsensusEvents) {}
+
+  public record Peers(
+      GetterGauge peerCount, GetterGauge validatorCount, GetterGauge inValidatorSet) {}
+
   public record Misc(
-      TypedInfo<Config> config,
-      Summary applicationStart,
-      Counter epochManagerEnqueuedConsensusEvents,
-      Counter vertexStoreSaved) {}
+      TypedInfo<Config> config, Summary applicationStart, Counter vertexStoreSaved) {}
 
   public record RejectedConsensusEvent(
       Type type, Invalidity invalidity, @Nullable TimestampIssue timestampIssue) {

--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -150,7 +150,6 @@ public record Metrics(
     Networking networking,
     Crypto crypto,
     EpochManager epochManager,
-    Peers peers,
     Misc misc) {
 
   public record Bft(
@@ -165,6 +164,8 @@ public record Metrics(
       Counter voteQuorums,
       Counter timeoutQuorums,
       LabelledCounter<RejectedConsensusEvent> rejectedConsensusEvents,
+      GetterGauge validatorCount,
+      GetterGauge inValidatorSet,
       Pacemaker pacemaker,
       Sync sync,
       VertexStore vertexStore) {
@@ -243,10 +244,11 @@ public record Metrics(
   public record EpochManager(
       GetterGauge currentEpoch, GetterGauge currentRound, Counter enqueuedConsensusEvents) {}
 
-  public record Peers(
-      GetterGauge peerCount, GetterGauge validatorCount, GetterGauge inValidatorSet) {}
-
-  public record Misc(TypedInfo<Config> config, Timer applicationStart, Counter vertexStoreSaved) {}
+  public record Misc(
+      TypedInfo<Config> config,
+      Timer applicationStart,
+      Counter vertexStoreSaved,
+      GetterGauge peerCount) {}
 
   public record RejectedConsensusEvent(
       Type type, Invalidity invalidity, @Nullable TimestampIssue timestampIssue) {

--- a/common/src/main/java/com/radixdlt/monitoring/MetricsInitializer.java
+++ b/common/src/main/java/com/radixdlt/monitoring/MetricsInitializer.java
@@ -178,6 +178,9 @@ public class MetricsInitializer {
     if (type == Summary.class) {
       return Summary.build(name, name).create();
     }
+    if (type == GetterGauge.class) {
+      return new GetterGauge(name);
+    }
     if (type instanceof ParameterizedType generic) {
       Class<? extends Record> labelClass =
           (Class<? extends Record>) generic.getActualTypeArguments()[0];

--- a/core/src/main/java/com/radixdlt/consensus/epoch/EpochManager.java
+++ b/core/src/main/java/com/radixdlt/consensus/epoch/EpochManager.java
@@ -332,7 +332,7 @@ public final class EpochManager {
       queuedEvents
           .computeIfAbsent(consensusEvent.getEpoch(), e -> new ArrayList<>())
           .add(consensusEvent);
-      metrics.misc().epochManagerEnqueuedConsensusEvents().inc();
+      metrics.epochManager().enqueuedConsensusEvents().inc();
       return;
     }
 

--- a/core/src/main/java/com/radixdlt/monitoring/MetricInstaller.java
+++ b/core/src/main/java/com/radixdlt/monitoring/MetricInstaller.java
@@ -105,9 +105,9 @@ public final class MetricInstaller {
   public void installAt(Metrics metrics) {
     final var config = new Config(ApplicationVersion.INSTANCE.string(), this.self.getKey().toHex());
     metrics.misc().config().set(config);
-    metrics.peers().peerCount().initialize(() -> this.peersView.peers().count());
-    metrics.peers().validatorCount().initialize(this::countValidators);
-    metrics.peers().inValidatorSet().initialize(() -> this.isInValidatorSet() ? 1 : 0);
+    metrics.misc().peerCount().initialize(() -> this.peersView.peers().count());
+    metrics.bft().validatorCount().initialize(this::countValidators);
+    metrics.bft().inValidatorSet().initialize(() -> this.isInValidatorSet() ? 1 : 0);
     metrics
         .epochManager()
         .currentEpoch()


### PR DESCRIPTION
The last PR for https://radixdlt.atlassian.net/browse/NODE-504 🥳 

(afterwards, the https://radixdlt.atlassian.net/browse/NODE-505 will take care of the only one ugliness left, related to health indicator)

[NODE-504]: https://radixdlt.atlassian.net/browse/NODE-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NODE-505]: https://radixdlt.atlassian.net/browse/NODE-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ