### PR TITLE
DO-1166 - Publish Image to dockerhub as radixdlt/babylon-node

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           images: |
             eu.gcr.io/dev-container-repo/babylon-node
+            radixdlt/babylon-node
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -105,6 +106,11 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDP }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: 'Register gcloud as Docker credential helper'
         run: |
             gcloud auth configure-docker -q

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Docker meta
+      - name: Docker meta release
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -46,6 +46,21 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+        if: github.event_name == 'release'
+      - name: Docker meta other
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            eu.gcr.io/dev-container-repo/babylon-node
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+        if: github.event_name != 'release'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -111,6 +126,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.event_name == 'release'
       - name: 'Register gcloud as Docker credential helper'
         run: |
             gcloud auth configure-docker -q

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,13 +32,30 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Docker meta release
+      - name: Set target image
+        id: set_variables
+        run: |
+          GH_EVENT_NAME="${{ github.event_name }}"
+          echo "This is a Github event type: $GH_EVENT_NAME"
+          if [[ "$GH_EVENT_NAME" == "release" ]] ;then
+            echo "::set-output name=radixdlt_image::radixdlt/babylon-node"
+            echo "is_release: true"
+            echo "release_version: ${{ github.event.release.tag_name }}"
+            echo "ref: ${{ github.event.release.tag_name }}"
+            echo "radixdlt_image: radixdlt/babylon-node"
+          else
+            echo "::set-output name=radixdlt_image::radixdlt/eu.gcr.io/dev-container-repo/babylon-node"
+            echo "is_release: false"
+            echo "release_version: ${{ github.event.release.tag_name }}"
+            echo "ref: ${{ github.event.release.tag_name }}"
+            echo "radixdlt_image: eu.gcr.io/dev-container-repo/babylon-node"
+          fi 
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
-            eu.gcr.io/dev-container-repo/babylon-node
-            radixdlt/babylon-node
+            ${{ steps.set_variables.outputs.radixdlt_image }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -46,21 +63,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-        if: github.event_name == 'release'
-      - name: Docker meta other
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            eu.gcr.io/dev-container-repo/babylon-node
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-        if: github.event_name != 'release'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
             echo "ref: ${{ github.event.release.tag_name }}"
             echo "radixdlt_image: radixdlt/babylon-node"
           else
-            echo "::set-output name=radixdlt_image::radixdlt/eu.gcr.io/dev-container-repo/babylon-node"
+            echo "::set-output name=radixdlt_image::eu.gcr.io/dev-container-repo/babylon-node"
             echo "is_release: false"
             echo "release_version: ${{ github.event.release.tag_name }}"
             echo "ref: ${{ github.event.release.tag_name }}"


### PR DESCRIPTION
This updates the github workflow to do the following:
- log into dockerhub and push image there if github event is "release"
- switch between Docker image names depending on Github Event Type
  - on release: radixdlt/babylon-node
  - else: eu.gcr.io/dev-container-repo/babylon-node
