### PR TITLE
fix(build): use ubuntu:22.04 for builder base image

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -6,10 +6,18 @@ ENV DEBIAN_FRONTEND noninteractive
 
 CMD /bin/bash
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget curl iputils-ping dnsutils \
-    unzip software-properties-common ca-certificates-java \
-    docker.io
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates-java \
+  curl \
+  dnsutils \
+  docker.io \
+  iputils-ping \
+  libssl-dev \
+  pkg-config \
+  software-properties-common \
+  unzip \
+  wget
+
 #install jdk17
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
     apt update && \

--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -2,7 +2,21 @@ FROM ubuntu:22.04
 MAINTAINER radixdlt <devops@radixdlt.com>
 
 RUN apt-get -y update > /dev/null && \
-    apt-get -y --no-install-recommends install apt-utils net-tools iptables iproute2 gettext-base curl tcpdump strace attr software-properties-common daemontools > /dev/null && \
+    apt-get -y --no-install-recommends install \
+    apt-utils \
+    attr \
+    curl \
+    daemontools \
+    gettext-base \
+    iproute2 \
+    iptables \
+    libssl-dev \
+    net-tools \
+    pkg-config \
+    software-properties-common \
+    strace \
+    tcpdump \
+    > /dev/null && \
     apt-get clean > /dev/null && \
     rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 

--- a/docker/rust-builder/Dockerfile
+++ b/docker/rust-builder/Dockerfile
@@ -1,20 +1,18 @@
-FROM rust:1.65.0-slim as base
+FROM ubuntu:22.04 as base
 WORKDIR /app
 
-RUN apt update; apt upgrade -y && \
+RUN apt-get update; apt-get upgrade -y && \
   apt install -y \
   build-essential \
   curl \
   g++-aarch64-linux-gnu \
   g++-x86-64-linux-gnu \
   libc6-dev-arm64-cross \
-  libclang-dev
+  libclang-dev \
+  libssl-dev \
+  pkg-config
 
-RUN rustup target add aarch64-unknown-linux-gnu && \
-  rustup toolchain install stable-aarch64-unknown-linux-gnu
-
-RUN rustup target add x86_64-unknown-linux-gnu && \
-  rustup toolchain install stable-x86_64-unknown-linux-gnu
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh; sh rustup.sh -y --target aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
 
 # This mapped-volume-build is used in development, via the build-sm.yaml docker compose.
 # By using mounts, this allows artifact caching. The whole core-rust directory is mounted, and run is called.
@@ -24,7 +22,7 @@ FROM base as mapped-volume-build
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
 
-CMD cargo build --target=$TARGET --profile=$RUST_PROFILE
+CMD $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
 
 # On CI we use docker build instead of docker compose.
 # The mapped-volume-build stage is skipped, and the following stages are run, with sub-stages cached for future runs.
@@ -32,11 +30,12 @@ FROM base as cache-packages
 ARG TARGET
 ARG RUST_PROFILE
 
+ENV PATH="$HOME/.cargo/bin:$PATH"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
 
 # First - we build a dummy rust file, to cache the compilation of all our dependencies in a Docker layer
-RUN USER=root cargo new dummy
+RUN USER=root $HOME/.cargo/bin/cargo new dummy
 RUN USER=root mkdir -p ./dummy/state-manager/src
 RUN USER=root mkdir -p ./dummy/core-rust/src
 RUN USER=root mkdir -p ./dummy/core-api-server/src
@@ -51,7 +50,7 @@ COPY core-rust/core-api-server/Cargo.toml ./dummy/core-api-server
 
 RUN mv ./dummy/src/main.rs ./dummy/src/lib.rs
 WORKDIR /app/dummy
-RUN cargo build --target=$TARGET --profile=$RUST_PROFILE
+RUN $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
 RUN rm -rf /app/dummy/*
 
 FROM cache-packages as prod-build
@@ -59,7 +58,7 @@ WORKDIR /app
 # Now - we copy in everything, and do the actual build
 COPY core-rust ./
 
-RUN cargo build --target=$TARGET --profile=$RUST_PROFILE
+RUN $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
 RUN cp -R target/$TARGET/release/libcorerust.so /
 RUN rm -rf /app
 


### PR DESCRIPTION
There was a linking issue when babylon-node was built on a Debian-based
image, since the OpenSSL was pretty old there, and was not found on a
Ubuntu-based image. (v1.1.1 vs v3.0.0)