### PR TITLE
Fix BFT current round recovery so that it takes a timeout certificate into account

### DIFF
--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -163,6 +163,7 @@ public record Metrics(
       Counter noVotesSent,
       Counter voteQuorums,
       Counter timeoutQuorums,
+      Timer consensusEventsQueueWait,
       LabelledCounter<RejectedConsensusEvent> rejectedConsensusEvents,
       GetterGauge validatorCount,
       GetterGauge inValidatorSet,

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
@@ -87,7 +87,6 @@ import com.radixdlt.utils.UInt64;
 import java.util.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -238,7 +237,6 @@ public final class MultiNodeRebootTest {
   }
 
   @Test
-  @Ignore("Reinstate once NODE-459 task is implemented")
   public void restart_all_nodes_intermittently() {
     runTest(
         new MixedLivenessEachRound(random, 0),
@@ -264,7 +262,6 @@ public final class MultiNodeRebootTest {
   }
 
   @Test
-  @Ignore("Reinstate once NODE-459 task is implemented")
   public void restart_all_nodes_intermittently_while_f_nodes_down() {
     runTest(
         new MixedLivenessEachRound(random, (numValidators - 1) / 3),

--- a/core/src/integration/java/com/radixdlt/integration/targeted/rev2/recovery/RecoveryAfterTimeoutQuorumTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/rev2/recovery/RecoveryAfterTimeoutQuorumTest.java
@@ -1,0 +1,199 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+package com.radixdlt.integration.targeted.rev2.recovery;
+
+import static com.radixdlt.environment.deterministic.network.MessageSelector.randomSelector;
+import static com.radixdlt.harness.deterministic.invariants.DeterministicMonitors.byzantineBehaviorNotDetected;
+import static com.radixdlt.harness.deterministic.invariants.DeterministicMonitors.ledgerTransactionSafety;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.radixdlt.consensus.Proposal;
+import com.radixdlt.consensus.Vote;
+import com.radixdlt.consensus.bft.Round;
+import com.radixdlt.consensus.liveness.PacemakerState;
+import com.radixdlt.environment.deterministic.network.MessageMutator;
+import com.radixdlt.harness.deterministic.DeterministicTest;
+import com.radixdlt.harness.predicates.NodePredicate;
+import com.radixdlt.harness.predicates.NodesPredicate;
+import com.radixdlt.modules.FunctionalRadixNodeModule;
+import com.radixdlt.modules.FunctionalRadixNodeModule.ConsensusConfig;
+import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
+import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
+import com.radixdlt.modules.StateComputerConfig;
+import com.radixdlt.networks.Network;
+import com.radixdlt.rev2.REV2TransactionGenerator;
+import com.radixdlt.statemanager.REv2DatabaseConfig;
+import com.radixdlt.statemanager.REv2StateConfig;
+import com.radixdlt.sync.SyncRelayConfig;
+import com.radixdlt.utils.UInt64;
+import java.util.Random;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests a scenario when a node is rebooted while its highest round was due to a timeout quorum. */
+public final class RecoveryAfterTimeoutQuorumTest {
+  private static final int NUM_VALIDATORS = 4;
+  private static final Round TIMEOUT_QUORUM_ROUND = Round.of(5);
+  private static final int LEADER_INDEX_AT_TIMEOUT_ROUND = 1;
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void recovery_after_timeout_quorum_test() {
+    final var databaseConfig = REv2DatabaseConfig.rocksDB(folder.getRoot().getAbsolutePath());
+    final var builder =
+        DeterministicTest.builder()
+            .numNodes(NUM_VALIDATORS, 0)
+            .messageSelector(randomSelector(new Random(12345)))
+            .messageMutator(dropProposalForHalfNodesAtRound(TIMEOUT_QUORUM_ROUND))
+            .addMonitors(byzantineBehaviorNotDetected(), ledgerTransactionSafety());
+
+    final var functionalNodeModule =
+        new FunctionalRadixNodeModule(
+            false,
+            SafetyRecoveryConfig.berkeleyStore(folder.getRoot().getAbsolutePath()),
+            ConsensusConfig.of(1000),
+            LedgerConfig.stateComputerWithSyncRelay(
+                StateComputerConfig.rev2(
+                    Network.INTEGRATIONTESTNET.getId(),
+                    new REv2StateConfig(UInt64.fromNonNegativeLong(10)),
+                    databaseConfig,
+                    StateComputerConfig.REV2ProposerConfig.transactionGenerator(
+                        new REV2TransactionGenerator(), 1)),
+                SyncRelayConfig.of(5000, 10, 5000L)));
+
+    try (var test = builder.functionalNodeModule(functionalNodeModule)) {
+      test.startAllNodes();
+
+      // Run until the round that's expected to form a timeout quorum
+      test.runUntilState(
+          NodesPredicate.allNodesMatch(NodePredicate.bftAtOrOverRound(TIMEOUT_QUORUM_ROUND)), 1000);
+
+      // Make sure that round was indeed due to a timeout quorum
+      for (var node : test.getNodeInjectors()) {
+        final var pacemakerState = node.getInstance(PacemakerState.class);
+        assertEquals(
+            pacemakerState.highQC().highestQC().getRound(), TIMEOUT_QUORUM_ROUND.previous());
+        assertTrue(
+            pacemakerState.highQC().highestTC().stream()
+                .anyMatch(tc -> tc.getRound().gte(TIMEOUT_QUORUM_ROUND)));
+      }
+
+      // Lock some votes for the next round
+      final var nextRound = TIMEOUT_QUORUM_ROUND.next();
+      for (var i = 0; i < NUM_VALIDATORS; i++) {
+        if (i != LEADER_INDEX_AT_TIMEOUT_ROUND) {
+          test.runUntilState(NodesPredicate.nodeAt(i, NodePredicate.votedAtRound(nextRound)), 100);
+        }
+      }
+
+      // Shutdown the leader for a timeout round, so that after restart other nodes don't receive a
+      // proposal which would re-trigger QC/TC processing and advance them to the correct round
+      test.shutdownNode(LEADER_INDEX_AT_TIMEOUT_ROUND);
+
+      // Before restarting, drop any queued votes that could be received (and processed) after
+      // restart (and again, re-trigger QC/TC sync up)
+      test.getNetwork().dropMessages(msg -> msg.message() instanceof Vote);
+
+      // --- at this point 3 out of 4 nodes are live (so network should be live) and the votes
+      //     have been dropped one-off (again, shouldn't affect liveness) --
+
+      // Restart the nodes (the leader for prev round remains down)
+      for (var i = 0; i < NUM_VALIDATORS; i++) {
+        if (i != LEADER_INDEX_AT_TIMEOUT_ROUND) {
+          test.restartNode(i);
+        }
+      }
+
+      // After restart, the network should be live
+      for (var i = 0; i < NUM_VALIDATORS; i++) {
+        if (i != LEADER_INDEX_AT_TIMEOUT_ROUND) {
+          test.runUntilState(
+              NodesPredicate.nodeAt(i, NodePredicate.bftAtOrOverRound(Round.of(10))), 1000);
+        }
+      }
+
+      // The leader for the timeout round, once started, should catch up too
+      test.startNode(LEADER_INDEX_AT_TIMEOUT_ROUND);
+      test.runUntilState(
+          NodesPredicate.nodeAt(
+              LEADER_INDEX_AT_TIMEOUT_ROUND, NodePredicate.bftAtOrOverRound(Round.of(10))),
+          1000);
+    }
+  }
+
+  private static MessageMutator dropProposalForHalfNodesAtRound(Round round) {
+    return (message, queue) -> {
+      final var msg = message.message();
+      if (msg instanceof Proposal proposal) {
+        return proposal.getRound().equals(round)
+            && message.channelId().receiverIndex() >= (NUM_VALIDATORS / 2);
+      }
+      return false;
+    };
+  }
+}

--- a/core/src/main/java/com/radixdlt/consensus/MockedConsensusRecoveryModule.java
+++ b/core/src/main/java/com/radixdlt/consensus/MockedConsensusRecoveryModule.java
@@ -105,7 +105,7 @@ public class MockedConsensusRecoveryModule extends AbstractModule {
   private RoundUpdate initialRoundUpdate(
       BFTConfiguration configuration, ProposerElection proposerElection) {
     HighQC highQC = configuration.getVertexStoreState().getHighQC();
-    Round round = highQC.highestQC().getRound().next();
+    Round round = highQC.getHighestRound().next();
     final BFTNode leader = proposerElection.getProposer(round);
     final BFTNode nextLeader = proposerElection.getProposer(round.next());
 

--- a/core/src/main/java/com/radixdlt/consensus/bft/BFTBuilder.java
+++ b/core/src/main/java/com/radixdlt/consensus/bft/BFTBuilder.java
@@ -230,7 +230,7 @@ public final class BFTBuilder {
         new BFTEventStatefulVerifier(proposalTimestampVerifier, metrics, roundUpdate);
 
     final var syncUpPreprocessor =
-        new SyncUpPreprocessor(bftEventStatefulVerifier, bftSyncer, roundUpdate);
+        new SyncUpPreprocessor(bftEventStatefulVerifier, bftSyncer, metrics, roundUpdate);
 
     return new BFTEventStatelessVerifier(
         validatorSet, syncUpPreprocessor, hasher, verifier, safetyRules, metrics);

--- a/core/src/main/java/com/radixdlt/consensus/epoch/EpochManager.java
+++ b/core/src/main/java/com/radixdlt/consensus/epoch/EpochManager.java
@@ -191,7 +191,7 @@ public final class EpochManager {
     final var bftConfiguration = this.lastEpochChange.getBFTConfiguration();
     final var proposerElection = bftConfiguration.getProposerElection();
     final var highQC = bftConfiguration.getVertexStoreState().getHighQC();
-    final var round = highQC.highestQC().getRound().next();
+    final var round = highQC.getHighestRound().next();
     final var leader = proposerElection.getProposer(round);
     final var nextLeader = proposerElection.getProposer(round.next());
     final var initialRoundUpdate = RoundUpdate.create(round, highQC, leader, nextLeader);

--- a/core/src/main/java/com/radixdlt/consensus/liveness/PacemakerState.java
+++ b/core/src/main/java/com/radixdlt/consensus/liveness/PacemakerState.java
@@ -64,6 +64,7 @@
 
 package com.radixdlt.consensus.liveness;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.radixdlt.consensus.HighQC;
 import com.radixdlt.consensus.bft.BFTNode;
@@ -123,5 +124,10 @@ public class PacemakerState implements PacemakerReducer {
     this.currentRound = nextRound;
     roundUpdateSender.dispatch(
         RoundUpdate.create(this.currentRound, this.highQC, leader, nextLeader));
+  }
+
+  @VisibleForTesting
+  public HighQC highQC() {
+    return this.highQC;
   }
 }

--- a/core/src/main/java/com/radixdlt/rev1/modules/REv1ConsensusRecoveryModule.java
+++ b/core/src/main/java/com/radixdlt/rev1/modules/REv1ConsensusRecoveryModule.java
@@ -81,7 +81,7 @@ public class REv1ConsensusRecoveryModule extends AbstractModule {
   private RoundUpdate initialRoundUpdate(
       VertexStoreState vertexStoreState, BFTConfiguration configuration) {
     var highQC = vertexStoreState.getHighQC();
-    var round = highQC.highestQC().getRound().next();
+    var round = highQC.getHighestRound().next();
     var proposerElection = configuration.getProposerElection();
     var leader = proposerElection.getProposer(round);
     var nextLeader = proposerElection.getProposer(round.next());

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2ConsensusRecoveryModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2ConsensusRecoveryModule.java
@@ -76,7 +76,7 @@ public final class REv2ConsensusRecoveryModule extends AbstractModule {
   private RoundUpdate initialRoundUpdate(
       VertexStoreState vertexStoreState, BFTConfiguration configuration) {
     var highQC = vertexStoreState.getHighQC();
-    var round = highQC.highestQC().getRound().next();
+    var round = highQC.getHighestRound().next();
     var proposerElection = configuration.getProposerElection();
     var leader = proposerElection.getProposer(round);
     var nextLeader = proposerElection.getProposer(round.next());

--- a/core/src/test-core/java/com/radixdlt/harness/predicates/NodePredicate.java
+++ b/core/src/test-core/java/com/radixdlt/harness/predicates/NodePredicate.java
@@ -65,6 +65,9 @@
 package com.radixdlt.harness.predicates;
 
 import com.google.inject.Injector;
+import com.radixdlt.consensus.bft.Round;
+import com.radixdlt.consensus.liveness.PacemakerState;
+import com.radixdlt.consensus.safety.SafetyRules;
 import com.radixdlt.rev2.REv2StateReader;
 import com.radixdlt.sync.TransactionsAndProofReader;
 import com.radixdlt.transaction.CommittedTransactionStatus;
@@ -143,5 +146,13 @@ public class NodePredicate {
 
   public static Predicate<Injector> atOrOverEpoch(long epoch) {
     return i -> i.getInstance(REv2StateReader.class).getEpoch() >= epoch;
+  }
+
+  public static Predicate<Injector> bftAtOrOverRound(Round round) {
+    return i -> i.getInstance(PacemakerState.class).highQC().getHighestRound().gte(round);
+  }
+
+  public static Predicate<Injector> votedAtRound(Round round) {
+    return i -> i.getInstance(SafetyRules.class).getLastVote(round).isPresent();
   }
 }

--- a/core/src/test-core/java/com/radixdlt/harness/predicates/NodesPredicate.java
+++ b/core/src/test-core/java/com/radixdlt/harness/predicates/NodesPredicate.java
@@ -83,13 +83,17 @@ public final class NodesPredicate {
     return n -> injectorPredicate.test(n.get(nodeIndex));
   }
 
+  public static Predicate<List<Injector>> allNodesMatch(Predicate<Injector> injectorPredicate) {
+    return n -> n.stream().allMatch(injectorPredicate);
+  }
+
   public static Predicate<List<Injector>> allAtExactlyStateVersion(long stateVersion) {
-    return n -> n.stream().allMatch(NodePredicate.atExactlyStateVersion(stateVersion));
+    return allNodesMatch(NodePredicate.atExactlyStateVersion(stateVersion));
   }
 
   public static Predicate<List<Injector>> allCommittedTransaction(
       RawNotarizedTransaction transaction) {
-    return n -> n.stream().allMatch(NodePredicate.committedUserTransaction(transaction));
+    return allNodesMatch(NodePredicate.committedUserTransaction(transaction));
   }
 
   public static Predicate<List<Injector>> anyCommittedTransaction(
@@ -105,7 +109,7 @@ public final class NodesPredicate {
   }
 
   public static Predicate<List<Injector>> allAtOrOverStateVersion(long stateVersion) {
-    return n -> n.stream().allMatch(NodePredicate.atOrOverStateVersion(stateVersion));
+    return allNodesMatch(NodePredicate.atOrOverStateVersion(stateVersion));
   }
 
   public static Predicate<List<Injector>> anyAtOrOverStateVersion(long stateVersion) {
@@ -120,14 +124,11 @@ public final class NodesPredicate {
   }
 
   public static Predicate<List<Injector>> allHaveExactMempoolCount(int count) {
-    return n ->
-        n.stream()
-            .allMatch(
-                i -> {
-                  var reader =
-                      i.getInstance(
-                          Key.get(new TypeLiteral<MempoolReader<RawNotarizedTransaction>>() {}));
-                  return reader.getCount() == count;
-                });
+    return allNodesMatch(
+        i -> {
+          var reader =
+              i.getInstance(Key.get(new TypeLiteral<MempoolReader<RawNotarizedTransaction>>() {}));
+          return reader.getCount() == count;
+        });
   }
 }

--- a/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
@@ -358,7 +358,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                     private RoundUpdate initialRoundUpdate(
                         BFTConfiguration configuration, ProposerElection proposerElection) {
                       var highQC = configuration.getVertexStoreState().getHighQC();
-                      var round = highQC.highestQC().getRound().next();
+                      var round = highQC.getHighestRound().next();
                       var leader = proposerElection.getProposer(round);
                       var nextLeader = proposerElection.getProposer(round.next());
 

--- a/core/src/test/java/com/radixdlt/consensus/bft/processor/SyncUpPreprocessorTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/bft/processor/SyncUpPreprocessorTest.java
@@ -81,6 +81,9 @@ import com.radixdlt.consensus.bft.BFTSyncer.SyncResult;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.consensus.bft.RoundUpdate;
 import java.util.Optional;
+
+import com.radixdlt.monitoring.Metrics;
+import com.radixdlt.monitoring.MetricsInitializer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -90,11 +93,12 @@ public class SyncUpPreprocessorTest {
 
   private final BFTEventProcessor forwardTo = mock(BFTEventProcessor.class);
   private final BFTSyncer bftSyncer = mock(BFTSyncer.class);
+  private final Metrics metrics = new MetricsInitializer().initialize();
   private final RoundUpdate initialRoundUpdate = mock(RoundUpdate.class);
 
   @Before
   public void setUp() {
-    this.syncUpPreprocessor = new SyncUpPreprocessor(forwardTo, bftSyncer, initialRoundUpdate);
+    this.syncUpPreprocessor = new SyncUpPreprocessor(forwardTo, bftSyncer, metrics, initialRoundUpdate);
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/consensus/bft/processor/SyncUpPreprocessorTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/bft/processor/SyncUpPreprocessorTest.java
@@ -80,10 +80,9 @@ import com.radixdlt.consensus.bft.BFTSyncer;
 import com.radixdlt.consensus.bft.BFTSyncer.SyncResult;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.consensus.bft.RoundUpdate;
-import java.util.Optional;
-
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.monitoring.MetricsInitializer;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -98,7 +97,8 @@ public class SyncUpPreprocessorTest {
 
   @Before
   public void setUp() {
-    this.syncUpPreprocessor = new SyncUpPreprocessor(forwardTo, bftSyncer, metrics, initialRoundUpdate);
+    this.syncUpPreprocessor =
+        new SyncUpPreprocessor(forwardTo, bftSyncer, metrics, initialRoundUpdate);
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
@@ -235,7 +235,7 @@ public class EpochManagerTest {
       @Provides
       private RoundUpdate initialRoundUpdate(BFTConfiguration bftConfiguration) {
         HighQC highQC = bftConfiguration.getVertexStoreState().getHighQC();
-        Round round = highQC.highestQC().getRound().next();
+        Round round = highQC.getHighestRound().next();
         return RoundUpdate.create(round, highQC, self, self);
       }
 


### PR DESCRIPTION
Fixes current round recovery when the previous quorum formed a timeout certificate (rather than a typical QC).
The initial round is now `max(highestQc.round, highestTc.round)`. Prior to the fix, it could happen that the node recovered to an earlier round (latest QC) and, if it had already sent a vote for its previously latest round, was unable to send a vote (including a timeout vote) for its current round (because of the safety rules). This can lead to a liveness break if it happens to a few nodes at once.

This PR also includes a new metric that measures the time consensus events spend in a queue.