### PR TITLE
Refactoring NativeCalls to introduce a stepped builder (for future metrics integration)

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/identifiers/Address.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/identifiers/Address.java
@@ -67,7 +67,7 @@ package com.radixdlt.identifiers;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.crypto.ECDSASecp256k1PublicKey;
 import com.radixdlt.rev2.ComponentAddress;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.sbor.Natives;
 
 public final class Address {
   static {
@@ -76,13 +76,12 @@ public final class Address {
   }
 
   public static ComponentAddress virtualAccountAddress(ECDSASecp256k1PublicKey key) {
-    return virtualAccountAddress.call(key);
+    return virtualAccountAddressFunc.call(key);
   }
 
-  private static final NativeCalls.StaticFunc1<ECDSASecp256k1PublicKey, ComponentAddress>
-      virtualAccountAddress =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {}, new TypeToken<>() {}, Address::virtualAccountAddress);
+  private static final Natives.Call1<ECDSASecp256k1PublicKey, ComponentAddress>
+      virtualAccountAddressFunc =
+          Natives.builder(Address::virtualAccountAddress).build(new TypeToken<>() {});
 
   private static native byte[] virtualAccountAddress(byte[] requestPayload);
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/identifiers/Bech32mCoder.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/identifiers/Bech32mCoder.java
@@ -71,7 +71,7 @@ import com.radixdlt.exceptions.Bech32DecodeException;
 import com.radixdlt.exceptions.Bech32EncodeException;
 import com.radixdlt.lang.Result;
 import com.radixdlt.lang.Tuple;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.sbor.Natives;
 import java.util.Objects;
 
 public final class Bech32mCoder {
@@ -102,17 +102,13 @@ public final class Bech32mCoder {
     return decodeBech32mFunc.call(address).unwrap(Bech32DecodeException::new);
   }
 
-  private static final NativeCalls.StaticFunc1<Tuple.Tuple2<String, byte[]>, Result<String, String>>
-      encodeBech32mFunc =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {}, new TypeToken<>() {}, Bech32mCoder::encodeBech32m);
+  private static final Natives.Call1<Tuple.Tuple2<String, byte[]>, Result<String, String>>
+      encodeBech32mFunc = Natives.builder(Bech32mCoder::encodeBech32m).build(new TypeToken<>() {});
 
   private static native byte[] encodeBech32m(byte[] requestPayload);
 
-  private static final NativeCalls.StaticFunc1<String, Result<Tuple.Tuple2<String, byte[]>, String>>
-      decodeBech32mFunc =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {}, new TypeToken<>() {}, Bech32mCoder::decodeBech32m);
+  private static final Natives.Call1<String, Result<Tuple.Tuple2<String, byte[]>, String>>
+      decodeBech32mFunc = Natives.builder(Bech32mCoder::decodeBech32m).build(new TypeToken<>() {});
 
   private static native byte[] decodeBech32m(byte[] requestPayload);
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/mempool/RustMempool.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/mempool/RustMempool.java
@@ -72,7 +72,7 @@ import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Result;
 import com.radixdlt.lang.Tuple;
 import com.radixdlt.monitoring.Metrics;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.sbor.Natives;
 import com.radixdlt.statemanager.StateManager;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt32;
@@ -84,24 +84,14 @@ public class RustMempool implements MempoolReader<RawNotarizedTransaction> {
 
   public RustMempool(Metrics metrics, StateManager stateManager) {
     this.metrics = metrics;
-    addFunc =
-        NativeCalls.Func1.with(
-            stateManager, new TypeToken<>() {}, new TypeToken<>() {}, RustMempool::add);
+    addFunc = Natives.builder(stateManager, RustMempool::add).build(new TypeToken<>() {});
     getTransactionsForProposalFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            RustMempool::getTransactionsForProposal);
+        Natives.builder(stateManager, RustMempool::getTransactionsForProposal)
+            .build(new TypeToken<>() {});
     getTransactionsToRelayFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            RustMempool::getTransactionsToRelay);
-    getCountFunc =
-        NativeCalls.Func1.with(
-            stateManager, new TypeToken<>() {}, new TypeToken<>() {}, RustMempool::getCount);
+        Natives.builder(stateManager, RustMempool::getTransactionsToRelay)
+            .build(new TypeToken<>() {});
+    getCountFunc = Natives.builder(stateManager, RustMempool::getCount).build(new TypeToken<>() {});
   }
 
   public RawNotarizedTransaction addTransaction(RawNotarizedTransaction transaction)
