### PR TITLE
Use RocksDB column families; some overall improvements

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
@@ -64,12 +64,12 @@
 
 package com.radixdlt.transaction;
 
-import com.google.common.hash.HashCode;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.lang.Tuple;
 import com.radixdlt.sbor.NativeCalls;
 import com.radixdlt.statemanager.StateManager;
+import com.radixdlt.utils.UInt32;
 import com.radixdlt.utils.UInt64;
 import java.util.List;
 import java.util.Objects;
@@ -84,12 +84,12 @@ public final class REv2TransactionAndProofStore {
             new TypeToken<>() {},
             new TypeToken<>() {},
             REv2TransactionAndProofStore::getTransactionAtStateVersion);
-    this.getNextProofFunc =
+    this.getTxnsAndProof =
         NativeCalls.Func1.with(
             stateManager,
             new TypeToken<>() {},
             new TypeToken<>() {},
-            REv2TransactionAndProofStore::getNextProof);
+            REv2TransactionAndProofStore::getTxnsAndProof);
     this.getLastProofFunc =
         NativeCalls.Func1.with(
             stateManager,
@@ -108,8 +108,13 @@ public final class REv2TransactionAndProofStore {
     return this.getTransactionAtStateVersionFunc.call(UInt64.fromNonNegativeLong(stateVersion));
   }
 
-  public Option<Tuple.Tuple2<List<HashCode>, byte[]>> getNextProof(long stateVersion) {
-    return this.getNextProofFunc.call(UInt64.fromNonNegativeLong(stateVersion));
+  public Option<Tuple.Tuple2<List<byte[]>, byte[]>> getTxnsAndProof(
+      long startStateVersionInclusive, int maxNumberOfTxns, int maxPayloadSizeInBytes) {
+    return this.getTxnsAndProof.call(
+        Tuple.Tuple3.of(
+            UInt64.fromNonNegativeLong(startStateVersionInclusive),
+            UInt32.fromNonNegativeInt(maxNumberOfTxns),
+            UInt32.fromNonNegativeInt(maxPayloadSizeInBytes)));
   }
 
   public Optional<byte[]> getLastProof() {
@@ -127,10 +132,12 @@ public final class REv2TransactionAndProofStore {
       StateManager stateManager, byte[] payload);
 
   private final NativeCalls.Func1<
-          StateManager, UInt64, Option<Tuple.Tuple2<List<HashCode>, byte[]>>>
-      getNextProofFunc;
+          StateManager,
+          Tuple.Tuple3<UInt64, UInt32, UInt32>,
+          Option<Tuple.Tuple2<List<byte[]>, byte[]>>>
+      getTxnsAndProof;
 
-  private static native byte[] getNextProof(StateManager stateManager, byte[] payload);
+  private static native byte[] getTxnsAndProof(StateManager stateManager, byte[] payload);
 
   private final NativeCalls.Func1<StateManager, Tuple.Tuple0, Option<byte[]>> getLastProofFunc;
 

--- a/core-rust/core-api-server/src/core_api/handlers/network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/network_status.rs
@@ -1,6 +1,7 @@
 use crate::core_api::*;
 use state_manager::jni::state_manager::ActualStateManager;
 use state_manager::query::TransactionIdentifierLoader;
+use state_manager::store::traits::QueryableTransactionStore;
 use state_manager::CommittedTransactionIdentifiers;
 
 #[tracing::instrument(skip(state), err(Debug))]
@@ -23,7 +24,7 @@ pub(crate) fn handle_network_status_internal(
     Ok(models::NetworkStatusResponse {
         post_genesis_state_identifier: state_manager
             .store
-            .get_transaction_identifiers(1)
+            .get_committed_transaction_identifiers(1)
             .map(|identifiers| -> Result<_, MappingError> {
                 Ok(Box::new(to_api_committed_state_identifier(identifiers)?))
             })

--- a/core-rust/core-api-server/src/core_api/handlers/v0/transaction_receipt.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/v0/transaction_receipt.rs
@@ -19,15 +19,30 @@ fn handle_v0_transaction_receipt_internal(
         .map_err(|err| err.into_response_error("intent_hash"))?;
 
     let network = &state_manager.network;
-    let committed_option = state_manager
+    let txn_state_version_opt = state_manager
         .store
-        .get_committed_transaction_by_identifier(&intent_hash);
+        .get_txn_state_version_by_identifier(&intent_hash);
 
-    if let Some((ledger_transaction, receipt, identifiers)) = committed_option {
+    if let Some(txn_state_version) = txn_state_version_opt {
+        let txn = state_manager
+            .store
+            .get_committed_transaction(txn_state_version)
+            .expect("Txn is missing");
+
+        let receipt = state_manager
+            .store
+            .get_committed_transaction_receipt(txn_state_version)
+            .expect("Txn receipt is missing");
+
+        let identifiers = state_manager
+            .store
+            .get_committed_transaction_identifiers(txn_state_version)
+            .expect("Txn identifiers are missing");
+
         Ok(models::V0CommittedTransactionResponse {
             committed: Box::new(to_api_committed_transaction(
                 network,
-                ledger_transaction,
+                txn,
                 receipt,
                 identifiers,
             )?),

--- a/core-rust/core-api-server/src/core_api/handlers/v0/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/v0/transaction_status.rs
@@ -27,16 +27,26 @@ fn handle_v0_transaction_status_internal(
     let intent_hash = extract_intent_hash(request.intent_hash)
         .map_err(|err| err.into_response_error("intent_hash"))?;
 
-    let committed_option = state_manager
+    let txn_state_version_opt = state_manager
         .store
-        .get_committed_transaction_by_identifier(&intent_hash);
+        .get_txn_state_version_by_identifier(&intent_hash);
 
     let mut known_pending_payloads = state_manager
         .pending_transaction_result_cache
         .peek_all_known_payloads_for_intent(&intent_hash);
 
-    if let Some((stored_transaction, receipt, _)) = committed_option {
-        let payload_hash = stored_transaction
+    if let Some(txn_state_version) = txn_state_version_opt {
+        let txn = state_manager
+            .store
+            .get_committed_transaction(txn_state_version)
+            .expect("Txn is missing");
+
+        let receipt = state_manager
+            .store
+            .get_committed_transaction_receipt(txn_state_version)
+            .expect("Txn receipt is missing");
+
+        let payload_hash = txn
             .user()
             .expect("Only user transactions should be able to be looked up by intent hash")
             .user_payload_hash();

--- a/core-rust/state-manager/src/jni/transaction_store.rs
+++ b/core-rust/state-manager/src/jni/transaction_store.rs
@@ -72,7 +72,6 @@ use jni::JNIEnv;
 use radix_engine::types::{scrypto_encode, ComponentAddress};
 use radix_engine_interface::*;
 
-use super::mempool::JavaPayloadHash;
 use super::utils::jni_state_manager_sbor_read_call;
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -109,47 +108,51 @@ fn do_get_transaction_at_state_version(
     state_manager: &ActualStateManager,
     state_version: u64,
 ) -> Option<ExecutedTransaction> {
-    let payload_hash = state_manager.store.get_payload_hash(state_version)?;
-
-    let (stored_transaction, ledger_receipt, _) = state_manager
+    let committed_transaction = state_manager
         .store
-        .get_committed_transaction(&payload_hash)?;
+        .get_committed_transaction(state_version)?;
 
-    let ledger_receipt_bytes = scrypto_encode(&ledger_receipt).unwrap();
+    let committed_transaction_receipt = state_manager
+        .store
+        .get_committed_transaction_receipt(state_version)?;
+
+    let ledger_receipt_bytes = scrypto_encode(&committed_transaction_receipt).unwrap();
 
     Some(ExecutedTransaction {
-        outcome: match ledger_receipt.outcome {
+        outcome: match committed_transaction_receipt.outcome {
             LedgerTransactionOutcome::Success(output) => TransactionOutcomeJava::Success(output),
             LedgerTransactionOutcome::Failure(err) => {
                 TransactionOutcomeJava::Failure(format!("{:?}", err))
             }
         },
         ledger_receipt_bytes,
-        transaction_bytes: stored_transaction.create_payload().unwrap(),
-        new_component_addresses: ledger_receipt.entity_changes.new_component_addresses,
+        transaction_bytes: committed_transaction.create_payload().unwrap(),
+        new_component_addresses: committed_transaction_receipt
+            .entity_changes
+            .new_component_addresses,
     })
 }
 
 #[no_mangle]
-extern "system" fn Java_com_radixdlt_transaction_REv2TransactionAndProofStore_getNextProof(
+extern "system" fn Java_com_radixdlt_transaction_REv2TransactionAndProofStore_getTxnsAndProof(
     env: JNIEnv,
     _class: JClass,
     j_state_manager: JObject,
     request_payload: jbyteArray,
 ) -> jbyteArray {
-    jni_state_manager_sbor_read_call(env, j_state_manager, request_payload, do_get_next_proof)
+    jni_state_manager_sbor_read_call(env, j_state_manager, request_payload, do_get_txns_and_proof)
 }
 
 #[tracing::instrument(skip_all)]
-fn do_get_next_proof(
+fn do_get_txns_and_proof(
     state_manager: &ActualStateManager,
-    state_version: u64,
-) -> Option<(Vec<JavaPayloadHash>, Vec<u8>)> {
-    let (payload_hashes, proof) = state_manager.store.get_next_proof(state_version)?;
-
-    let payload_hashes = payload_hashes.into_iter().map(|hash| hash.into()).collect();
-
-    Some((payload_hashes, proof))
+    (start_state_version_inclusive, max_number_of_txns, max_payload_size_in_bytes): (u64, u32, u32),
+) -> Option<(Vec<Vec<u8>>, Vec<u8>)> {
+    state_manager.store.get_txns_and_proof(
+        start_state_version_inclusive,
+        max_number_of_txns,
+        max_payload_size_in_bytes,
+    )
 }
 
 #[no_mangle]

--- a/core-rust/state-manager/src/query/transaction_identifiers.rs
+++ b/core-rust/state-manager/src/query/transaction_identifiers.rs
@@ -3,34 +3,11 @@ use crate::CommittedTransactionIdentifiers;
 
 pub trait TransactionIdentifierLoader {
     fn get_top_of_ledger_transaction_identifiers(&self) -> Option<CommittedTransactionIdentifiers>;
-    fn get_transaction_identifiers(
-        &self,
-        state_version: u64,
-    ) -> Option<CommittedTransactionIdentifiers>;
 }
 
-impl<T: QueryableProofStore + TransactionIndex<u64>> TransactionIdentifierLoader for T {
+impl<T: QueryableProofStore + QueryableTransactionStore> TransactionIdentifierLoader for T {
     fn get_top_of_ledger_transaction_identifiers(&self) -> Option<CommittedTransactionIdentifiers> {
         let top_state_version = self.max_state_version();
-        self.get_transaction_identifiers(top_state_version)
-    }
-
-    fn get_transaction_identifiers(
-        &self,
-        state_version: u64,
-    ) -> Option<CommittedTransactionIdentifiers> {
-        let payload_hash = self.get_payload_hash(state_version)?;
-
-        // TODO: This is rather wasteful, particularly with a big genesis transaction(!)
-        //       when we refactor the DB, we should be able to get this information much more cheaply
-        let (_, _, identifiers) = self
-            .get_committed_transaction(&payload_hash)
-            .unwrap_or_else(|| {
-                panic!(
-                    "A transaction is missing at state version {}",
-                    state_version
-                )
-            });
-        Some(identifiers)
+        self.get_committed_transaction_identifiers(top_state_version)
     }
 }

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -15,7 +15,7 @@ use radix_engine_interface::*;
 
 use crate::AccumulatorHash;
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct CommittedTransactionIdentifiers {
     pub state_version: u64,
     pub accumulator_hash: AccumulatorHash,
@@ -36,20 +36,20 @@ pub enum CommittedTransactionStatus {
     Failure(RuntimeError),
 }
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct SubstateChanges {
     pub created: BTreeMap<SubstateId, OutputValue>,
     pub updated: BTreeMap<SubstateId, OutputValue>,
     pub deleted: BTreeMap<SubstateId, DeletedSubstateVersion>,
 }
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct DeletedSubstateVersion {
     pub substate_hash: Hash,
     pub version: u32,
 }
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub enum LedgerTransactionOutcome {
     Success(Vec<Vec<u8>>),
     Failure(RuntimeError),
@@ -66,7 +66,7 @@ impl From<TransactionOutcome> for LedgerTransactionOutcome {
     }
 }
 
-#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct LedgerTransactionReceipt {
     pub outcome: LedgerTransactionOutcome,
     pub fee_summary: FeeSummary,

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -239,7 +239,7 @@ enum AlreadyPreparedTransaction {
 impl<S> StateManager<S>
 where
     S: ReadableSubstateStore,
-    S: for<'a> TransactionIndex<&'a IntentHash> + TransactionIndex<u64> + QueryableTransactionStore,
+    S: for<'a> TransactionIndex<&'a IntentHash> + QueryableTransactionStore,
     S: ReadableSubstateStore + QueryableSubstateStore, // Temporary - can remove when epoch validation moves to executor
     S: QueryableProofStore,
 {
@@ -309,7 +309,7 @@ where
 
     /// Checking if the transaction should be rejected requires full validation, ie:
     /// * Static Validation
-    /// * Executing the transaction (up to loan replatment)
+    /// * Executing the transaction (up to loan repayment)
     ///
     /// We look for cached rejections first, to avoid this heavy lifting where we can
     fn check_for_rejection_and_add_to_mempool_internal(
@@ -405,7 +405,7 @@ where
     ) -> Result<(), RejectionReason> {
         if self
             .store
-            .get_payload_hash(&transaction.intent_hash())
+            .get_txn_state_version_by_identifier(&transaction.intent_hash())
             .is_some()
         {
             return Err(RejectionReason::IntentHashCommitted);
@@ -517,7 +517,7 @@ where
                 .map(|validated_transaction| validated_transaction.intent_hash())
                 .and_then(|intent_hash| {
                     self.store
-                        .get_payload_hash(&intent_hash)
+                        .get_txn_state_version_by_identifier(&intent_hash)
                         .map(|_| (intent_hash, AlreadyPreparedTransaction::Committed))
                 })
             });
@@ -747,7 +747,7 @@ impl<'db, S> StateManager<S>
 where
     S: CommitStore<'db>,
     S: ReadableSubstateStore,
-    S: QueryableProofStore + TransactionIndex<u64>,
+    S: QueryableProofStore + QueryableTransactionStore,
 {
     pub fn save_vertex_store(&'db mut self, vertex_store: Vec<u8>) {
         let mut db_transaction = self.store.create_db_transaction();
@@ -757,7 +757,6 @@ where
 
     pub fn commit(&'db mut self, commit_request: CommitRequest) -> Result<(), CommitError> {
         let mut to_store = Vec::new();
-        let mut payload_hashes = Vec::new();
         let mut intent_hashes = Vec::new();
         let commit_request_start_state_version =
             commit_request.proof_state_version - (commit_request.transaction_payloads.len() as u64);
@@ -863,16 +862,14 @@ where
             };
 
             to_store.push((transaction, ledger_receipt, identifiers));
-            payload_hashes.push(payload_hash);
         }
 
         let committed_transactions_count = to_store.len();
 
         db_transaction.insert_committed_transactions(to_store);
-        db_transaction.insert_tids_and_proof(
+        db_transaction.insert_proof(
             commit_request.proof_state_version,
             epoch_boundary,
-            payload_hashes,
             commit_request.proof,
         );
         if let Some(post_commit_vertex_store) = commit_request.post_commit_vertex_store {

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -97,7 +97,7 @@ pub enum DatabaseConfig {
 
 pub enum StateManagerDatabase {
     InMemory {
-        transactions_and_proofs: InMemoryStore,
+        in_memory_store: InMemoryStore,
         substates: SerializedInMemorySubstateStore,
         vertices: InMemoryVertexStore,
     },
@@ -109,7 +109,7 @@ impl StateManagerDatabase {
     pub fn from_config(config: DatabaseConfig) -> Self {
         match config {
             DatabaseConfig::InMemory => StateManagerDatabase::InMemory {
-                transactions_and_proofs: InMemoryStore::new(),
+                in_memory_store: InMemoryStore::new(),
                 substates: SerializedInMemorySubstateStore::new(),
                 vertices: InMemoryVertexStore::new(),
             },
@@ -134,7 +134,7 @@ impl ReadableSubstateStore for StateManagerDatabase {
 
 pub enum StateManagerCommitTransaction<'db> {
     InMemory {
-        transactions_and_proofs: &'db mut InMemoryStore,
+        in_memory_store: &'db mut InMemoryStore,
         substates: &'db mut SerializedInMemorySubstateStore,
         vertices: &'db mut InMemoryVertexStore,
     },
@@ -163,9 +163,8 @@ impl<'db> WriteableTransactionStore for StateManagerCommitTransaction<'db> {
     ) {
         match self {
             StateManagerCommitTransaction::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.insert_committed_transactions(transactions),
+                in_memory_store, ..
+            } => in_memory_store.insert_committed_transactions(transactions),
             StateManagerCommitTransaction::RocksDB(db_txn) => {
                 db_txn.insert_committed_transactions(transactions)
             }
@@ -174,37 +173,18 @@ impl<'db> WriteableTransactionStore for StateManagerCommitTransaction<'db> {
 }
 
 impl<'db> WriteableProofStore for StateManagerCommitTransaction<'db> {
-    fn insert_tids_and_proof(
+    fn insert_proof(
         &mut self,
         state_version: u64,
         epoch_boundary: Option<u64>,
-        ids: Vec<LedgerPayloadHash>,
         proof_bytes: Vec<u8>,
     ) {
         match self {
             StateManagerCommitTransaction::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.insert_tids_and_proof(
-                state_version,
-                epoch_boundary,
-                ids,
-                proof_bytes,
-            ),
+                in_memory_store, ..
+            } => in_memory_store.insert_proof(state_version, epoch_boundary, proof_bytes),
             StateManagerCommitTransaction::RocksDB(db_txn) => {
-                db_txn.insert_tids_and_proof(state_version, epoch_boundary, ids, proof_bytes)
-            }
-        }
-    }
-
-    fn insert_tids_without_proof(&mut self, state_version: u64, ids: Vec<LedgerPayloadHash>) {
-        match self {
-            StateManagerCommitTransaction::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.insert_tids_without_proof(state_version, ids),
-            StateManagerCommitTransaction::RocksDB(db_txn) => {
-                db_txn.insert_tids_without_proof(state_version, ids)
+                db_txn.insert_proof(state_version, epoch_boundary, proof_bytes)
             }
         }
     }
@@ -251,11 +231,11 @@ impl<'db> CommitStore<'db> for StateManagerDatabase {
     fn create_db_transaction(&'db mut self) -> StateManagerCommitTransaction<'db> {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
+                in_memory_store,
                 substates,
                 vertices,
             } => StateManagerCommitTransaction::InMemory {
-                transactions_and_proofs,
+                in_memory_store,
                 substates,
                 vertices,
             },
@@ -270,59 +250,86 @@ impl<'db> CommitStore<'db> for StateManagerDatabase {
 
 impl QueryableTransactionStore for StateManagerDatabase {
     #[tracing::instrument(skip_all)]
-    fn get_committed_transaction(
-        &self,
-        payload_hash: &LedgerPayloadHash,
-    ) -> Option<(
-        LedgerTransaction,
-        LedgerTransactionReceipt,
-        CommittedTransactionIdentifiers,
-    )> {
+    fn get_committed_transaction(&self, state_version: u64) -> Option<LedgerTransaction> {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.get_committed_transaction(payload_hash),
-            StateManagerDatabase::RocksDB(store) => store.get_committed_transaction(payload_hash),
+                in_memory_store, ..
+            } => in_memory_store.get_committed_transaction(state_version),
+            StateManagerDatabase::RocksDB(store) => store.get_committed_transaction(state_version),
             StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
         }
     }
-}
 
-impl TransactionIndex<&UserPayloadHash> for StateManagerDatabase {
-    fn get_payload_hash(&self, identifier: &UserPayloadHash) -> Option<LedgerPayloadHash> {
+    #[tracing::instrument(skip_all)]
+    fn get_committed_transaction_receipt(
+        &self,
+        state_version: u64,
+    ) -> Option<LedgerTransactionReceipt> {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.get_payload_hash(identifier),
-            StateManagerDatabase::RocksDB(store) => store.get_payload_hash(identifier),
+                in_memory_store, ..
+            } => in_memory_store.get_committed_transaction_receipt(state_version),
+            StateManagerDatabase::RocksDB(store) => {
+                store.get_committed_transaction_receipt(state_version)
+            }
+            StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
+        }
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn get_committed_transaction_identifiers(
+        &self,
+        state_version: u64,
+    ) -> Option<CommittedTransactionIdentifiers> {
+        match self {
+            StateManagerDatabase::InMemory {
+                in_memory_store, ..
+            } => in_memory_store.get_committed_transaction_identifiers(state_version),
+            StateManagerDatabase::RocksDB(store) => {
+                store.get_committed_transaction_identifiers(state_version)
+            }
             StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
         }
     }
 }
 
 impl TransactionIndex<&IntentHash> for StateManagerDatabase {
-    fn get_payload_hash(&self, identifier: &IntentHash) -> Option<LedgerPayloadHash> {
+    fn get_txn_state_version_by_identifier(&self, identifier: &IntentHash) -> Option<u64> {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.get_payload_hash(identifier),
-            StateManagerDatabase::RocksDB(store) => store.get_payload_hash(identifier),
+                in_memory_store, ..
+            } => in_memory_store.get_txn_state_version_by_identifier(identifier),
+            StateManagerDatabase::RocksDB(store) => {
+                store.get_txn_state_version_by_identifier(identifier)
+            }
             StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
         }
     }
 }
 
-impl TransactionIndex<u64> for StateManagerDatabase {
-    fn get_payload_hash(&self, state_version: u64) -> Option<LedgerPayloadHash> {
+impl TransactionIndex<&UserPayloadHash> for StateManagerDatabase {
+    fn get_txn_state_version_by_identifier(&self, identifier: &UserPayloadHash) -> Option<u64> {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.get_payload_hash(state_version),
-            StateManagerDatabase::RocksDB(store) => store.get_payload_hash(state_version),
+                in_memory_store, ..
+            } => in_memory_store.get_txn_state_version_by_identifier(identifier),
+            StateManagerDatabase::RocksDB(store) => {
+                store.get_txn_state_version_by_identifier(identifier)
+            }
+            StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
+        }
+    }
+}
+
+impl TransactionIndex<&LedgerPayloadHash> for StateManagerDatabase {
+    fn get_txn_state_version_by_identifier(&self, identifier: &LedgerPayloadHash) -> Option<u64> {
+        match self {
+            StateManagerDatabase::InMemory {
+                in_memory_store, ..
+            } => in_memory_store.get_txn_state_version_by_identifier(identifier),
+            StateManagerDatabase::RocksDB(store) => {
+                store.get_txn_state_version_by_identifier(identifier)
+            }
             StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
         }
     }
@@ -332,21 +339,32 @@ impl QueryableProofStore for StateManagerDatabase {
     fn max_state_version(&self) -> u64 {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.max_state_version(),
+                in_memory_store, ..
+            } => in_memory_store.max_state_version(),
             StateManagerDatabase::RocksDB(store) => store.max_state_version(),
             StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
         }
     }
 
-    fn get_next_proof(&self, state_version: u64) -> Option<(Vec<LedgerPayloadHash>, Vec<u8>)> {
+    fn get_txns_and_proof(
+        &self,
+        start_state_version_inclusive: u64,
+        max_number_of_txns: u32,
+        max_payload_size_in_bytes: u32,
+    ) -> Option<(Vec<Vec<u8>>, Vec<u8>)> {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.get_next_proof(state_version),
-            StateManagerDatabase::RocksDB(store) => store.get_next_proof(state_version),
+                in_memory_store, ..
+            } => in_memory_store.get_txns_and_proof(
+                start_state_version_inclusive,
+                max_number_of_txns,
+                max_payload_size_in_bytes,
+            ),
+            StateManagerDatabase::RocksDB(store) => store.get_txns_and_proof(
+                start_state_version_inclusive,
+                max_number_of_txns,
+                max_payload_size_in_bytes,
+            ),
             StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
         }
     }
@@ -354,9 +372,8 @@ impl QueryableProofStore for StateManagerDatabase {
     fn get_epoch_proof(&self, epoch: u64) -> Option<Vec<u8>> {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.get_epoch_proof(epoch),
+                in_memory_store, ..
+            } => in_memory_store.get_epoch_proof(epoch),
             StateManagerDatabase::RocksDB(store) => store.get_epoch_proof(epoch),
             StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
         }
@@ -365,9 +382,8 @@ impl QueryableProofStore for StateManagerDatabase {
     fn get_last_proof(&self) -> Option<Vec<u8>> {
         match self {
             StateManagerDatabase::InMemory {
-                transactions_and_proofs,
-                ..
-            } => transactions_and_proofs.get_last_proof(),
+                in_memory_store, ..
+            } => in_memory_store.get_last_proof(),
             StateManagerDatabase::RocksDB(store) => store.get_last_proof(),
             StateManagerDatabase::None => panic!("Unexpected call to no state manager store"),
         }

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -63,12 +63,13 @@
  */
 
 use crate::types::UserPayloadHash;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 
 use crate::store::traits::*;
 use crate::{
-    CommittedTransactionIdentifiers, HasIntentHash, IntentHash, LedgerPayloadHash,
-    LedgerTransactionReceipt,
+    AccumulatorHash, CommittedTransactionIdentifiers, HasIntentHash, HasLedgerPayloadHash,
+    HasUserPayloadHash, IntentHash, LedgerPayloadHash, LedgerTransactionReceipt,
 };
 use radix_engine::ledger::{
     OutputValue, QueryableSubstateStore, ReadableSubstateStore, WriteableSubstateStore,
@@ -78,43 +79,64 @@ use radix_engine::types::{
     scrypto_decode, scrypto_encode, KeyValueStoreId, KeyValueStoreOffset, RENodeId, SubstateId,
     SubstateOffset,
 };
-use rocksdb::{Direction, IteratorMode, SingleThreaded, TransactionDB};
+use rocksdb::{
+    ColumnFamily, ColumnFamilyDescriptor, Direction, IteratorMode, Options, SingleThreaded,
+    TransactionDB, TransactionDBOptions,
+};
 use std::path::PathBuf;
+use tracing::error;
 
-#[macro_export]
-macro_rules! db_key {
-    ($table:expr, $slice:expr) => {{
-        let mut vec = vec![$table.prefix()];
-        vec.extend_from_slice($slice);
-        vec
-    }};
+use crate::transaction::LedgerTransaction;
+
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Debug)]
+enum RocksDBColumnFamily {
+    /// Committed transactions
+    TxnByStateVersion,
+    TxnReceiptByStateVersion,
+    TxnAccumulatorHashByStateVersion,
+    /// Transaction lookups
+    StateVersionByTxnIntentHash,
+    StateVersionByTxnUserPayloadHash,
+    StateVersionByTxnLedgerPayloadHash,
+    /// Ledger proofs
+    LedgerProofByStateVersion,
+    LedgerProofByEpoch,
+    /// Radix Engine state
+    Substates,
+    /// Vertex store
+    VertexStore,
 }
 
-enum RocksDBTable {
-    Transactions,
-    StateVersions,
-    Proofs,
-    EpochProofs,
+use RocksDBColumnFamily::*;
+
+const ALL_COLUMN_FAMILIES: [RocksDBColumnFamily; 10] = [
+    TxnByStateVersion,
+    TxnReceiptByStateVersion,
+    TxnAccumulatorHashByStateVersion,
+    StateVersionByTxnIntentHash,
+    StateVersionByTxnUserPayloadHash,
+    StateVersionByTxnLedgerPayloadHash,
+    LedgerProofByStateVersion,
+    LedgerProofByEpoch,
     Substates,
     VertexStore,
-    TransactionIntentLookup,
-    UserPayloadHashLookup,
-}
-use crate::transaction::LedgerTransaction;
-use RocksDBTable::*;
+];
 
-impl RocksDBTable {
-    fn prefix(&self) -> u8 {
-        match self {
-            Transactions => 0u8,
-            StateVersions => 1u8,
-            Proofs => 2u8,
-            EpochProofs => 3u8,
-            Substates => 4u8,
-            VertexStore => 5u8,
-            TransactionIntentLookup => 6u8,
-            UserPayloadHashLookup => 7u8,
-        }
+impl fmt::Display for RocksDBColumnFamily {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str = match self {
+            TxnByStateVersion => "txn_by_state_version",
+            TxnReceiptByStateVersion => "txn_receipt_by_state_version",
+            TxnAccumulatorHashByStateVersion => "txn_accumulator_hash_by_state_version",
+            StateVersionByTxnIntentHash => "state_version_by_txn_intent_hash",
+            StateVersionByTxnUserPayloadHash => "state_version_by_txn_user_payload_hash",
+            StateVersionByTxnLedgerPayloadHash => "state_version_by_txn_ledger_payload_hash",
+            LedgerProofByStateVersion => "ledger_proof_by_state_version",
+            LedgerProofByEpoch => "ledger_proof_by_epoch",
+            Substates => "substates",
+            VertexStore => "vertex_store",
+        };
+        write!(f, "{}", str)
     }
 }
 
@@ -122,22 +144,32 @@ pub struct RocksDBStore {
     db: TransactionDB<SingleThreaded>,
 }
 
-fn get_transaction_key(payload_hash: &LedgerPayloadHash) -> Vec<u8> {
-    db_key!(Transactions, payload_hash.as_ref())
-}
-
-fn get_user_transaction_payload_key(payload_hash: &UserPayloadHash) -> Vec<u8> {
-    db_key!(UserPayloadHashLookup, payload_hash.as_ref())
-}
-
-fn get_transaction_intent_key(intent_hash: &IntentHash) -> Vec<u8> {
-    db_key!(TransactionIntentLookup, intent_hash.as_ref())
-}
-
 impl RocksDBStore {
     pub fn new(root: PathBuf) -> RocksDBStore {
-        let db = TransactionDB::open_default(root.as_path()).unwrap();
+        let mut db_opts = Options::default();
+        db_opts.create_if_missing(true);
+        db_opts.create_missing_column_families(true);
+
+        let transactional_db_opts = TransactionDBOptions::default();
+
+        let column_families: Vec<ColumnFamilyDescriptor> = ALL_COLUMN_FAMILIES
+            .into_iter()
+            .map(|cf| ColumnFamilyDescriptor::new(cf.to_string(), Options::default()))
+            .collect();
+
+        let db = TransactionDB::open_cf_descriptors(
+            &db_opts,
+            &transactional_db_opts,
+            root.as_path(),
+            column_families,
+        )
+        .unwrap();
+
         RocksDBStore { db }
+    }
+
+    fn cf_handle(&self, cf: &RocksDBColumnFamily) -> &ColumnFamily {
+        self.db.cf_handle(&cf.to_string()).unwrap()
     }
 }
 
@@ -146,23 +178,20 @@ impl<'db> CommitStore<'db> for RocksDBStore {
 
     fn create_db_transaction(&'db mut self) -> RocksDBCommitTransaction<'db> {
         let db_txn = self.db.transaction();
-        RocksDBCommitTransaction { db_txn }
-    }
-}
-
-impl WriteableSubstateStore for RocksDBStore {
-    fn put_substate(&mut self, substate_id: SubstateId, substate: OutputValue) {
-        self.db
-            .put(
-                db_key!(Substates, &scrypto_encode(&substate_id).unwrap()),
-                scrypto_encode(&substate).unwrap(),
-            )
-            .expect("RockDB: put_substate unexpected error");
+        let column_families = ALL_COLUMN_FAMILIES
+            .iter()
+            .map(|cf| (cf.clone(), self.cf_handle(cf)))
+            .collect();
+        RocksDBCommitTransaction {
+            db_txn,
+            column_families,
+        }
     }
 }
 
 pub struct RocksDBCommitTransaction<'db> {
     db_txn: rocksdb::Transaction<'db, TransactionDB>,
+    column_families: BTreeMap<RocksDBColumnFamily, &'db ColumnFamily>,
 }
 
 impl<'db> RocksDBCommitTransaction<'db> {
@@ -172,55 +201,98 @@ impl<'db> RocksDBCommitTransaction<'db> {
         receipt: LedgerTransactionReceipt,
         identifiers: CommittedTransactionIdentifiers,
     ) {
+        let state_version = identifiers.state_version;
+
         // TEMPORARY until this is handled in the engine: we store both an intent lookup and the transaction itself
         if let LedgerTransaction::User(notarized_transaction) = &transaction {
-            let key = get_transaction_intent_key(&notarized_transaction.intent_hash());
-            let existing_intent_option = self
+            let existing_intent_hash_mapping_opt = self
                 .db_txn
-                .get_for_update(key, true)
+                .get_for_update_cf(
+                    self.cf_handle(&StateVersionByTxnIntentHash),
+                    notarized_transaction.intent_hash(),
+                    true,
+                )
                 .expect("RocksDB: failure to read intent hash");
-            if let Some(existing_intent_hash) = existing_intent_option {
+            if let Some(existing_intent_hash_mapping) = existing_intent_hash_mapping_opt {
                 panic!(
-                    "Attempted to save intent hash which already exists: {:?}",
-                    IntentHash::from_raw_bytes(existing_intent_hash.try_into().unwrap())
+                    "Attempted to save intent hash {:?} which already exists at state version {:?}",
+                    notarized_transaction.intent_hash(),
+                    u64::from_be_bytes(existing_intent_hash_mapping.try_into().unwrap())
                 );
             }
             self.db_txn
-                .put(
-                    get_transaction_intent_key(&notarized_transaction.intent_hash()),
-                    transaction.get_hash().as_ref(),
+                .put_cf(
+                    self.cf_handle(&StateVersionByTxnIntentHash),
+                    notarized_transaction.intent_hash(),
+                    state_version.to_be_bytes(),
                 )
                 .expect("RocksDB: failure to put intent hash");
+
+            self.db_txn
+                .put_cf(
+                    self.cf_handle(&StateVersionByTxnUserPayloadHash),
+                    notarized_transaction.user_payload_hash(),
+                    state_version.to_be_bytes(),
+                )
+                .expect("RocksDB: failure to put user payload hash");
         }
-        let transaction_key = get_transaction_key(&transaction.get_hash());
-        // TODO: We really need to re-work how we store this data!
-        // For now, panic if we have duplicate transactions to prevent incorrect receipt/identifiers being saved
-        // There shouldn't be any possibility of this happening at the moment, so better to panic if it does as
-        // it indicates a bug.
-        let transaction_already_exists = self
-            .db_txn
-            .get(transaction_key)
-            .expect("RocksDB: failure to check for transaction presence")
-            .is_some();
-        if transaction_already_exists {
-            panic!("Attempt to persist a duplicate transaction payload - which isn't supported at the moment in our database structure: {:?}", transaction)
-        }
+
         self.db_txn
-            .put(
-                get_transaction_key(&transaction.get_hash()),
-                scrypto_encode(&(transaction, receipt, identifiers)).unwrap(),
+            .put_cf(
+                self.cf_handle(&StateVersionByTxnLedgerPayloadHash),
+                transaction.ledger_payload_hash(),
+                state_version.to_be_bytes(),
+            )
+            .expect("RocksDB: failure to put ledger payload hash");
+
+        self.db_txn
+            .put_cf(
+                self.cf_handle(&TxnByStateVersion),
+                state_version.to_be_bytes(),
+                transaction.create_payload().unwrap(),
             )
             .expect("RocksDB: failure to put transaction");
+
+        self.db_txn
+            .put_cf(
+                self.cf_handle(&TxnReceiptByStateVersion),
+                state_version.to_be_bytes(),
+                scrypto_encode(&receipt).unwrap(),
+            )
+            .expect("RocksDB: failure to put transaction receipt");
+
+        self.db_txn
+            .put_cf(
+                self.cf_handle(&TxnAccumulatorHashByStateVersion),
+                state_version.to_be_bytes(),
+                identifiers.accumulator_hash.into_bytes(),
+            )
+            .expect("RocksDB: failure to put transaction accumulator hash");
+    }
+
+    fn max_state_version(&self) -> u64 {
+        self.db_txn
+            .iterator_cf(self.cf_handle(&TxnByStateVersion), IteratorMode::End)
+            .next()
+            .map(|res| res.unwrap())
+            .map(|(key, _)| u64::from_be_bytes((*key).try_into().unwrap()))
+            .unwrap_or(0)
+    }
+
+    fn cf_handle(&self, cf: &RocksDBColumnFamily) -> &ColumnFamily {
+        self.column_families.get(cf).unwrap()
     }
 }
 
 impl<'db> ReadableSubstateStore for RocksDBCommitTransaction<'db> {
     fn get_substate(&self, substate_id: &SubstateId) -> Option<OutputValue> {
-        // TODO: Use get_pinned
         self.db_txn
-            .get(db_key!(Substates, &scrypto_encode(substate_id).unwrap()))
+            .get_pinned_cf(
+                self.cf_handle(&Substates),
+                &scrypto_encode(substate_id).unwrap(),
+            )
             .unwrap()
-            .map(|b| scrypto_decode(&b).unwrap())
+            .map(|pinnable_slice| scrypto_decode(pinnable_slice.as_ref()).unwrap())
     }
 }
 
@@ -233,6 +305,13 @@ impl<'db> WriteableTransactionStore for RocksDBCommitTransaction<'db> {
             CommittedTransactionIdentifiers,
         )>,
     ) {
+        let first_txn_state_version = transactions.get(0).unwrap().2.state_version;
+        let max_state_version_in_db = self.max_state_version();
+        if first_txn_state_version != max_state_version_in_db + 1 {
+            panic!("Attempted to commit a txn batch that starts with state version {} but the latest state version in DB is {}",
+                first_txn_state_version, max_state_version_in_db);
+        }
+
         for (txn, receipt, identifiers) in transactions {
             self.insert_transaction(txn, receipt, identifiers);
         }
@@ -240,32 +319,34 @@ impl<'db> WriteableTransactionStore for RocksDBCommitTransaction<'db> {
 }
 
 impl<'db> WriteableProofStore for RocksDBCommitTransaction<'db> {
-    fn insert_tids_and_proof(
+    fn insert_proof(
         &mut self,
         state_version: u64,
         epoch_boundary: Option<u64>,
-        ids: Vec<LedgerPayloadHash>,
         proof_bytes: Vec<u8>,
     ) {
-        self.insert_tids_without_proof(state_version, ids);
+        // This is a little "hack" to avoid decoding the whole proof (which isn't even SBOR)
+        // yet still be able to tell if a proof is an epoch change while providing sync responses.
+        // See: get_txns_and_proof
+        let encoded_proof = scrypto_encode(&(epoch_boundary, &proof_bytes)).unwrap();
 
-        let proof_version_key = db_key!(Proofs, &state_version.to_be_bytes());
-        self.db_txn.put(proof_version_key, &proof_bytes).unwrap();
+        self.db_txn
+            .put_cf(
+                self.cf_handle(&LedgerProofByStateVersion),
+                state_version.to_be_bytes(),
+                &encoded_proof,
+            )
+            .unwrap();
 
         if let Some(epoch_boundary) = epoch_boundary {
-            let epoch_proof_key = db_key!(EpochProofs, &epoch_boundary.to_be_bytes());
-            self.db_txn.put(epoch_proof_key, &proof_bytes).unwrap();
-        }
-    }
-
-    fn insert_tids_without_proof(&mut self, state_version: u64, ids: Vec<LedgerPayloadHash>) {
-        if !ids.is_empty() {
-            let first_state_version = state_version - u64::try_from(ids.len() - 1).unwrap();
-            for (index, payload_hash) in ids.into_iter().enumerate() {
-                let txn_state_version = first_state_version + index as u64;
-                let version_key = db_key!(StateVersions, &txn_state_version.to_be_bytes());
-                self.db_txn.put(version_key, payload_hash.as_ref()).unwrap();
-            }
+            // Note that the LedgerProofByEpoch value is just raw proof bytes, without the extra tuple wrapper and SBOR.
+            self.db_txn
+                .put_cf(
+                    self.cf_handle(&LedgerProofByEpoch),
+                    epoch_boundary.to_be_bytes(),
+                    &proof_bytes,
+                )
+                .unwrap();
         }
     }
 }
@@ -273,19 +354,12 @@ impl<'db> WriteableProofStore for RocksDBCommitTransaction<'db> {
 impl<'db> WriteableSubstateStore for RocksDBCommitTransaction<'db> {
     fn put_substate(&mut self, substate_id: SubstateId, substate: OutputValue) {
         self.db_txn
-            .put(
-                db_key!(Substates, &scrypto_encode(&substate_id).unwrap()),
+            .put_cf(
+                self.cf_handle(&Substates),
+                &scrypto_encode(&substate_id).unwrap(),
                 scrypto_encode(&substate).unwrap(),
             )
             .expect("RocksDB: put_substate unexpected error");
-    }
-}
-
-impl<'db> WriteableVertexStore for RocksDBCommitTransaction<'db> {
-    fn save_vertex_store(&mut self, vertex_store_bytes: Vec<u8>) {
-        self.db_txn
-            .put(db_key!(VertexStore, &[]), vertex_store_bytes)
-            .unwrap();
     }
 }
 
@@ -299,136 +373,225 @@ impl<'db> CommitStoreTransaction<'db> for RocksDBCommitTransaction<'db> {
 
 impl ReadableSubstateStore for RocksDBStore {
     fn get_substate(&self, substate_id: &SubstateId) -> Option<OutputValue> {
-        // TODO: Use get_pinned
         self.db
-            .get(db_key!(Substates, &scrypto_encode(substate_id).unwrap()))
+            .get_pinned_cf(
+                self.cf_handle(&Substates),
+                &scrypto_encode(substate_id).unwrap(),
+            )
             .unwrap()
-            .map(|b| scrypto_decode(&b).unwrap())
+            .map(|pinnable_slice| scrypto_decode(pinnable_slice.as_ref()).unwrap())
     }
 }
 
 impl QueryableTransactionStore for RocksDBStore {
-    fn get_committed_transaction(
-        &self,
-        payload_hash: &LedgerPayloadHash,
-    ) -> Option<(
-        LedgerTransaction,
-        LedgerTransactionReceipt,
-        CommittedTransactionIdentifiers,
-    )> {
-        let entry = self
-            .db
-            .get(get_transaction_key(payload_hash))
-            .expect("DB error loading transaction")?;
-        let decoded = scrypto_decode(&entry).expect("Transaction wasn't encoded as expected");
-        Some(decoded)
+    fn get_committed_transaction(&self, state_version: u64) -> Option<LedgerTransaction> {
+        self.db
+            .get_cf(
+                self.cf_handle(&TxnByStateVersion),
+                state_version.to_be_bytes(),
+            )
+            .expect("DB error loading transaction")
+            .map(|v| scrypto_decode(&v).expect("Failed to decode a committed transaction"))
     }
-}
 
-impl TransactionIndex<&UserPayloadHash> for RocksDBStore {
-    fn get_payload_hash(&self, identifier: &UserPayloadHash) -> Option<LedgerPayloadHash> {
-        let payload_hash_entry = self
-            .db
-            .get(get_user_transaction_payload_key(identifier))
-            .expect("DB error loading payload hash")?;
-        let hash = LedgerPayloadHash::from_raw_bytes(
-            payload_hash_entry
-                .try_into()
-                .expect("Saved payload hash is wrong length"),
-        );
-        Some(hash)
+    fn get_committed_transaction_receipt(
+        &self,
+        state_version: u64,
+    ) -> Option<LedgerTransactionReceipt> {
+        self.db
+            .get_cf(
+                self.cf_handle(&TxnReceiptByStateVersion),
+                state_version.to_be_bytes(),
+            )
+            .expect("DB error loading transaction")
+            .map(|v| scrypto_decode(&v).expect("Failed to decode a committed transaction receipt"))
+    }
+
+    fn get_committed_transaction_identifiers(
+        &self,
+        state_version: u64,
+    ) -> Option<CommittedTransactionIdentifiers> {
+        self.db
+            .get_cf(
+                self.cf_handle(&TxnAccumulatorHashByStateVersion),
+                state_version.to_be_bytes(),
+            )
+            .expect("DB error loading transaction")
+            .map(|v| CommittedTransactionIdentifiers {
+                state_version,
+                accumulator_hash: AccumulatorHash::from_raw_bytes(
+                    v.try_into()
+                        .expect("Failed to decode a committed transaction accumulator hash"),
+                ),
+            })
     }
 }
 
 impl TransactionIndex<&IntentHash> for RocksDBStore {
-    fn get_payload_hash(&self, identifier: &IntentHash) -> Option<LedgerPayloadHash> {
-        let payload_hash_entry = self
-            .db
-            .get(get_transaction_intent_key(identifier))
-            .expect("DB error loading payload hash")?;
-        let hash = LedgerPayloadHash::from_raw_bytes(
-            payload_hash_entry
-                .try_into()
-                .expect("Saved payload hash is wrong length"),
-        );
-        Some(hash)
+    fn get_txn_state_version_by_identifier(&self, identifier: &IntentHash) -> Option<u64> {
+        self.db
+            .get_cf(self.cf_handle(&StateVersionByTxnIntentHash), identifier)
+            .expect("DB error reading state version for intent hash")
+            .map(|b| u64::from_be_bytes(b.try_into().unwrap()))
     }
 }
 
-impl TransactionIndex<u64> for RocksDBStore {
-    fn get_payload_hash(&self, state_version: u64) -> Option<LedgerPayloadHash> {
-        let state_version_entry = self
-            .db
-            .get(db_key!(StateVersions, &state_version.to_be_bytes()))
-            .expect("DB error loading state version")?;
-        let hash = LedgerPayloadHash::from_raw_bytes(
-            state_version_entry
-                .try_into()
-                .expect("Saved payload hash is wrong length"),
-        );
-        Some(hash)
+impl TransactionIndex<&UserPayloadHash> for RocksDBStore {
+    fn get_txn_state_version_by_identifier(&self, identifier: &UserPayloadHash) -> Option<u64> {
+        self.db
+            .get_cf(
+                self.cf_handle(&StateVersionByTxnUserPayloadHash),
+                identifier,
+            )
+            .expect("DB error reading state version for user payload hash")
+            .map(|b| u64::from_be_bytes(b.try_into().unwrap()))
+    }
+}
+
+impl TransactionIndex<&LedgerPayloadHash> for RocksDBStore {
+    fn get_txn_state_version_by_identifier(&self, identifier: &LedgerPayloadHash) -> Option<u64> {
+        self.db
+            .get_cf(
+                self.cf_handle(&StateVersionByTxnLedgerPayloadHash),
+                identifier,
+            )
+            .expect("DB error reading state version for ledger payload hash")
+            .map(|b| u64::from_be_bytes(b.try_into().unwrap()))
     }
 }
 
 impl QueryableProofStore for RocksDBStore {
     fn max_state_version(&self) -> u64 {
         self.db
-            .iterator(IteratorMode::From(
-                &[StateVersions.prefix() + 1],
-                Direction::Reverse,
-            ))
+            .iterator_cf(self.cf_handle(&TxnByStateVersion), IteratorMode::End)
             .next()
             .map(|res| res.unwrap())
-            .filter(|(key, _)| key[0] == StateVersions.prefix())
-            .map(|(key, _)| {
-                let (_, state_version_bytes) = key.split_first().unwrap();
-                u64::from_be_bytes(state_version_bytes.try_into().unwrap())
-            })
+            .map(|(key, _)| u64::from_be_bytes((*key).try_into().unwrap()))
             .unwrap_or(0)
     }
 
-    fn get_next_proof(&self, state_version: u64) -> Option<(Vec<LedgerPayloadHash>, Vec<u8>)> {
-        let first_state_version = state_version + 1;
-        let proof_version_key = db_key!(Proofs, &first_state_version.to_be_bytes());
-        let (next_state_version, proof) = self
-            .db
-            .iterator(IteratorMode::From(&proof_version_key, Direction::Forward))
-            .next()
-            .map(|res| res.unwrap())
-            .filter(|(key, _)| key[0] == Proofs.prefix())
-            .map(|(key, proof)| {
-                let (_, state_version_bytes) = key.split_first().unwrap();
-                let next_state_version =
-                    u64::from_be_bytes(state_version_bytes.try_into().unwrap());
-                (next_state_version, proof.to_vec())
-            })?;
+    fn get_txns_and_proof(
+        &self,
+        start_state_version_inclusive: u64,
+        max_number_of_txns: u32,
+        max_payload_size_in_bytes: u32,
+    ) -> Option<(Vec<Vec<u8>>, Vec<u8>)> {
+        let mut payload_size_so_far = 0;
+        let mut latest_usable_proof: Option<Vec<u8>> = None;
+        let mut txns = Vec::new();
 
-        let mut tids = Vec::new();
-        for v in first_state_version..=next_state_version {
-            let txn_version_key = db_key!(StateVersions, &v.to_be_bytes());
-            let bytes = self.db.get(txn_version_key).unwrap().unwrap();
-            tids.push(LedgerPayloadHash::from_raw_bytes(
-                bytes.try_into().expect("Payload hash is the wrong length"),
-            ));
+        let mut proofs_iter = self.db.iterator_cf(
+            self.cf_handle(&LedgerProofByStateVersion),
+            IteratorMode::From(
+                &start_state_version_inclusive.to_be_bytes(),
+                Direction::Forward,
+            ),
+        );
+
+        let mut txns_iter = self.db.iterator_cf(
+            self.cf_handle(&TxnByStateVersion),
+            IteratorMode::From(
+                &start_state_version_inclusive.to_be_bytes(),
+                Direction::Forward,
+            ),
+        );
+
+        'proof_loop: while payload_size_so_far <= max_payload_size_in_bytes
+            && txns.len() <= (max_number_of_txns as usize)
+        {
+            // Fetch next proof and see if all txns it includes can fit
+            // If they do - add them to the output and update the latest usable proof then continue the iteration
+            // If they don't - (sadly) ignore this proof's txns read so far and break the loop
+            // If we're out of proofs (or some txns are missing): also break the loop
+            match proofs_iter.next() {
+                Some(next_proof_result) => {
+                    let next_proof_kv = next_proof_result.unwrap();
+                    let next_proof_state_version =
+                        u64::from_be_bytes((*next_proof_kv.0).try_into().unwrap());
+                    let (next_proof_epoch_opt, next_proof_bytes): (Option<u64>, Vec<u8>) =
+                        scrypto_decode(next_proof_kv.1.as_ref()).unwrap();
+
+                    let mut payload_size_including_next_proof_txns = payload_size_so_far;
+                    let mut next_proof_txns = Vec::new();
+
+                    'proof_txns_loop: while payload_size_including_next_proof_txns
+                        <= max_payload_size_in_bytes
+                        && txns.len() + next_proof_txns.len() <= (max_number_of_txns as usize)
+                    {
+                        match txns_iter.next() {
+                            Some(next_txn_result) => {
+                                let next_txn_kv = next_txn_result.unwrap();
+                                let next_txn_state_version =
+                                    u64::from_be_bytes((*next_txn_kv.0).try_into().unwrap());
+                                let next_txn_payload = next_txn_kv.1.to_vec();
+
+                                payload_size_including_next_proof_txns +=
+                                    next_txn_payload.len() as u32;
+                                next_proof_txns.push(next_txn_payload);
+
+                                if next_txn_state_version == next_proof_state_version {
+                                    // We've reached the last txn under next_proof
+                                    break 'proof_txns_loop;
+                                }
+                            }
+                            None => {
+                                // A txn must be missing! Log an error as this indicates DB corruption
+                                error!("The DB is missing transactions! There is a proof at state version {} but only got {} txns (starting from state version {} inclusive)",
+                                    next_proof_state_version, (txns.len() + next_proof_txns.len()), start_state_version_inclusive);
+                                // We can still serve a response (return whatever txns/proof we've collected so far)
+                                break 'proof_loop;
+                            }
+                        }
+                    }
+
+                    // All txns under next_proof have been processed, once again confirm
+                    // that they can all fit in the response (the last txn could have crossed the limit)
+                    if payload_size_including_next_proof_txns <= max_payload_size_in_bytes
+                        && txns.len() + next_proof_txns.len() <= (max_number_of_txns as usize)
+                    {
+                        // Yup, all good, use next_proof as the result and add its txns
+                        latest_usable_proof = Some(next_proof_bytes);
+                        txns.append(&mut next_proof_txns);
+                        payload_size_so_far = payload_size_including_next_proof_txns;
+
+                        if next_proof_epoch_opt.is_some() {
+                            // Stop if we've reached an epoch proof
+                            break 'proof_loop;
+                        }
+                    } else {
+                        // We couldn't fit next proof's txns so there's no point in further iteration
+                        break 'proof_loop;
+                    }
+                }
+                None => {
+                    // No more proofs
+                    break 'proof_loop;
+                }
+            }
         }
-        Some((tids, proof))
+
+        latest_usable_proof.map(|proof| (txns, proof))
     }
 
     fn get_epoch_proof(&self, epoch: u64) -> Option<Vec<u8>> {
-        let epoch_proof_key = db_key!(EpochProofs, &epoch.to_be_bytes());
-        self.db.get(epoch_proof_key).unwrap()
+        self.db
+            .get_cf(self.cf_handle(&LedgerProofByEpoch), epoch.to_be_bytes())
+            .unwrap()
     }
 
     fn get_last_proof(&self) -> Option<Vec<u8>> {
         self.db
-            .iterator(IteratorMode::From(
-                &[Proofs.prefix() + 1],
-                Direction::Reverse,
-            ))
+            .iterator_cf(
+                self.cf_handle(&LedgerProofByStateVersion),
+                IteratorMode::End,
+            )
             .map(|res| res.unwrap())
             .next()
-            .filter(|(key, _)| key[0] == 2u8)
-            .map(|(_, proof)| proof.to_vec())
+            .map(|(_, proof)| {
+                // A proof is a tuple of (epoch_change, proof_bytes), see: insert_proof
+                let decoded_tuple: (Option<u64>, Vec<u8>) = scrypto_decode(proof.as_ref()).unwrap();
+                decoded_tuple.1
+            })
     }
 }
 
@@ -443,20 +606,15 @@ impl QueryableSubstateStore for RocksDBStore {
         ))
         .unwrap();
 
-        let iter = self.db.iterator(IteratorMode::From(
-            &db_key!(Substates, &id),
-            Direction::Forward,
-        ));
+        let iter = self.db.iterator_cf(
+            self.cf_handle(&Substates),
+            IteratorMode::From(&id, Direction::Forward),
+        );
         let mut items = HashMap::new();
         for res in iter {
             let (key, value) = res.unwrap();
-            let (prefix, key) = key.split_first().unwrap();
-            if *prefix != Substates.prefix() {
-                break;
-            }
-
             let substate: OutputValue = scrypto_decode(&value).unwrap();
-            let substate_id: SubstateId = scrypto_decode(key).unwrap();
+            let substate_id: SubstateId = scrypto_decode(&key).unwrap();
             if let SubstateId(
                 RENodeId::KeyValueStore(id),
                 SubstateOffset::KeyValueStore(KeyValueStoreOffset::Entry(key)),
@@ -475,8 +633,16 @@ impl QueryableSubstateStore for RocksDBStore {
     }
 }
 
+impl<'db> WriteableVertexStore for RocksDBCommitTransaction<'db> {
+    fn save_vertex_store(&mut self, vertex_store_bytes: Vec<u8>) {
+        self.db_txn
+            .put_cf(self.cf_handle(&VertexStore), [], vertex_store_bytes)
+            .unwrap();
+    }
+}
+
 impl RecoverableVertexStore for RocksDBStore {
     fn get_vertex_store(&self) -> Option<Vec<u8>> {
-        self.db.get(db_key!(VertexStore, &[])).unwrap()
+        self.db.get_cf(self.cf_handle(&VertexStore), []).unwrap()
     }
 }


### PR DESCRIPTION
Some notable changes:
* using RocksDB column families instead of custom prefixes
* txns are now primarily indexed by state version, not a hash
* txns, receipts and identifiers (accumulator hash) are stored separately: not a particularly strong opinion for this one, but I think it's worth it (to be able to serve sync responses without the need to scrypto_decode each individual transaction)