### PR TITLE
build: small build speedups

### DIFF
--- a/docker/rust-builder/Dockerfile
+++ b/docker/rust-builder/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update; apt-get upgrade -y && \
   pkg-config
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh; sh rustup.sh -y --target aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
+RUN $HOME/.cargo/bin/cargo install sccache
 
 # This mapped-volume-build is used in development, via the build-sm.yaml docker compose.
 # By using mounts, this allows artifact caching. The whole core-rust directory is mounted, and run is called.
@@ -21,6 +22,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh; sh r
 FROM base as mapped-volume-build
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+ENV RUSTC_WRAPPER=/root/.cargo/bin/sccache
 
 CMD $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
 
@@ -30,9 +32,9 @@ FROM base as cache-packages
 ARG TARGET
 ARG RUST_PROFILE
 
-ENV PATH="$HOME/.cargo/bin:$PATH"
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+ENV RUSTC_WRAPPER=/root/.cargo/bin/sccache
 
 # First - we build a dummy rust file, to cache the compilation of all our dependencies in a Docker layer
 RUN USER=root $HOME/.cargo/bin/cargo new dummy
@@ -54,6 +56,11 @@ RUN $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
 RUN rm -rf /app/dummy/*
 
 FROM cache-packages as prod-build
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+ENV RUSTC_WRAPPER=/root/.cargo/bin/sccache
+
 WORKDIR /app
 # Now - we copy in everything, and do the actual build
 COPY core-rust ./

--- a/docker/rust-builder/Dockerfile
+++ b/docker/rust-builder/Dockerfile
@@ -65,7 +65,7 @@ WORKDIR /app
 RUN rm -rf state-manager core-rust core-api-server
 COPY core-rust ./
 
-RUN $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
+RUN find . -name '*.rs' | xargs touch; $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
 RUN cp -R target/$TARGET/release/libcorerust.so /
 RUN rm -rf /app
 

--- a/docker/rust-builder/Dockerfile
+++ b/docker/rust-builder/Dockerfile
@@ -29,6 +29,7 @@ CMD $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
 # On CI we use docker build instead of docker compose.
 # The mapped-volume-build stage is skipped, and the following stages are run, with sub-stages cached for future runs.
 FROM base as cache-packages
+WORKDIR /app
 ARG TARGET
 ARG RUST_PROFILE
 
@@ -37,23 +38,20 @@ ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
 ENV RUSTC_WRAPPER=/root/.cargo/bin/sccache
 
 # First - we build a dummy rust file, to cache the compilation of all our dependencies in a Docker layer
-RUN USER=root $HOME/.cargo/bin/cargo new dummy
-RUN USER=root mkdir -p ./dummy/state-manager/src
-RUN USER=root mkdir -p ./dummy/core-rust/src
-RUN USER=root mkdir -p ./dummy/core-api-server/src
-RUN USER=root touch ./dummy/state-manager/src/lib.rs
-RUN USER=root touch ./dummy/core-rust/src/lib.rs
-RUN USER=root touch ./dummy/core-api-server/src/lib.rs
-COPY core-rust/Cargo.toml ./dummy
-COPY core-rust/Cargo.lock ./dummy
-COPY core-rust/core-rust/Cargo.toml ./dummy/core-rust
-COPY core-rust/state-manager/Cargo.toml ./dummy/state-manager
-COPY core-rust/core-api-server/Cargo.toml ./dummy/core-api-server
+RUN USER=root $HOME/.cargo/bin/cargo init --lib --name dummy --vcs none .
+RUN USER=root mkdir -p ./state-manager/src
+RUN USER=root mkdir -p ./core-rust/src
+RUN USER=root mkdir -p ./core-api-server/src
+RUN USER=root touch ./state-manager/src/lib.rs
+RUN USER=root touch ./core-rust/src/lib.rs
+RUN USER=root touch ./core-api-server/src/lib.rs
+COPY core-rust/Cargo.toml ./
+COPY core-rust/Cargo.lock ./
+COPY core-rust/core-rust/Cargo.toml ./core-rust
+COPY core-rust/state-manager/Cargo.toml ./state-manager
+COPY core-rust/core-api-server/Cargo.toml ./core-api-server
 
-RUN mv ./dummy/src/main.rs ./dummy/src/lib.rs
-WORKDIR /app/dummy
 RUN $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE
-RUN rm -rf /app/dummy/*
 
 FROM cache-packages as prod-build
 
@@ -63,6 +61,8 @@ ENV RUSTC_WRAPPER=/root/.cargo/bin/sccache
 
 WORKDIR /app
 # Now - we copy in everything, and do the actual build
+
+RUN rm -rf state-manager core-rust core-api-server
 COPY core-rust ./
 
 RUN $HOME/.cargo/bin/cargo build --target=$TARGET --profile=$RUST_PROFILE


### PR DESCRIPTION
This commit introduces `sccache` to the base builder image, hopefully
producing cheap cache hits on a `rustc` level.