### PR TITLE
Replace non word characters in node name when creating database directory

### DIFF
--- a/core/src/main/java/com/radixdlt/rev2/modules/BerkeleySafetyStoreModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/BerkeleySafetyStoreModule.java
@@ -98,6 +98,6 @@ public class BerkeleySafetyStoreModule extends AbstractModule {
   @Provides
   @DatabaseLocation
   private String databaseLocation(@Self BFTValidatorId node) {
-    return rootPath + "/" + node;
+    return rootPath + "/" + node.toString().replaceAll("\\W+", "_");
   }
 }


### PR DESCRIPTION
Replaced all non word characters with `_`. 

Unfortunately `:` character is not allowed as filename on windows. 

Observed exception when trying to create database file with `:` in it
`1) [Guice/ErrorInjectingConstructor]: EnvironmentFailureException: (JE 18.3.12) IOException: The filename, directory name, or volume label syntax is incorrect UNEXPECTED_EXCEPTION: Unexpected internal Exception, may have side effects.
  at DatabaseEnvironment.<init>(DatabaseEnvironment.java:94)
  at BerkeleySafetyStoreModule.configure(BerkeleySafetyStoreModule.java:91)
      \_ installed by: RadixNodeModule -> BerkeleySafetyStoreModule
  at BerkeleyAddressBookStore.<init>(BerkeleyAddressBookStore.java:94)
      \_ for 2nd parameter
  while locating BerkeleyAddressBookStore
  at P2PModule.configure(P2PModule.java:111)
      \_ installed by: RadixNodeModule -> P2PModule
  at AddressBook.<init>(AddressBook.java:155)
      \_ for 4th parameter
  at P2PModule.configure(P2PModule.java:107)
      \_ installed by: RadixNodeModule -> P2PModule
  at AddressBookPeerControl.<init>(AddressBookPeerControl.java:81)
      \_ for 1st parameter
  while locating AddressBookPeerControl
  at P2PModule.configure(P2PModule.java:109)
      \_ installed by: RadixNodeModule -> P2PModule
  at SyncServiceModule.invalidSyncResponseHandler(SyncServiceModule.java:100)
      \_ for 2nd parameter
  at SyncServiceModule.invalidSyncResponseHandler(SyncServiceModule.java:100)
      \_ installed by: RadixNodeModule -> SyncServiceModule
  at LocalSyncService.<init>(LocalSyncService.java:160)
      \_ for 14th parameter
  at SyncServiceModule.configure(SyncServiceModule.java:107)
      \_ installed by: RadixNodeModule -> SyncServiceModule
  at RemoteSyncService.<init>(RemoteSyncService.java:114)
      \_ for 2nd parameter
  at SyncServiceModule.configure(SyncServiceModule.java:108)
      \_ installed by: RadixNodeModule -> SyncServiceModule
  at SyncServiceModule.ledgerUpdateEventProcessor(SyncServiceModule.java:100)
      \_ for 1st parameter
  at SyncServiceModule.ledgerUpdateEventProcessor(SyncServiceModule.java:100)
      \_ installed by: RadixNodeModule -> SyncServiceModule
  while locating EventProcessorOnRunner<?> annotated with @Element(setName=,uniqueId=32, type=MULTIBINDER, keyType=)
  at RxEnvironmentModule.consensusRunner(RxEnvironmentModule.java:141)
      \_ for 2nd parameter
  at RxEnvironmentModule.consensusRunner(RxEnvironmentModule.java:141)
      \_ installed by: RadixNodeModule -> RxEnvironmentModule
  while locating ModuleRunner annotated with @Element(setName=,uniqueId=2, type=MAPBINDER, keyType=String)
  while locating Map<String, ModuleRunner>`