### PR TITLE
refactor: separate mempool locking from the state_manager lock

### DIFF
--- a/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
@@ -11,8 +11,7 @@ pub(crate) async fn handle_mempool_list(
     Ok(models::MempoolListResponse {
         contents: state_manager
             .mempool
-            .list_all_hashes()
-            .into_iter()
+            .all_hashes_iter()
             .map(
                 |(intent_hash, payload_hash)| models::MempoolTransactionHashes {
                     intent_hash: to_api_intent_hash(intent_hash),

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
@@ -8,9 +8,9 @@ pub(crate) async fn handle_mempool_list(
     let state_manager = state.state_manager.read();
     assert_matching_network(&request.network, &state_manager.network)?;
 
+    let mempool = state_manager.mempool.read();
     Ok(models::MempoolListResponse {
-        contents: state_manager
-            .mempool
+        contents: mempool
             .all_hashes_iter()
             .map(
                 |(intent_hash, payload_hash)| models::MempoolTransactionHashes {

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_transaction.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_transaction.rs
@@ -21,7 +21,7 @@ fn handle_mempool_list_internal(
     let payload_hash = extract_payload_hash(request.payload_hash)
         .map_err(|err| err.into_response_error("payload_hash"))?;
 
-    match state_manager.mempool.get_payload(&payload_hash) {
+    match state_manager.mempool.read().get_payload(&payload_hash) {
         Some(pending_transaction) => Ok(models::MempoolTransactionResponse {
             notarized_transaction: Box::new(to_api_notarized_transaction(
                 &mapping_context,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -114,6 +114,7 @@ fn handle_transaction_status_internal(
 
     let mempool_payloads_hashes = state_manager
         .mempool
+        .read()
         .get_payload_hashes_for_intent(&intent_hash);
 
     if !mempool_payloads_hashes.is_empty() {

--- a/core-rust/state-manager/src/jni/mempool.rs
+++ b/core-rust/state-manager/src/jni/mempool.rs
@@ -146,6 +146,7 @@ fn do_get_transactions_for_proposal(
 
     state_manager
         .mempool
+        .read()
         .get_proposal_transactions(
             max_count.into(),
             max_payload_size_bytes.into(),
@@ -168,7 +169,7 @@ extern "system" fn Java_com_radixdlt_mempool_RustMempool_getCount(
 
 #[tracing::instrument(skip_all)]
 fn do_get_count(state_manager: &ActualStateManager, _args: ()) -> i32 {
-    state_manager.mempool.get_count().try_into().unwrap()
+    state_manager.mempool.read().get_count().try_into().unwrap()
 }
 
 #[no_mangle]

--- a/core-rust/state-manager/src/mempool/simple_mempool.rs
+++ b/core-rust/state-manager/src/mempool/simple_mempool.rs
@@ -207,8 +207,8 @@ impl SimpleMempool {
             .collect()
     }
 
-    pub fn get_transactions(&self) -> HashMap<UserPayloadHash, MempoolData> {
-        self.data.clone()
+    pub fn transactions(&self) -> &HashMap<UserPayloadHash, MempoolData> {
+        &self.data
     }
 
     pub fn remove_transaction(

--- a/core-rust/state-manager/src/mempool/simple_mempool.rs
+++ b/core-rust/state-manager/src/mempool/simple_mempool.rs
@@ -240,7 +240,7 @@ impl SimpleMempool {
         }
     }
 
-    pub fn list_all_hashes(&self) -> Vec<(&IntentHash, &UserPayloadHash)> {
+    pub fn all_hashes_iter(&self) -> impl Iterator<Item = (&IntentHash, &UserPayloadHash)> {
         self.intent_lookup
             .iter()
             .flat_map(|(intent_hash, payload_hashes)| {
@@ -248,7 +248,6 @@ impl SimpleMempool {
                     .iter()
                     .map(move |payload_hash| (intent_hash, payload_hash))
             })
-            .collect()
     }
 
     pub fn get_payload(&self, payload_hash: &UserPayloadHash) -> Option<&PendingTransaction> {


### PR DESCRIPTION
This pull request is a salvaged part of #291 , so I don't have to rebase so much next time.
Please see the commits for the individually explained changes.