### PR TITLE
ci: Federation auth method for gcp registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-deb
           restore-keys: ${{ runner.os }}-gradle-deb
       - id: auth
-        uses: google-github-actions/auth@v0.4.0
+        uses: google-github-actions/auth@a61909d048e0be579b6c15b27088d19668493851
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -98,7 +98,7 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R docker
       - id: auth
-        uses: google-github-actions/auth@v0.4.0
+        uses: google-github-actions/auth@a61909d048e0be579b6c15b27088d19668493851
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,8 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
       - name: configure-docker
         run: |
             gcloud auth configure-docker -q

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,8 +64,8 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: configure-docker
+        uses: 'google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce'
+      - name: 'Register gcloud as Docker credential helper'
         run: |
             gcloud auth configure-docker -q
       - name: Create deb package
@@ -104,7 +104,7 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: configure-docker
+      - name: 'Register gcloud as Docker credential helper'
         run: |
             gcloud auth configure-docker -q
       - name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,10 @@ jobs:
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v2
         with:
@@ -54,12 +58,14 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-deb
           restore-keys: ${{ runner.os }}-gradle-deb
-      - name: Login to GCR
-        uses: docker/login-action@v1
+      - id: auth
+        uses: google-github-actions/auth@v0.4.0
         with:
-          registry: eu.gcr.io
-          username: _json_key
-          password: ${{ secrets.GCR_EU_DEV_JSON_KEY }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: configure-docker
+        run: |
+            gcloud auth configure-docker -q
       - name: Create deb package
         run: |
             sudo apt-get update && sudo apt-get install make
@@ -76,6 +82,10 @@ jobs:
     needs:
       - build_deb
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v2
         with:
@@ -87,12 +97,14 @@ jobs:
           path: docker
       - name: Display structure of downloaded files
         run: ls -R docker
-      - name: Login to GCR
-        uses: docker/login-action@v1
+      - id: auth
+        uses: google-github-actions/auth@v0.4.0
         with:
-          registry: eu.gcr.io
-          username: _json_key
-          password: ${{ secrets.GCR_EU_DEV_JSON_KEY }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: configure-docker
+        run: |
+            gcloud auth configure-docker -q
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Federation auth method for gcp registry


## Description

Login to gpc registry through federations instead of long live tokens