@@ -166,24 +156,21 @@ public class RustMempool implements MempoolReader<RawNotarizedTransaction> {
 
   private static native byte[] add(StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<
-          StateManager, RawNotarizedTransaction, Result<HashCode, MempoolError>>
-      addFunc;
+  private final Natives.Call1<RawNotarizedTransaction, Result<HashCode, MempoolError>> addFunc;
 
   private static native byte[] getTransactionsForProposal(
       StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<
-          StateManager, Tuple.Tuple3<UInt32, UInt32, List<HashCode>>, List<RawNotarizedTransaction>>
+  private final Natives.Call1<
+          Tuple.Tuple3<UInt32, UInt32, List<HashCode>>, List<RawNotarizedTransaction>>
       getTransactionsForProposalFunc;
 
   private static native byte[] getTransactionsToRelay(StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<
-          StateManager, Tuple.Tuple2<UInt32, UInt32>, List<RawNotarizedTransaction>>
+  private final Natives.Call1<Tuple.Tuple2<UInt32, UInt32>, List<RawNotarizedTransaction>>
       getTransactionsToRelayFunc;
 
   private static native byte[] getCount(Object stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<StateManager, Tuple.Tuple0, Integer> getCountFunc;
+  private final Natives.Call1<Tuple.Tuple0, Integer> getCountFunc;
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/prometheus/StateManagerPrometheus.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/prometheus/StateManagerPrometheus.java
@@ -67,7 +67,7 @@ package com.radixdlt.prometheus;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.radixdlt.lang.Tuple;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.sbor.Natives;
 import com.radixdlt.statemanager.StateManager;
 
 public class StateManagerPrometheus {
@@ -75,18 +75,15 @@ public class StateManagerPrometheus {
   @Inject
   public StateManagerPrometheus(StateManager stateManager) {
     this.prometheusMetricsFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            StateManagerPrometheus::prometheusMetrics);
+        Natives.builder(stateManager, StateManagerPrometheus::prometheusMetrics)
+            .build(new TypeToken<>() {});
   }
 
   public String prometheusMetrics() {
     return prometheusMetricsFunc.call(Tuple.tuple());
   }
 
-  private final NativeCalls.Func1<StateManager, Tuple.Tuple0, String> prometheusMetricsFunc;
+  private final Natives.Call1<Tuple.Tuple0, String> prometheusMetricsFunc;
 
   private static native byte[] prometheusMetrics(StateManager stateManager, byte[] args);
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/recovery/VertexStoreRecovery.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/recovery/VertexStoreRecovery.java
@@ -67,7 +67,7 @@ package com.radixdlt.recovery;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.lang.Tuple;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.sbor.Natives;
 import com.radixdlt.statemanager.StateManager;
 import java.util.Objects;
 import java.util.Optional;
@@ -76,11 +76,8 @@ public final class VertexStoreRecovery {
   public VertexStoreRecovery(StateManager stateManager) {
     Objects.requireNonNull(stateManager);
     this.getVertexStore =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            VertexStoreRecovery::getVertexStore);
+        Natives.builder(stateManager, VertexStoreRecovery::getVertexStore)
+            .build(new TypeToken<>() {});
   }
 
   public Optional<byte[]> recoverVertexStore() {
@@ -89,5 +86,5 @@ public final class VertexStoreRecovery {
 
   private static native byte[] getVertexStore(StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<StateManager, Tuple.Tuple0, Option<byte[]>> getVertexStore;
+  private final Natives.Call1<Tuple.Tuple0, Option<byte[]>> getVertexStore;
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/rev2/ScryptoConstants.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/rev2/ScryptoConstants.java
@@ -65,10 +65,8 @@
 package com.radixdlt.rev2;
 
 import com.google.common.reflect.TypeToken;
-import com.radixdlt.exceptions.StateManagerRuntimeError;
-import com.radixdlt.lang.Result;
 import com.radixdlt.lang.Tuple;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.sbor.Natives;
 
 public final class ScryptoConstants {
   static {
@@ -77,31 +75,23 @@ public final class ScryptoConstants {
   }
 
   public static final ComponentAddress FAUCET_COMPONENT_ADDRESS =
-      NativeCalls.StaticFunc1.with(
-              new TypeToken<Tuple.Tuple0>() {},
-              new TypeToken<Result<ComponentAddress, StateManagerRuntimeError>>() {},
-              ScryptoConstants::getFaucetComponentAddress)
+      Natives.builder(ScryptoConstants::getFaucetComponentAddress)
+          .build(new TypeToken<Natives.Call1<Tuple.Tuple0, ComponentAddress>>() {})
           .call(Tuple.Tuple0.of());
 
   public static final PackageAddress ACCOUNT_PACKAGE_ADDRESS =
-      NativeCalls.StaticFunc1.with(
-              new TypeToken<Tuple.Tuple0>() {},
-              new TypeToken<Result<PackageAddress, StateManagerRuntimeError>>() {},
-              ScryptoConstants::getAccountPackageAddress)
+      Natives.builder(ScryptoConstants::getAccountPackageAddress)
+          .build(new TypeToken<Natives.Call1<Tuple.Tuple0, PackageAddress>>() {})
           .call(Tuple.Tuple0.of());
 
   public static final ResourceAddress XRD_RESOURCE_ADDRESS =
-      NativeCalls.StaticFunc1.with(
-              new TypeToken<Tuple.Tuple0>() {},
-              new TypeToken<Result<ResourceAddress, StateManagerRuntimeError>>() {},
-              ScryptoConstants::getXrdResourceAddress)
+      Natives.builder(ScryptoConstants::getXrdResourceAddress)
+          .build(new TypeToken<Natives.Call1<Tuple.Tuple0, ResourceAddress>>() {})
           .call(Tuple.Tuple0.of());
 
   public static final ComponentAddress EPOCH_MANAGER_COMPONENT_ADDRESS =
-      NativeCalls.StaticFunc1.with(
-              new TypeToken<Tuple.Tuple0>() {},
-              new TypeToken<Result<ComponentAddress, StateManagerRuntimeError>>() {},
-              ScryptoConstants::getEpochManagerComponentAddress)
+      Natives.builder(ScryptoConstants::getEpochManagerComponentAddress)
+          .build(new TypeToken<Natives.Call1<Tuple.Tuple0, ComponentAddress>>() {})
           .call(Tuple.Tuple0.of());
 
   private static native byte[] getFaucetComponentAddress(byte[] unused);

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
@@ -67,11 +67,15 @@ package com.radixdlt.statecomputer;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Result;
 import com.radixdlt.lang.Tuple;
-import com.radixdlt.mempool.*;
+import com.radixdlt.mempool.MempoolInserter;
+import com.radixdlt.mempool.MempoolReader;
+import com.radixdlt.mempool.RustMempool;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.recovery.VertexStoreRecovery;
-import com.radixdlt.rev2.*;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.rev2.ComponentAddress;
+import com.radixdlt.rev2.Decimal;
+import com.radixdlt.rev2.ValidatorInfo;
+import com.radixdlt.sbor.Natives;
 import com.radixdlt.statecomputer.commit.*;
 import com.radixdlt.statemanager.StateManager;
 import com.radixdlt.transaction.REv2TransactionAndProofStore;
@@ -93,42 +97,24 @@ public class RustStateComputer {
     this.vertexStoreRecovery = new VertexStoreRecovery(stateManager);
 
     this.verifyFunc =
-        NativeCalls.Func1.with(
-            stateManager, new TypeToken<>() {}, new TypeToken<>() {}, RustStateComputer::verify);
+        Natives.builder(stateManager, RustStateComputer::verify).build(new TypeToken<>() {});
     this.saveVertexStoreFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            RustStateComputer::saveVertexStore);
-
+        Natives.builder(stateManager, RustStateComputer::saveVertexStore)
+            .build(new TypeToken<>() {});
     this.prepareGenesisFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            RustStateComputer::prepareGenesis);
+        Natives.builder(stateManager, RustStateComputer::prepareGenesis)
+            .build(new TypeToken<>() {});
     this.prepareFunc =
-        NativeCalls.Func1.with(
-            stateManager, new TypeToken<>() {}, new TypeToken<>() {}, RustStateComputer::prepare);
+        Natives.builder(stateManager, RustStateComputer::prepare).build(new TypeToken<>() {});
     this.commitFunc =
-        NativeCalls.Func1.with(
-            stateManager, new TypeToken<>() {}, new TypeToken<>() {}, RustStateComputer::commit);
+        Natives.builder(stateManager, RustStateComputer::commit).build(new TypeToken<>() {});
     this.componentXrdAmountFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            RustStateComputer::componentXrdAmount);
+        Natives.builder(stateManager, RustStateComputer::componentXrdAmount)
+            .build(new TypeToken<>() {});
     this.validatorInfoFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            RustStateComputer::validatorInfo);
-    this.epoch =
-        NativeCalls.Func1.with(
-            stateManager, new TypeToken<>() {}, new TypeToken<>() {}, RustStateComputer::epoch);
+        Natives.builder(stateManager, RustStateComputer::validatorInfo).build(new TypeToken<>() {});
+    this.epochFunc =
+        Natives.builder(stateManager, RustStateComputer::epoch).build(new TypeToken<>() {});
   }
 
   public VertexStoreRecovery getVertexStoreRecovery() {
@@ -157,9 +143,7 @@ public class RustStateComputer {
     return verifyFunc.call(transaction);
   }
 
-  private final NativeCalls.Func1<
-          StateManager, RawNotarizedTransaction, Result<Tuple.Tuple0, String>>
-      verifyFunc;
+  private final Natives.Call1<RawNotarizedTransaction, Result<Tuple.Tuple0, String>> verifyFunc;
 
   private static native byte[] verify(StateManager stateManager, byte[] payload);
 
@@ -167,7 +151,7 @@ public class RustStateComputer {
     saveVertexStoreFunc.call(vertexStoreBytes);
   }
 
-  private final NativeCalls.Func1<StateManager, byte[], Tuple.Tuple0> saveVertexStoreFunc;
+  private final Natives.Call1<byte[], Tuple.Tuple0> saveVertexStoreFunc;
 
   private static native byte[] saveVertexStore(StateManager stateManager, byte[] payload);
 
@@ -175,8 +159,7 @@ public class RustStateComputer {
     return prepareGenesisFunc.call(prepareGenesisRequest);
   }
 
-  private final NativeCalls.Func1<StateManager, PrepareGenesisRequest, PrepareGenesisResult>
-      prepareGenesisFunc;
+  private final Natives.Call1<PrepareGenesisRequest, PrepareGenesisResult> prepareGenesisFunc;
 
   private static native byte[] prepareGenesis(StateManager stateManager, byte[] payload);
 
@@ -184,7 +167,7 @@ public class RustStateComputer {
     return prepareFunc.call(prepareRequest);
   }
 
-  private final NativeCalls.Func1<StateManager, PrepareRequest, PrepareResult> prepareFunc;
+  private final Natives.Call1<PrepareRequest, PrepareResult> prepareFunc;
 
   private static native byte[] prepare(StateManager stateManager, byte[] payload);
 
@@ -192,12 +175,11 @@ public class RustStateComputer {
     return commitFunc.call(commitRequest);
   }
 
-  private final NativeCalls.Func1<StateManager, CommitRequest, Result<Tuple.Tuple0, CommitError>>
-      commitFunc;
+  private final Natives.Call1<CommitRequest, Result<Tuple.Tuple0, CommitError>> commitFunc;
 
   private static native byte[] commit(StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<StateManager, ComponentAddress, Decimal> componentXrdAmountFunc;
+  private final Natives.Call1<ComponentAddress, Decimal> componentXrdAmountFunc;
 
   public Decimal getComponentXrdAmount(ComponentAddress componentAddress) {
     return componentXrdAmountFunc.call(componentAddress);
@@ -205,15 +187,15 @@ public class RustStateComputer {
 
   private static native byte[] componentXrdAmount(StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<StateManager, Tuple.Tuple0, UInt64> epoch;
+  private final Natives.Call1<Tuple.Tuple0, UInt64> epochFunc;
 
   public UInt64 getEpoch() {
-    return epoch.call(Tuple.tuple());
+    return epochFunc.call(Tuple.tuple());
   }
 
   private static native byte[] epoch(StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<StateManager, ComponentAddress, ValidatorInfo> validatorInfoFunc;
+  private final Natives.Call1<ComponentAddress, ValidatorInfo> validatorInfoFunc;
 
   public ValidatorInfo getValidatorInfo(ComponentAddress validatorAddress) {
     return validatorInfoFunc.call(validatorAddress);

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
@@ -67,7 +67,7 @@ package com.radixdlt.transaction;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.lang.Tuple;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.sbor.Natives;
 import com.radixdlt.statemanager.StateManager;
 import com.radixdlt.utils.UInt32;
 import com.radixdlt.utils.UInt64;
@@ -79,29 +79,17 @@ public final class REv2TransactionAndProofStore {
   public REv2TransactionAndProofStore(StateManager stateManager) {
     Objects.requireNonNull(stateManager);
     this.getTransactionAtStateVersionFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            REv2TransactionAndProofStore::getTransactionAtStateVersion);
+        Natives.builder(stateManager, REv2TransactionAndProofStore::getTransactionAtStateVersion)
+            .build(new TypeToken<>() {});
     this.getTxnsAndProof =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            REv2TransactionAndProofStore::getTxnsAndProof);
+        Natives.builder(stateManager, REv2TransactionAndProofStore::getTxnsAndProof)
+            .build(new TypeToken<>() {});
     this.getLastProofFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            REv2TransactionAndProofStore::getLastProof);
+        Natives.builder(stateManager, REv2TransactionAndProofStore::getLastProof)
+            .build(new TypeToken<>() {});
     this.getEpochProofFunc =
-        NativeCalls.Func1.with(
-            stateManager,
-            new TypeToken<>() {},
-            new TypeToken<>() {},
-            REv2TransactionAndProofStore::getEpochProof);
+        Natives.builder(stateManager, REv2TransactionAndProofStore::getEpochProof)
+            .build(new TypeToken<>() {});
   }
 
   public Option<ExecutedTransaction> getTransactionAtStateVersion(long stateVersion) {
@@ -127,25 +115,22 @@ public final class REv2TransactionAndProofStore {
     return this.getEpochProofFunc.call(UInt64.fromNonNegativeLong(epoch)).toOptional();
   }
 
-  private final NativeCalls.Func1<StateManager, UInt64, Option<ExecutedTransaction>>
-      getTransactionAtStateVersionFunc;
+  private final Natives.Call1<UInt64, Option<ExecutedTransaction>> getTransactionAtStateVersionFunc;
 
   private static native byte[] getTransactionAtStateVersion(
       StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<
-          StateManager,
-          Tuple.Tuple3<UInt64, UInt32, UInt32>,
-          Option<Tuple.Tuple2<List<byte[]>, byte[]>>>
+  private final Natives.Call1<
+          Tuple.Tuple3<UInt64, UInt32, UInt32>, Option<Tuple.Tuple2<List<byte[]>, byte[]>>>
       getTxnsAndProof;
 
   private static native byte[] getTxnsAndProof(StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<StateManager, Tuple.Tuple0, Option<byte[]>> getLastProofFunc;
+  private final Natives.Call1<Tuple.Tuple0, Option<byte[]>> getLastProofFunc;
 
   private static native byte[] getLastProof(StateManager stateManager, byte[] payload);
 
-  private final NativeCalls.Func1<StateManager, UInt64, Option<byte[]>> getEpochProofFunc;
+  private final Natives.Call1<UInt64, Option<byte[]>> getEpochProofFunc;
 
   private static native byte[] getEpochProof(StateManager stateManager, byte[] payload);
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/TransactionBuilder.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/TransactionBuilder.java
@@ -77,7 +77,7 @@ import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.NetworkDefinition;
 import com.radixdlt.rev2.TransactionHeader;
-import com.radixdlt.sbor.NativeCalls;
+import com.radixdlt.sbor.Natives;
 import com.radixdlt.transactions.RawLedgerTransaction;
 import com.radixdlt.utils.PrivateKeys;
 import com.radixdlt.utils.UInt64;
@@ -181,15 +181,14 @@ public final class TransactionBuilder {
     return createNotarizedBytesFunc.call(tuple(signedIntent, signature));
   }
 
-  private static final NativeCalls.StaticFunc1<
+  private static final Natives.Call1<
           Tuple.Tuple3<NetworkDefinition, String, List<byte[]>>, Result<byte[], String>>
       compileManifestFunc =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {}, new TypeToken<>() {}, TransactionBuilder::compileManifest);
+          Natives.builder(TransactionBuilder::compileManifest).build(new TypeToken<>() {});
 
   private static native byte[] compileManifest(byte[] payload);
 
-  private static final NativeCalls.StaticFunc1<
+  private static final Natives.Call1<
           Tuple.Tuple5<
               Map<ECDSASecp256k1PublicKey, Tuple.Tuple2<Decimal, ComponentAddress>>,
               Map<ECDSASecp256k1PublicKey, Decimal>,
@@ -198,43 +197,34 @@ public final class TransactionBuilder {
               UInt64>,
           byte[]>
       createGenesisFunc =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {},
-              new TypeToken<>() {},
-              TransactionBuilder::createGenesisLedgerTransaction);
+          Natives.builder(TransactionBuilder::createGenesisLedgerTransaction)
+              .build(new TypeToken<>() {});
 
   private static native byte[] createGenesisLedgerTransaction(byte[] requestPayload);
 
-  private static final NativeCalls.StaticFunc1<Tuple.Tuple2<NetworkDefinition, PublicKey>, byte[]>
+  private static final Natives.Call1<Tuple.Tuple2<NetworkDefinition, PublicKey>, byte[]>
       newAccountIntentFunc =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {}, new TypeToken<>() {}, TransactionBuilder::newAccountIntent);
+          Natives.builder(TransactionBuilder::newAccountIntent).build(new TypeToken<>() {});
 
   private static native byte[] newAccountIntent(byte[] requestPayload);
 
-  private static final NativeCalls.StaticFunc1<
+  private static final Natives.Call1<
           Tuple.Tuple4<NetworkDefinition, TransactionHeader, String, List<byte[]>>,
           Result<byte[], String>>
       createIntentFunc =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {}, new TypeToken<>() {}, TransactionBuilder::createIntent);
+          Natives.builder(TransactionBuilder::createIntent).build(new TypeToken<>() {});
 
   private static native byte[] createIntent(byte[] requestPayload);
 
-  private static final NativeCalls.StaticFunc1<
-          Tuple.Tuple2<byte[], List<SignatureWithPublicKey>>, byte[]>
+  private static final Natives.Call1<Tuple.Tuple2<byte[], List<SignatureWithPublicKey>>, byte[]>
       createSignedIntentBytesFunc =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {},
-              new TypeToken<>() {},
-              TransactionBuilder::createSignedIntentBytes);
+          Natives.builder(TransactionBuilder::createSignedIntentBytes).build(new TypeToken<>() {});
 
   private static native byte[] createSignedIntentBytes(byte[] requestPayload);
 
-  private static final NativeCalls.StaticFunc1<Tuple.Tuple2<byte[], Signature>, byte[]>
+  private static final Natives.Call1<Tuple.Tuple2<byte[], Signature>, byte[]>
       createNotarizedBytesFunc =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {}, new TypeToken<>() {}, TransactionBuilder::createNotarizedBytes);
+          Natives.builder(TransactionBuilder::createNotarizedBytes).build(new TypeToken<>() {});
 
   private static native byte[] createNotarizedBytes(byte[] requestPayload);
 
@@ -247,16 +237,13 @@ public final class TransactionBuilder {
     return transactionBytesToNotarizedTransactionBytesFn.call(transactionBytes);
   }
 
-  private static final NativeCalls.StaticFunc1<byte[], byte[]> userTransactionToLedger =
-      NativeCalls.StaticFunc1.with(
-          new TypeToken<>() {}, new TypeToken<>() {}, TransactionBuilder::userTransactionToLedger);
+  private static final Natives.Call1<byte[], byte[]> userTransactionToLedger =
+      Natives.builder(TransactionBuilder::userTransactionToLedger).build(new TypeToken<>() {});
 
-  private static final NativeCalls.StaticFunc1<byte[], Option<byte[]>>
+  private static final Natives.Call1<byte[], Option<byte[]>>
       transactionBytesToNotarizedTransactionBytesFn =
-          NativeCalls.StaticFunc1.with(
-              new TypeToken<>() {},
-              new TypeToken<>() {},
-              TransactionBuilder::transactionBytesToNotarizedTransactionBytes);
+          Natives.builder(TransactionBuilder::transactionBytesToNotarizedTransactionBytes)
+              .build(new TypeToken<>() {});
 
   private static native byte[] userTransactionToLedger(byte[] requestPayload);
 

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -793,7 +793,7 @@ where
                     // just because transactions were rejected in this history doesn't mean this history will be committed.
                     //
                     // But it'll do for now as a defensive measure until we can have a more intelligent mempool.
-                    mempool.remove_transaction(&intent_hash, &user_payload_hash);
+                    mempool.remove_transaction(intent_hash, user_payload_hash);
                 }
             }
             self.metrics


### PR DESCRIPTION
This is a pure refactoring (no behavior change!) which should enable easier impl of point 5. of https://radixdlt.atlassian.net/browse/NODE-509.

In this PR:
- I replace a single `NativeCalls.with(...)` factory method with a stepped builder
  - currently there are not that many steps, but the entire idea is to have an optional `.measured(...)` building step - coming in the next PR
- I remove the specialized impls of `Func` vs `StaticFunc`
  - ofc these are still 2 different APIs, but backed by a single impl
- I reduce the number of `new TypeToken<>() {}` expressions to 1 per call definition