### PR TITLE
Update release profile settings for best wasmi performance

### DIFF
--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -7,3 +7,9 @@ members = [
 
 [profile.dev]
 opt-level = 3
+
+# Recommended settings for wasmi for best performance
+#  see: https://github.com/paritytech/wasmi/blob/master/CHANGELOG.md#0140---2022-07-26
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION

## Description

In relation to the `wasmi` upgrade to `0.23.0` (see https://github.com/radixdlt/radixdlt-scrypto/pull/762) we need to adjust release profile settings for best `wasmi` performance (see [wasmi-0.14.0 changelog](https://github.com/paritytech/wasmi/blob/master/CHANGELOG.md#0140---2022-07-26))

## Labels
* enhancement
