### PR TITLE
Refactoring: Generic staging tree

### DIFF
--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -185,19 +185,21 @@ pub struct ImmutableStore {
     outputs: ImmutableHashMap<SubstateId, OutputValue>,
 }
 
-impl Default for ImmutableStore {
-    fn default() -> Self {
+impl Accumulator<TransactionReceipt> for ImmutableStore {
+    fn create_empty() -> Self {
         Self {
             outputs: ImmutableHashMap::new(),
         }
     }
-}
 
-impl Accumulator<TransactionReceipt> for ImmutableStore {
     fn accumulate(&mut self, delta: &TransactionReceipt) {
         if let TransactionResult::Commit(commit) = &delta.result {
             commit.state_updates.commit(self);
         }
+    }
+
+    fn constant_clone(&self) -> Self {
+        self.clone()
     }
 }
 

--- a/core-rust/state-manager/src/staging/stage_tree.rs
+++ b/core-rust/state-manager/src/staging/stage_tree.rs
@@ -62,206 +62,140 @@
  * permissions under this License.
  */
 
-use radix_engine::transaction::TransactionReceipt;
 use radix_engine::types::*;
-use radix_engine::{ledger::*, transaction::TransactionResult};
 
-use im::hashmap::HashMap as ImmutableHashMap;
 use sbor::rust::vec::Vec;
 use slotmap::{new_key_type, SlotMap};
 
-/// An immutable/persistent store (i.e a store built from a [`parent`] store
-/// shares data with it). Note: while from the abstract representation point
-/// of view you can delete keys, the underlying data is freed only and only
-/// if there are no references to it (there are no paths from any root reference
-/// to the node representing that (key, value)). For this reason, extra steps
-/// are taken to free up (key, value) pairs accumulating over time.
-/// This is intended as an wrapper/abstraction layer, so that changes to the
-/// ReadableSubstateStore/WriteableSubstateStore traits are easier to maintain.
-#[derive(Clone)]
-struct ImmutableStore {
-    outputs: ImmutableHashMap<SubstateId, OutputValue>,
-}
-
-impl ImmutableStore {
-    fn new() -> Self {
-        ImmutableStore {
-            outputs: ImmutableHashMap::new(),
-        }
-    }
-
-    fn from_parent(parent: &ImmutableStore) -> Self {
-        ImmutableStore {
-            // Note: this clone is O(1), only the root node is actually cloned
-            // Check im::collections::HashMap for details
-            outputs: parent.outputs.clone(),
-        }
-    }
-}
-
-impl WriteableSubstateStore for ImmutableStore {
-    fn put_substate(&mut self, substate_id: SubstateId, output: OutputValue) {
-        self.outputs.insert(substate_id, output);
-    }
-}
-
-impl ReadableSubstateStore for ImmutableStore {
-    fn get_substate(&self, substate_id: &SubstateId) -> Option<OutputValue> {
-        self.outputs.get(substate_id).cloned()
-    }
-}
-
 new_key_type! {
-    pub struct StagedSubstateStoreNodeKey;
+    /// A key to a derived stage.
+    /// "Derived" here means "obtained by applying deltas to the root stage".
+    pub struct DerivedStageKey;
 }
 
-/// Because the root store (which eventually is saved on disk) is not an
-/// StagedSubstateStoreNode/ImmutableStore we need to be able to
-/// distinguish it.
+/// A key to a (root or derived) stage.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum StagedSubstateStoreKey {
-    RootStoreKey,
-    InternalNodeStoreKey(StagedSubstateStoreNodeKey),
+pub enum StageKey {
+    Root,
+    Derived(DerivedStageKey),
 }
 
-/// [`children_keys`] are needed in order to traverse the tree.
-/// [`receipt`] applied to the parent's store, results in this node store.
-/// We need to keep the [`receipt`] to both recompute the stores when doing
+/// A change to the accumulated state.
+pub trait Delta {
+    fn weight(&self) -> usize;
+}
+
+/// An accumulated state coming from multiple [`Delta`]s.
+pub trait Accumulator<D: Delta>: Default + Clone {
+    fn accumulate(&mut self, delta: &D);
+}
+
+/// The [`children_keys`] are needed in order to traverse the tree.
+/// The [`delta`] applied to the parent's [`accumulator`] results in this node's [`accumulator`].
+/// We need to keep the [`delta`] to both recompute the stores when doing
 /// the data reconstruction/"garbage collection" but also to retrieve it
-/// when caching.
-pub struct StagedSubstateStoreNode {
-    children_keys: Vec<StagedSubstateStoreNodeKey>,
-    receipt: TransactionReceipt,
-    store: ImmutableStore,
+/// when committing.
+pub struct DerivedStageNode<D: Delta, A: Accumulator<D>> {
+    child_keys: Vec<DerivedStageKey>,
+    delta: D,
+    accumulator: A,
 }
 
-impl StagedSubstateStoreNode {
-    fn new(receipt: TransactionReceipt, mut store: ImmutableStore) -> Self {
-        if let TransactionResult::Commit(commit) = &receipt.result {
-            commit.state_updates.commit(&mut store);
-        }
-        StagedSubstateStoreNode {
-            children_keys: Vec::new(),
-            receipt,
-            store,
-        }
-    }
-
-    /// Weight is defined as the number of changes to the ImmutableStore
-    /// done exclusively by this node.
-    fn weight(&self) -> usize {
-        match &self.receipt.result {
-            // NOTE for future Substate delete support: add down_substates.len()
-            // to the weight as well.
-            TransactionResult::Commit(commit) => commit.state_updates.up_substates.len(),
-            TransactionResult::Reject(_) => 0,
-            TransactionResult::Abort(_) => 0,
+impl<D: Delta, A: Accumulator<D>> DerivedStageNode<D, A> {
+    fn new(delta: D, accumulator: A) -> Self {
+        DerivedStageNode {
+            child_keys: Vec::new(),
+            delta,
+            accumulator,
         }
     }
 }
 
-/// Structure which manages the staged store tree
-pub struct StagedSubstateStoreManager<S: ReadableSubstateStore> {
-    pub root: S,
-    nodes: SlotMap<StagedSubstateStoreNodeKey, StagedSubstateStoreNode>,
-    children_keys: Vec<StagedSubstateStoreNodeKey>,
+/// Stage tree (a manager of the staging nodes).
+pub struct StageTree<D: Delta, A: Accumulator<D>> {
+    empty_accumulator: A,
+    nodes: SlotMap<DerivedStageKey, DerivedStageNode<D, A>>,
+    child_keys: Vec<DerivedStageKey>,
     dead_weight: usize,
     total_weight: usize,
 }
 
-impl<S: ReadableSubstateStore> StagedSubstateStoreManager<S> {
-    pub fn new(root: S) -> Self {
-        StagedSubstateStoreManager {
-            root,
+impl<D: Delta, A: Accumulator<D>> StageTree<D, A> {
+    pub fn new() -> Self {
+        StageTree {
+            empty_accumulator: A::default(),
             nodes: SlotMap::with_capacity_and_key(1000),
-            children_keys: Vec::new(),
+            child_keys: Vec::new(),
             dead_weight: 0,
             total_weight: 0,
         }
     }
 
-    pub fn new_child_node(
-        &mut self,
-        parent_key: StagedSubstateStoreKey,
-        receipt: TransactionReceipt,
-    ) -> StagedSubstateStoreNodeKey {
-        let store = match parent_key {
-            StagedSubstateStoreKey::RootStoreKey => ImmutableStore::new(),
-            StagedSubstateStoreKey::InternalNodeStoreKey(parent_key) => {
-                ImmutableStore::from_parent(&self.nodes.get(parent_key).unwrap().store)
+    pub fn new_child_node(&mut self, parent_key: StageKey, delta: D) -> DerivedStageKey {
+        self.total_weight += delta.weight();
+        let mut new_accumulator = match parent_key {
+            StageKey::Root => A::default(),
+            StageKey::Derived(parent_key) => {
+                self.nodes.get_mut(parent_key).unwrap().accumulator.clone()
             }
         };
-
-        // Build new node by applying the receipt to the parent store
-        let new_node = StagedSubstateStoreNode::new(receipt, store);
-
-        // Update the `total_weight` of the tree
-        self.total_weight += new_node.weight();
+        new_accumulator.accumulate(&delta);
+        let new_node = DerivedStageNode::new(delta, new_accumulator);
         let new_node_key = self.nodes.insert(new_node);
-        match parent_key {
-            StagedSubstateStoreKey::RootStoreKey => {
-                self.children_keys.push(new_node_key);
+        let child_keys = match parent_key {
+            StageKey::Root => &mut self.child_keys,
+            StageKey::Derived(parent_key) => {
+                &mut self.nodes.get_mut(parent_key).unwrap().child_keys
             }
-            StagedSubstateStoreKey::InternalNodeStoreKey(parent_key) => {
-                let parent_node = self.nodes.get_mut(parent_key).unwrap();
-                parent_node.children_keys.push(new_node_key);
-            }
-        }
+        };
+        child_keys.push(new_node_key);
         new_node_key
     }
 
-    pub fn get_store(&self, key: StagedSubstateStoreKey) -> StagedSubstateStore<S> {
-        StagedSubstateStore { manager: self, key }
+    pub fn get_accumulator(&self, key: &StageKey) -> &A {
+        match key {
+            StageKey::Root => &self.empty_accumulator,
+            StageKey::Derived(key) => &self.nodes.get(*key).unwrap().accumulator,
+        }
     }
 
-    pub fn get_receipt(&self, key: &StagedSubstateStoreNodeKey) -> &TransactionReceipt {
-        &self.nodes.get(*key).unwrap().receipt
+    pub fn get_delta(&self, key: &DerivedStageKey) -> &D {
+        &self.nodes.get(*key).unwrap().delta
     }
 
     fn recompute_data_recursive(
-        nodes: &mut SlotMap<StagedSubstateStoreNodeKey, StagedSubstateStoreNode>,
-        node_key: StagedSubstateStoreNodeKey,
+        nodes: &mut SlotMap<DerivedStageKey, DerivedStageNode<D, A>>,
+        node_key: DerivedStageKey,
     ) {
-        let parent_store = ImmutableStore::from_parent(&nodes.get(node_key).unwrap().store);
-
-        let children_keys = nodes.get(node_key).unwrap().children_keys.clone();
-        for child_key in children_keys.iter() {
+        let node = nodes.get(node_key).unwrap();
+        let parent_accumulator = node.accumulator.clone();
+        let child_keys = node.child_keys.clone();
+        for child_key in child_keys.iter() {
             let child_node = nodes.get_mut(*child_key).unwrap();
-            child_node.store = parent_store.clone();
-            if let TransactionResult::Commit(commit) = &child_node.receipt.result {
-                commit.state_updates.commit(&mut child_node.store);
-            }
+            child_node.accumulator = parent_accumulator.clone();
+            child_node.accumulator.accumulate(&child_node.delta);
             Self::recompute_data_recursive(nodes, *child_key);
         }
     }
 
-    /// Rebuilds ImmutableStores by starting from the root with new, empty ones
-    /// and recursively reapplies the [`receipt`]s.
     fn recompute_data(&mut self) {
-        // Reset the [`dead_weight`]
         self.dead_weight = 0;
-
-        for node_key in self.children_keys.iter() {
-            let node = self.nodes.get_mut(*node_key).unwrap();
-            node.store = ImmutableStore::new();
-            if let TransactionResult::Commit(commit) = &node.receipt.result {
-                commit.state_updates.commit(&mut node.store);
-            }
+        for node_key in self.child_keys.iter() {
+            let child_node = self.nodes.get_mut(*node_key).unwrap();
+            child_node.accumulator = A::default();
+            child_node.accumulator.accumulate(&child_node.delta);
             Self::recompute_data_recursive(&mut self.nodes, *node_key);
         }
     }
 
-    fn remove_node<CB>(
-        nodes: &mut SlotMap<StagedSubstateStoreNodeKey, StagedSubstateStoreNode>,
+    fn remove_node<CB: FnMut(&DerivedStageKey)>(
+        nodes: &mut SlotMap<DerivedStageKey, DerivedStageNode<D, A>>,
         total_weight: &mut usize,
         callback: &mut CB,
-        node_key: &StagedSubstateStoreNodeKey,
-    ) -> StagedSubstateStoreNode
-    where
-        CB: FnMut(&StagedSubstateStoreNodeKey),
-    {
+        node_key: &DerivedStageKey,
+    ) -> DerivedStageNode<D, A> {
         let removed = nodes.remove(*node_key).unwrap();
-        *total_weight -= removed.weight();
+        *total_weight -= removed.delta.weight();
         callback(node_key);
         removed
     }
@@ -269,25 +203,23 @@ impl<S: ReadableSubstateStore> StagedSubstateStoreManager<S> {
     /// Recursively deletes all nodes that are not in new_root_key subtree and returns the
     /// sum of weights from current root to new_root_key. Updates to ImmutableStore on this
     /// path will persist even after deleting the nodes.
-    fn delete_recursive<CB>(
-        nodes: &mut SlotMap<StagedSubstateStoreNodeKey, StagedSubstateStoreNode>,
+    fn delete_recursive<CB: FnMut(&DerivedStageKey)>(
+        nodes: &mut SlotMap<DerivedStageKey, DerivedStageNode<D, A>>,
         total_weight: &mut usize,
-        new_root_key: &StagedSubstateStoreNodeKey,
+        new_root_key: &DerivedStageKey,
         callback: &mut CB,
-        node_key: &StagedSubstateStoreNodeKey,
+        node_key: &DerivedStageKey,
         root_path_weight_sum: usize,
-    ) -> usize
-    where
-        CB: FnMut(&StagedSubstateStoreNodeKey),
-    {
-        let root_path_weight_sum = root_path_weight_sum + nodes.get(*node_key).unwrap().weight();
+    ) -> usize {
+        let node = nodes.get(*node_key).unwrap();
+        let root_path_weight_sum = root_path_weight_sum + node.delta.weight();
         if *node_key == *new_root_key {
             return root_path_weight_sum;
         }
 
         let mut dead_weight = 0;
-        let children_keys = nodes.get(*node_key).unwrap().children_keys.clone();
-        for child_key in children_keys {
+        let child_keys = node.child_keys.clone();
+        for child_key in child_keys {
             // Instead of doing max([0, 0, 0, max, 0,.. 0]) we can do sum()
             dead_weight += Self::delete_recursive(
                 nodes,
@@ -312,7 +244,7 @@ impl<S: ReadableSubstateStore> StagedSubstateStoreManager<S> {
     /// root store is pointing to in order for it to be able to drop no longer relevant branches.
     /// Note that because retroactive deletion for a history of persistent/immutable data
     /// structure is not possible, it is not guaranteed that the chain of state changes
-    /// ([`ImmutableStore`]s. [`StagedSubstateStoreNode`]s however, are always deleted) committed
+    /// ([`Accumulators`]s. [`DerivedStageNode`]s however, are always deleted) committed
     /// to the real store are discarded (every time `reparent` is called).
     /// This does not really matter from a correctness perspective (the staging store
     /// will act as a cache for the real store) but as an memory overhead. The memory
@@ -321,15 +253,16 @@ impl<S: ReadableSubstateStore> StagedSubstateStoreManager<S> {
     /// To better understand please check:
     /// Diagram here: https://whimsical.com/persistent-staged-store-amortized-reparenting-Lyc6gRgVXVzLdqWvwVT3v4
     /// And `test_complicated_reparent` unit test
-    pub fn reparent<CB>(&mut self, new_root_key: StagedSubstateStoreKey, callback: &mut CB)
-    where
-        CB: FnMut(&StagedSubstateStoreNodeKey),
-    {
+    pub fn reparent<CB: FnMut(&DerivedStageKey)>(
+        &mut self,
+        new_root_key: StageKey,
+        callback: &mut CB,
+    ) {
         match new_root_key {
-            StagedSubstateStoreKey::RootStoreKey => {}
-            StagedSubstateStoreKey::InternalNodeStoreKey(new_root_key) => {
+            StageKey::Root => {}
+            StageKey::Derived(new_root_key) => {
                 // Delete all nodes that are not in new_root_key subtree
-                for node_key in self.children_keys.iter() {
+                for node_key in self.child_keys.iter() {
                     self.dead_weight += Self::delete_recursive(
                         &mut self.nodes,
                         &mut self.total_weight,
@@ -346,7 +279,7 @@ impl<S: ReadableSubstateStore> StagedSubstateStoreManager<S> {
                     callback,
                     &new_root_key,
                 );
-                self.children_keys = new_root.children_keys;
+                self.child_keys = new_root.child_keys;
 
                 // If the number of state changes that overlap with the self.root (dead_weight) store is greater
                 // than the number of state changes applied on top of it (total_weight), we recalculate the
@@ -359,138 +292,48 @@ impl<S: ReadableSubstateStore> StagedSubstateStoreManager<S> {
     }
 }
 
-pub struct StagedSubstateStore<'t, S: ReadableSubstateStore> {
-    manager: &'t StagedSubstateStoreManager<S>,
-    key: StagedSubstateStoreKey,
-}
-
-impl<'t, S: ReadableSubstateStore> ReadableSubstateStore for StagedSubstateStore<'t, S> {
-    fn get_substate(&self, substate_id: &SubstateId) -> Option<OutputValue> {
-        match self.key {
-            StagedSubstateStoreKey::RootStoreKey => self.manager.root.get_substate(substate_id),
-            StagedSubstateStoreKey::InternalNodeStoreKey(key) => {
-                // NOTE for future Substate delete support: in order to properly reflect
-                // deleted keys, a Sentinel/Tombstone value should be stored instead of
-                // actually removing the key. When querying here, convert the Tombstone back
-                // into a None (Option can be used as the Tombstone).
-                match self
-                    .manager
-                    .nodes
-                    .get(key)
-                    .unwrap()
-                    .store
-                    .get_substate(substate_id)
-                {
-                    Some(output_value) => Some(output_value),
-                    None => self.manager.root.get_substate(substate_id),
-                }
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use radix_engine::engine::ScryptoInterpreter;
-    use radix_engine::fee::FeeSummary;
-    use radix_engine::ledger::{OutputValue, ReadableSubstateStore, TypedInMemorySubstateStore};
-    use radix_engine::model::{PersistedSubstate, Resource, VaultSubstate};
-    use radix_engine::state_manager::StateDiff;
-    use radix_engine::transaction::{
-        CommitResult, EntityChanges, TransactionExecution, TransactionOutcome, TransactionReceipt,
-        TransactionResult,
-    };
     use radix_engine::types::rust::iter::zip;
-    use radix_engine::wasm::DefaultWasmEngine;
-    use radix_engine_interface::api::types::{RENodeId, SubstateId, SubstateOffset, VaultOffset};
-    use radix_engine_interface::math::Decimal;
-    use radix_engine_interface::model::ResourceAddress;
-    use sbor::rust::collections::BTreeMap;
     use sbor::rust::collections::HashMap;
     use sbor::rust::vec::Vec;
 
-    fn build_transaction_receipt_from_state_diff(state_diff: StateDiff) -> TransactionReceipt {
-        TransactionReceipt {
-            execution: TransactionExecution {
-                fee_summary: FeeSummary {
-                    cost_unit_price: Decimal::default(),
-                    tip_percentage: 0,
-                    cost_unit_limit: 10,
-                    cost_unit_consumed: 1,
-                    total_execution_cost_xrd: Decimal::default(),
-                    total_royalty_cost_xrd: Decimal::default(),
-                    bad_debt_xrd: Decimal::default(),
-                    vault_locks: Vec::new(),
-                    vault_payments_xrd: None,
-                    execution_cost_unit_breakdown: HashMap::new(),
-                    royalty_cost_unit_breakdown: HashMap::new(),
-                },
-                events: Vec::new(),
-            },
-            result: TransactionResult::Commit(CommitResult {
-                application_logs: Vec::new(),
-                next_epoch: None,
-                outcome: TransactionOutcome::Success(Vec::new()),
-                state_updates: state_diff,
-                entity_changes: EntityChanges {
-                    new_component_addresses: Vec::new(),
-                    new_package_addresses: Vec::new(),
-                    new_resource_addresses: Vec::new(),
-                },
-                resource_changes: Vec::new(),
-            }),
+    struct TestDelta(Vec<(u8, u32)>);
+
+    impl Delta for TestDelta {
+        fn weight(&self) -> usize {
+            self.0.len()
         }
     }
 
-    fn build_dummy_substate_id(id: [u8; 36]) -> SubstateId {
-        SubstateId(
-            RENodeId::Vault(id),
-            SubstateOffset::Vault(VaultOffset::Vault),
-        )
-    }
+    #[derive(Clone, Default)]
+    struct TestAccumulator(HashMap<u8, u32>);
 
-    fn build_dummy_output_value(version: u32) -> OutputValue {
-        OutputValue {
-            substate: PersistedSubstate::Vault(VaultSubstate(Resource::Fungible {
-                resource_address: ResourceAddress::Normal([2u8; 26]),
-                divisibility: 56,
-                amount: Decimal::one(),
-            })),
-            version,
+    impl Accumulator<TestDelta> for TestAccumulator {
+        fn accumulate(&mut self, delta: &TestDelta) {
+            for (id, value) in delta.0.iter() {
+                self.0.insert(*id, *value);
+            }
         }
     }
 
     #[derive(Clone)]
     struct TestNodeData {
         parent_id: usize,
-        updates: Vec<(usize, usize)>,
+        updates: Vec<(u8, u32)>,
     }
 
     #[test]
     fn test_complicated_reparent() {
         // Arrange
-        let scrypto_interpreter = ScryptoInterpreter::<DefaultWasmEngine>::default();
-        let store = TypedInMemorySubstateStore::with_bootstrap(&scrypto_interpreter);
-        let mut manager = StagedSubstateStoreManager::new(store);
-
-        let substate_ids: Vec<SubstateId> = (0u8..5u8)
-            .into_iter()
-            .map(|id| build_dummy_substate_id([id; 36]))
-            .collect();
-        let output_values: Vec<OutputValue> = (0u32..5u32)
-            .into_iter()
-            .map(build_dummy_output_value)
-            .collect();
+        let mut manager = StageTree::<TestDelta, TestAccumulator>::new();
 
         let node_test_data = [
             TestNodeData {
                 // child_node[1]
                 parent_id: 0, // root
-                updates: [
-                    (0, 1), // manager.get_store(child_node[1]).get_substate(substate_ids[0]) == output_values[1]
-                ]
-                .to_vec(),
+                updates: [(0, 1)].to_vec(),
             },
             TestNodeData {
                 // child_node[2]
@@ -541,47 +384,35 @@ mod tests {
         .to_vec();
 
         let mut expected_total_weight = 0;
-        let mut child_node = [StagedSubstateStoreKey::RootStoreKey].to_vec();
-        let mut expected_node_states = [BTreeMap::new()].to_vec();
+        let mut child_keys = [StageKey::Root].to_vec();
+        let mut expected_accumulators = [TestAccumulator(HashMap::new())].to_vec();
         let mut expected_weights = [0].to_vec();
         for node_data in node_test_data.iter() {
-            let up_substates: BTreeMap<SubstateId, OutputValue> = node_data
-                .updates
-                .iter()
-                .map(|(substate_id, output_id)| {
-                    (
-                        substate_ids[*substate_id].clone(),
-                        output_values[*output_id].clone(),
-                    )
-                })
-                .collect();
-            let state_diff = StateDiff {
-                up_substates: up_substates.clone(),
-                down_substates: Vec::new(),
-            };
-            let new_child_node = manager.new_child_node(
-                child_node[node_data.parent_id],
-                build_transaction_receipt_from_state_diff(state_diff.clone()),
+            let new_child_key = manager.new_child_node(
+                child_keys[node_data.parent_id],
+                TestDelta(node_data.updates.clone()),
             );
-            child_node.push(StagedSubstateStoreKey::InternalNodeStoreKey(new_child_node));
+            child_keys.push(StageKey::Derived(new_child_key));
 
-            let mut expected_node_state = expected_node_states[node_data.parent_id].clone();
-            expected_node_state.extend(up_substates);
+            let mut expected_accumulator = expected_accumulators[node_data.parent_id].clone();
+            expected_accumulator.0.extend(
+                node_data
+                    .updates
+                    .iter()
+                    .map(|(key, value)| (*key, *value))
+                    .collect::<HashMap<u8, u32>>(),
+            );
 
-            expected_node_states.push(expected_node_state);
+            expected_accumulators.push(expected_accumulator);
             expected_weights.push(node_data.updates.len());
             expected_total_weight += node_data.updates.len();
 
             // check that all stores have the expected state
-            for (child_node, expected_node_state) in
-                zip(child_node.iter(), expected_node_states.iter())
+            for (child_key, expected_accumulator) in
+                zip(child_keys.iter(), expected_accumulators.iter())
             {
-                let store = manager.get_store(*child_node);
-                for (substate_id, output_value) in expected_node_state.iter() {
-                    assert_eq!(
-                        store.get_substate(substate_id),
-                        Some((*output_value).clone())
-                    );
+                for (id, value) in expected_accumulator.0.iter() {
+                    assert_eq!(manager.get_accumulator(child_key).0.get(id), Some(value));
                 }
             }
 
@@ -594,7 +425,7 @@ mod tests {
         //      │            └──> 5 -> 6 -> 9 -> 10
         //      └> 7 -> 8
         // After reparenting to 3: 7 and 8 are discarded completely. 1, 2 and 3 discarded but leave dead weight behind
-        manager.reparent(child_node[3], &mut |_| {});
+        manager.reparent(child_keys[3], &mut |_| {});
         let expected_dead_weight = [1, 2, 3]
             .iter()
             .fold(0, |acc, node_id| acc + expected_weights[*node_id]);
@@ -607,7 +438,7 @@ mod tests {
 
         // After reparenting to 5: node 4 gets discarded completely. Node 5 is discarded and added to the dead weight.
         // This should trigger the recomputation/garbage collection.
-        manager.reparent(child_node[5], &mut |_| {});
+        manager.reparent(child_keys[5], &mut |_| {});
         expected_total_weight -= [4, 5]
             .iter()
             .fold(0, |acc, node_id| acc + expected_weights[*node_id]);

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -191,7 +191,7 @@ where
     S: ReadableSubstateStore,
 {
     pub fn store(&self) -> &S {
-        &self.execution_cache.staged_store_manager.root
+        &self.execution_cache.root_store
     }
 
     pub fn preview(&self, preview_request: PreviewRequest) -> Result<PreviewResult, PreviewError> {
@@ -822,8 +822,7 @@ where
 {
     pub fn save_vertex_store(&'db mut self, vertex_store: Vec<u8>) {
         self.execution_cache
-            .staged_store_manager
-            .root
+            .root_store
             .save_vertex_store(vertex_store);
     }
 
@@ -947,17 +946,14 @@ where
             }
         }
 
-        self.execution_cache
-            .staged_store_manager
-            .root
-            .commit(CommitBundle {
-                transactions: committed_transaction_bundles,
-                proof_bytes: commit_request.proof,
-                proof_state_version: commit_request.proof_state_version,
-                epoch_boundary,
-                substates: substates_collector.substates,
-                vertex_store: commit_request.vertex_store,
-            });
+        self.execution_cache.root_store.commit(CommitBundle {
+            transactions: committed_transaction_bundles,
+            proof_bytes: commit_request.proof,
+            proof_state_version: commit_request.proof_state_version,
+            epoch_boundary,
+            substates: substates_collector.substates,
+            vertex_store: commit_request.vertex_store,
+        });
 
         self.metrics
             .ledger_state_version

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -120,7 +120,8 @@ pub struct StateManagerLoggingConfig {
 pub struct StateManager<S: ReadableSubstateStore> {
     pub mempool: SimpleMempool,
     pub network: NetworkDefinition,
-    execution_cache: ExecutionCache<S>,
+    store: S,
+    execution_cache: ExecutionCache,
     pub user_transaction_validator: UserTransactionValidator,
     pub ledger_transaction_validator: LedgerTransactionValidator,
     pub pending_transaction_result_cache: PendingTransactionResultCache,
@@ -162,7 +163,8 @@ where
         StateManager {
             network,
             mempool,
-            execution_cache: ExecutionCache::new(store, accumulator_hash),
+            store,
+            execution_cache: ExecutionCache::new(accumulator_hash),
             user_transaction_validator,
             ledger_transaction_validator: committed_transaction_validator,
             execution_config: ExecutionConfig {
@@ -191,7 +193,7 @@ where
     S: ReadableSubstateStore,
 {
     pub fn store(&self) -> &S {
-        &self.execution_cache.root_store
+        &self.store
     }
 
     pub fn preview(&self, preview_request: PreviewRequest) -> Result<PreviewResult, PreviewError> {
@@ -224,7 +226,7 @@ where
         };
 
         execute_preview(
-            self.store(),
+            &self.store,
             &self.scrypto_interpreter,
             &self.intent_hash_manager,
             &self.network,
@@ -239,17 +241,20 @@ where
         payload_hash: &LedgerPayloadHash,
     ) -> (AccumulatorHash, &TransactionReceipt) {
         let new_accumulator_hash = parent_accumulator_hash.accumulate(payload_hash);
-        let receipt =
-            self.execution_cache
-                .execute(parent_accumulator_hash, &new_accumulator_hash, |store| {
-                    execute_transaction(
-                        store,
-                        &self.scrypto_interpreter,
-                        &self.fee_reserve_config,
-                        &self.execution_config,
-                        executable,
-                    )
-                });
+        let receipt = self.execution_cache.execute(
+            &self.store,
+            parent_accumulator_hash,
+            &new_accumulator_hash,
+            |store| {
+                execute_transaction(
+                    store,
+                    &self.scrypto_interpreter,
+                    &self.fee_reserve_config,
+                    &self.execution_config,
+                    executable,
+                )
+            },
+        );
         (new_accumulator_hash, receipt)
     }
 }
@@ -294,7 +299,7 @@ where
         let start = std::time::Instant::now();
 
         let receipt = execute_transaction(
-            self.store(),
+            &self.store,
             &self.scrypto_interpreter,
             &self.fee_reserve_config,
             &self.execution_config,
@@ -417,7 +422,7 @@ where
         let attempt = TransactionAttempt {
             rejection: new_status.as_ref().err().cloned(),
             against_state: AtState::Committed {
-                state_version: self.store().max_state_version(),
+                state_version: self.store.max_state_version(),
             },
             timestamp: current_time,
         };
@@ -550,7 +555,7 @@ where
 
     pub fn prepare(&mut self, prepare_request: PrepareRequest) -> PrepareResult {
         // This intent hash check, and current epoch should eventually live in the executor
-        let pending_transaction_base_state_version = self.store().max_state_version();
+        let pending_transaction_base_state_version = self.store.max_state_version();
         let mut already_committed_or_prepared_intent_hashes: HashMap<
             IntentHash,
             AlreadyPreparedTransaction,
@@ -566,7 +571,7 @@ where
                 .ok()
                 .map(|validated_transaction| validated_transaction.intent_hash())
                 .and_then(|intent_hash| {
-                    self.store()
+                    self.store
                         .get_txn_state_version_by_identifier(&intent_hash)
                         .map(|_| (intent_hash, AlreadyPreparedTransaction::Committed))
                 })
@@ -575,7 +580,7 @@ where
         already_committed_or_prepared_intent_hashes
             .extend(already_committed_proposed_payload_hashes);
 
-        let mut parent_accumulator_hash = self.store().get_top_accumulator_hash();
+        let mut parent_accumulator_hash = self.store.get_top_accumulator_hash();
 
         for prepared in prepare_request.already_prepared_payloads {
             let parsed_transaction =
@@ -821,9 +826,7 @@ where
     S: WriteableVertexStore,
 {
     pub fn save_vertex_store(&'db mut self, vertex_store: Vec<u8>) {
-        self.execution_cache
-            .root_store
-            .save_vertex_store(vertex_store);
+        self.store.save_vertex_store(vertex_store);
     }
 
     pub fn commit(&'db mut self, commit_request: CommitRequest) -> Result<(), CommitError> {
@@ -946,7 +949,7 @@ where
             }
         }
 
-        self.execution_cache.root_store.commit(CommitBundle {
+        self.store.commit(CommitBundle {
             transactions: committed_transaction_bundles,
             proof_bytes: commit_request.proof,
             proof_state_version: commit_request.proof_state_version,
@@ -988,7 +991,7 @@ impl<S: ReadableSubstateStore + QueryableSubstateStore> StateManager<S> {
         &self,
         component_address: ComponentAddress,
     ) -> Option<HashMap<ResourceAddress, Decimal>> {
-        let mut resource_accounter = ResourceAccounter::new(self.store());
+        let mut resource_accounter = ResourceAccounter::new(&self.store);
         resource_accounter
             .add_resources(RENodeId::Global(GlobalAddress::Component(
                 component_address,
@@ -1005,7 +1008,7 @@ impl<S: ReadableSubstateStore + QueryableSubstateStore> StateManager<S> {
             node_id,
             SubstateOffset::Validator(ValidatorOffset::Validator),
         );
-        let output = self.store().get_substate(&substate_id).unwrap();
+        let output = self.store.get_substate(&substate_id).unwrap();
         let validator_substate: ValidatorSubstate = output.substate.to_runtime().into();
         JavaValidatorInfo {
             lp_token_address: validator_substate.liquidity_token,
@@ -1014,7 +1017,7 @@ impl<S: ReadableSubstateStore + QueryableSubstateStore> StateManager<S> {
     }
 
     pub fn get_epoch(&self) -> u64 {
-        self.store().get_epoch()
+        self.store.get_epoch()
     }
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/radixdlt/babylon-node/pull/280.

The obvious next step is to add `TreeDelta` field (to `Delta` struct) and `TreeStore` field (to `Accumulator`), which solves the hash tree staging. 