### PR TITLE
Adding LabelledTimer + Using it for native method timing

### DIFF
--- a/common/src/main/java/com/radixdlt/monitoring/LabelledCounter.java
+++ b/common/src/main/java/com/radixdlt/monitoring/LabelledCounter.java
@@ -64,9 +64,7 @@
 
 package com.radixdlt.monitoring;
 
-import io.prometheus.client.Collector;
 import io.prometheus.client.Counter;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -75,7 +73,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @param <L> A type of record representing a complete set of labels.
  */
-public class LabelledCounter<L extends Record> extends Collector implements Collector.Describable {
+public class LabelledCounter<L extends Record> {
 
   /** A wrapped {@link Counter}. */
   private final Counter wrapped;
@@ -86,12 +84,10 @@ public class LabelledCounter<L extends Record> extends Collector implements Coll
   /**
    * A direct constructor.
    *
-   * @param name A metric name; will also be used as a description.
-   * @param labelClass A class of a {@link Record} representing a complete set of labels.
+   * @param wrapped A wrapped counter.
    */
-  public LabelledCounter(String name, Class<L> labelClass) {
-    this.wrapped =
-        Counter.build(name, name).labelNames(NameRenderer.labelNames(labelClass)).create();
+  public LabelledCounter(Counter wrapped) {
+    this.wrapped = wrapped;
     this.labelledChildren = new ConcurrentHashMap<>();
   }
 
@@ -104,15 +100,5 @@ public class LabelledCounter<L extends Record> extends Collector implements Coll
   public Counter.Child label(L labelRecord) {
     return this.labelledChildren.computeIfAbsent(
         labelRecord, value -> this.wrapped.labels(NameRenderer.labelValues(value)));
-  }
-
-  @Override
-  public List<MetricFamilySamples> collect() {
-    return this.wrapped.collect();
-  }
-
-  @Override
-  public List<MetricFamilySamples> describe() {
-    return this.wrapped.describe();
   }
 }

--- a/common/src/main/java/com/radixdlt/monitoring/LabelledGauge.java
+++ b/common/src/main/java/com/radixdlt/monitoring/LabelledGauge.java
@@ -64,9 +64,7 @@
 
 package com.radixdlt.monitoring;
 
-import io.prometheus.client.Collector;
 import io.prometheus.client.Gauge;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -75,7 +73,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @param <L> A type of record representing a complete set of labels.
  */
-public class LabelledGauge<L extends Record> extends Collector implements Collector.Describable {
+public class LabelledGauge<L extends Record> {
 
   /** A wrapped {@link Gauge}. */
   private final Gauge wrapped;
@@ -86,11 +84,10 @@ public class LabelledGauge<L extends Record> extends Collector implements Collec
   /**
    * A direct constructor.
    *
-   * @param name A metric name; will also be used as a description.
-   * @param labelClass A class of a {@link Record} representing a complete set of labels.
+   * @param wrapped A wrapped gauge.
    */
-  public LabelledGauge(String name, Class<L> labelClass) {
-    this.wrapped = Gauge.build(name, name).labelNames(NameRenderer.labelNames(labelClass)).create();
+  public LabelledGauge(Gauge wrapped) {
+    this.wrapped = wrapped;
     this.labelledChildren = new ConcurrentHashMap<>();
   }
 
@@ -103,15 +100,5 @@ public class LabelledGauge<L extends Record> extends Collector implements Collec
   public Gauge.Child label(L labelRecord) {
     return this.labelledChildren.computeIfAbsent(
         labelRecord, value -> this.wrapped.labels(NameRenderer.labelValues(value)));
-  }
-
-  @Override
-  public List<MetricFamilySamples> collect() {
-    return this.wrapped.collect();
-  }
-
-  @Override
-  public List<MetricFamilySamples> describe() {
-    return this.wrapped.describe();
   }
 }

--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -65,7 +65,12 @@
 package com.radixdlt.monitoring;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
+import com.google.common.collect.MoreCollectors;
 import io.prometheus.client.*;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.function.DoubleSupplier;
 import javax.annotation.Nullable;
 
@@ -96,6 +101,7 @@ import javax.annotation.Nullable;
  *       be used instead of Prometheus-native typo-prone {@link Counter#labels(String...)}.
  *   <li>{@link LabelledGauge}: our type-safe wrapper for a {@link Gauge} with labels (i.e. to be
  *       used instead of Prometheus-native typo-prone {@link Gauge#labels(String...)}.
+ *   <li>{@link LabelledTimer}: type-safe labels support for our {@link Timer}.
  *   <li>{@link TypedInfo}: our type-safe wrapper for a special information-only metric, to be
  *       always used instead of the raw Prometheus-native {@link Info}.
  * </ul>
@@ -151,6 +157,7 @@ public record Metrics(
     Networking networking,
     Crypto crypto,
     EpochManager epochManager,
+    StateManager stateManager,
     Misc misc) {
 
   public record Bft(
@@ -250,11 +257,29 @@ public record Metrics(
   public record EpochManager(
       GetterGauge currentEpoch, GetterGauge currentRound, Counter enqueuedConsensusEvents) {}
 
+  public record StateManager(LabelledTimer<MethodId> nativeCall) {}
+
   public record Misc(
       TypedInfo<Config> config,
       Timer applicationStart,
       Counter vertexStoreSaved,
       GetterGauge peerCount) {}
+
+  public record MethodId(String cls, String method) {
+
+    /**
+     * Creates a method ID while ensuring that only one such native method exists within the class.
+     */
+    public MethodId(Class<?> cls, String methodName) {
+      this(
+          cls.getSimpleName(),
+          Arrays.stream(cls.getDeclaredMethods())
+              .filter(m -> Modifier.isNative(m.getModifiers()))
+              .map(Method::getName)
+              .filter(Predicates.equalTo(methodName))
+              .collect(MoreCollectors.onlyElement()));
+    }
+  }
 
   public record RejectedConsensusEvent(
       Type type, Invalidity invalidity, @Nullable TimestampIssue timestampIssue) {

--- a/common/src/main/java/com/radixdlt/monitoring/MetricsInitializer.java
+++ b/common/src/main/java/com/radixdlt/monitoring/MetricsInitializer.java
@@ -104,7 +104,7 @@ public class MetricsInitializer {
    * @return Initialized instance.
    */
   public Metrics initialize() {
-    return createCollectorHierarchy("rn", Metrics.class);
+    return createHierarchy("rn", Metrics.class);
   }
 
   /**
@@ -117,8 +117,7 @@ public class MetricsInitializer {
    * @param <R> A record type.
    */
   @SuppressWarnings("unchecked")
-  private <R extends Record> R createCollectorHierarchy(
-      @Nullable String namePrefix, Class<R> recordClass) {
+  private <R extends Record> R createHierarchy(@Nullable String namePrefix, Class<R> recordClass) {
     Constructor<?> constructor = recordClass.getConstructors()[0];
     Object[] rowValues =
         Stream.of(recordClass.getRecordComponents())
@@ -140,7 +139,7 @@ public class MetricsInitializer {
    * Instantiates a specific component of a record, which may either be:
    *
    * <ul>
-   *   <li>a sub-record (i.e. recursing into {@link #createCollectorHierarchy(String, Class)});
+   *   <li>a sub-record (i.e. recursing into {@link #createHierarchy(String, Class)});
    *   <li>or a leaf collector. It will be registered with Prometheus under the given name, unless
    *       the record component is explicitly annotated as {@link NotExposed}.
    * </ul>
@@ -153,52 +152,85 @@ public class MetricsInitializer {
   private Object createComponentValue(String name, RecordComponent component) {
     Type componentType = component.getGenericType();
     if (componentType instanceof Class<?> rowClass && rowClass.isRecord()) {
-      return createCollectorHierarchy(name, (Class<? extends Record>) rowClass);
+      return createHierarchy(name, (Class<? extends Record>) rowClass);
     }
-    Collector collector = instantiateCollector(name, componentType);
+    LeafWithCollector leaf = instantiateLeaf(name, componentType);
     if (!component.isAnnotationPresent(NotExposed.class)) {
-      registry.register(collector);
+      registry.register(leaf.collector());
     }
-    return collector;
+    return leaf.leaf();
   }
 
   /**
-   * Resolves a required collector from the given type and instantiates it with the given name.
-   * Supports a subset of standard Prometheus collectors and our type-safe label-support wrappers
-   * (see {@link Metrics}).
+   * Resolves a required leaf from the given type and instantiates it with the given name. Supports
+   * a subset of standard Prometheus collectors and our type-safe label-support wrappers (see {@link
+   * Metrics}).
    *
    * @param name A name.
    * @param type A type.
-   * @return Collector.
+   * @return Leaf, returned together with its underlying {@link Collector} (to be registered with
+   *     Prometheus).
    */
   @SuppressWarnings("unchecked")
-  private Collector instantiateCollector(String name, Type type) {
+  private LeafWithCollector instantiateLeaf(String name, Type type) {
     if (type == Counter.class) {
-      return Counter.build(name, name).create();
+      return new LeafWithCollector(Counter.build(name, name).create());
     }
     if (type == Gauge.class) {
-      return Gauge.build(name, name).create();
+      return new LeafWithCollector(Gauge.build(name, name).create());
     }
     if (type == Timer.class) {
-      return new Timer(name);
+      Summary summary = buildTimeMeasuringSummary(name).create();
+      return new LeafWithCollector(new Timer(summary.labels()), summary);
     }
     if (type == GetterGauge.class) {
-      return new GetterGauge(name);
+      return new LeafWithCollector(new GetterGauge(name));
     }
     if (type instanceof ParameterizedType generic) {
       Class<? extends Record> labelClass =
           (Class<? extends Record>) generic.getActualTypeArguments()[0];
+      String[] labels = NameRenderer.labelNames(labelClass);
       if (generic.getRawType() == LabelledCounter.class) {
-        return new LabelledCounter<>(name, labelClass);
+        Counter counter = Counter.build(name, name).labelNames(labels).create();
+        return new LeafWithCollector(new LabelledCounter<>(counter), counter);
       }
       if (generic.getRawType() == LabelledGauge.class) {
-        return new LabelledGauge<>(name, labelClass);
+        Gauge gauge = Gauge.build(name, name).labelNames(labels).create();
+        return new LeafWithCollector(new LabelledGauge<>(gauge), gauge);
       }
       if (generic.getRawType() == TypedInfo.class) {
-        return new TypedInfo<>(name);
+        Info info = Info.build(name, name).create();
+        return new LeafWithCollector(new TypedInfo<>(info), info);
+      }
+      if (generic.getRawType() == LabelledTimer.class) {
+        Summary summary = buildTimeMeasuringSummary(name).labelNames(labels).create();
+        return new LeafWithCollector(new LabelledTimer<>(summary), summary);
       }
     }
     throw new IllegalArgumentException(
-        "unknown collector type %s used for metric %s".formatted(type.getTypeName(), name));
+        "unknown type %s used for metric %s".formatted(type.getTypeName(), name));
+  }
+
+  /**
+   * Starts a build of a {@link Summary} tailored for time measurement.
+   *
+   * @param name Metric name.
+   * @return Unfinished builder.
+   */
+  private static Summary.Builder buildTimeMeasuringSummary(String name) {
+    return Summary.build(name.concat("_seconds"), name).unit("seconds");
+  }
+
+  private record LeafWithCollector(Object leaf, Collector collector) {
+
+    /**
+     * A convenience constructor for cases where we use Prometheus measurement primitive directly as
+     * a leaf in our hierarchy.
+     *
+     * @param directCollector Collector.
+     */
+    public LeafWithCollector(Collector directCollector) {
+      this(directCollector, directCollector);
+    }
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/mempool/RustMempool.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/mempool/RustMempool.java
@@ -71,7 +71,9 @@ import com.google.common.hash.HashCode;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Result;
 import com.radixdlt.lang.Tuple;
+import com.radixdlt.monitoring.LabelledTimer;
 import com.radixdlt.monitoring.Metrics;
+import com.radixdlt.monitoring.Metrics.MethodId;
 import com.radixdlt.sbor.Natives;
 import com.radixdlt.statemanager.StateManager;
 import com.radixdlt.transactions.RawNotarizedTransaction;
@@ -84,14 +86,23 @@ public class RustMempool implements MempoolReader<RawNotarizedTransaction> {
 
   public RustMempool(Metrics metrics, StateManager stateManager) {
     this.metrics = metrics;
-    addFunc = Natives.builder(stateManager, RustMempool::add).build(new TypeToken<>() {});
+    LabelledTimer<MethodId> timer = metrics.stateManager().nativeCall();
+    addFunc =
+        Natives.builder(stateManager, RustMempool::add)
+            .measure(timer.label(new MethodId(RustMempool.class, "add")))
+            .build(new TypeToken<>() {});
     getTransactionsForProposalFunc =
         Natives.builder(stateManager, RustMempool::getTransactionsForProposal)
+            .measure(timer.label(new MethodId(RustMempool.class, "getTransactionsForProposal")))
             .build(new TypeToken<>() {});
     getTransactionsToRelayFunc =
         Natives.builder(stateManager, RustMempool::getTransactionsToRelay)
+            .measure(timer.label(new MethodId(RustMempool.class, "getTransactionsToRelay")))
             .build(new TypeToken<>() {});
-    getCountFunc = Natives.builder(stateManager, RustMempool::getCount).build(new TypeToken<>() {});
+    getCountFunc =
+        Natives.builder(stateManager, RustMempool::getCount)
+            .measure(timer.label(new MethodId(RustMempool.class, "getCount")))
+            .build(new TypeToken<>() {});
   }
 
   public RawNotarizedTransaction addTransaction(RawNotarizedTransaction transaction)

--- a/core-rust-bridge/src/main/java/com/radixdlt/recovery/VertexStoreRecovery.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/recovery/VertexStoreRecovery.java
@@ -67,16 +67,20 @@ package com.radixdlt.recovery;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.lang.Tuple;
+import com.radixdlt.monitoring.LabelledTimer;
+import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.sbor.Natives;
 import com.radixdlt.statemanager.StateManager;
 import java.util.Objects;
 import java.util.Optional;
 
 public final class VertexStoreRecovery {
-  public VertexStoreRecovery(StateManager stateManager) {
+  public VertexStoreRecovery(Metrics metrics, StateManager stateManager) {
     Objects.requireNonNull(stateManager);
+    LabelledTimer<Metrics.MethodId> timer = metrics.stateManager().nativeCall();
     this.getVertexStore =
         Natives.builder(stateManager, VertexStoreRecovery::getVertexStore)
+            .measure(timer.label(new Metrics.MethodId(VertexStoreRecovery.class, "getVertexStore")))
             .build(new TypeToken<>() {});
   }
 

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
@@ -70,7 +70,9 @@ import com.radixdlt.lang.Tuple;
 import com.radixdlt.mempool.MempoolInserter;
 import com.radixdlt.mempool.MempoolReader;
 import com.radixdlt.mempool.RustMempool;
+import com.radixdlt.monitoring.LabelledTimer;
 import com.radixdlt.monitoring.Metrics;
+import com.radixdlt.monitoring.Metrics.MethodId;
 import com.radixdlt.recovery.VertexStoreRecovery;
 import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.rev2.Decimal;
@@ -93,28 +95,42 @@ public class RustStateComputer {
     Objects.requireNonNull(stateManager);
 
     this.mempool = new RustMempool(metrics, stateManager);
-    this.transactionStore = new REv2TransactionAndProofStore(stateManager);
-    this.vertexStoreRecovery = new VertexStoreRecovery(stateManager);
+    this.transactionStore = new REv2TransactionAndProofStore(metrics, stateManager);
+    this.vertexStoreRecovery = new VertexStoreRecovery(metrics, stateManager);
 
+    LabelledTimer<MethodId> timer = metrics.stateManager().nativeCall();
     this.verifyFunc =
-        Natives.builder(stateManager, RustStateComputer::verify).build(new TypeToken<>() {});
+        Natives.builder(stateManager, RustStateComputer::verify)
+            .measure(timer.label(new MethodId(RustStateComputer.class, "verify")))
+            .build(new TypeToken<>() {});
     this.saveVertexStoreFunc =
         Natives.builder(stateManager, RustStateComputer::saveVertexStore)
+            .measure(timer.label(new MethodId(RustStateComputer.class, "saveVertexStore")))
             .build(new TypeToken<>() {});
     this.prepareGenesisFunc =
         Natives.builder(stateManager, RustStateComputer::prepareGenesis)
+            .measure(timer.label(new MethodId(RustStateComputer.class, "prepareGenesis")))
             .build(new TypeToken<>() {});
     this.prepareFunc =
-        Natives.builder(stateManager, RustStateComputer::prepare).build(new TypeToken<>() {});
+        Natives.builder(stateManager, RustStateComputer::prepare)
+            .measure(timer.label(new MethodId(RustStateComputer.class, "prepare")))
+            .build(new TypeToken<>() {});
     this.commitFunc =
-        Natives.builder(stateManager, RustStateComputer::commit).build(new TypeToken<>() {});
+        Natives.builder(stateManager, RustStateComputer::commit)
+            .measure(timer.label(new MethodId(RustStateComputer.class, "commit")))
+            .build(new TypeToken<>() {});
     this.componentXrdAmountFunc =
         Natives.builder(stateManager, RustStateComputer::componentXrdAmount)
+            .measure(timer.label(new MethodId(RustStateComputer.class, "componentXrdAmount")))
             .build(new TypeToken<>() {});
     this.validatorInfoFunc =
-        Natives.builder(stateManager, RustStateComputer::validatorInfo).build(new TypeToken<>() {});
+        Natives.builder(stateManager, RustStateComputer::validatorInfo)
+            .measure(timer.label(new MethodId(RustStateComputer.class, "validatorInfo")))
+            .build(new TypeToken<>() {});
     this.epochFunc =
-        Natives.builder(stateManager, RustStateComputer::epoch).build(new TypeToken<>() {});
+        Natives.builder(stateManager, RustStateComputer::epoch)
+            .measure(timer.label(new MethodId(RustStateComputer.class, "epoch")))
+            .build(new TypeToken<>() {});
   }
 
   public VertexStoreRecovery getVertexStoreRecovery() {

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
@@ -67,6 +67,9 @@ package com.radixdlt.transaction;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.lang.Tuple;
+import com.radixdlt.monitoring.LabelledTimer;
+import com.radixdlt.monitoring.Metrics;
+import com.radixdlt.monitoring.Metrics.MethodId;
 import com.radixdlt.sbor.Natives;
 import com.radixdlt.statemanager.StateManager;
 import com.radixdlt.utils.UInt32;
@@ -76,19 +79,29 @@ import java.util.Objects;
 import java.util.Optional;
 
 public final class REv2TransactionAndProofStore {
-  public REv2TransactionAndProofStore(StateManager stateManager) {
+  public REv2TransactionAndProofStore(Metrics metrics, StateManager stateManager) {
     Objects.requireNonNull(stateManager);
+
+    LabelledTimer<MethodId> timer = metrics.stateManager().nativeCall();
     this.getTransactionAtStateVersionFunc =
         Natives.builder(stateManager, REv2TransactionAndProofStore::getTransactionAtStateVersion)
+            .measure(
+                timer.label(
+                    new MethodId(
+                        REv2TransactionAndProofStore.class, "getTransactionAtStateVersion")))
             .build(new TypeToken<>() {});
     this.getTxnsAndProof =
         Natives.builder(stateManager, REv2TransactionAndProofStore::getTxnsAndProof)
+            .measure(
+                timer.label(new MethodId(REv2TransactionAndProofStore.class, "getTxnsAndProof")))
             .build(new TypeToken<>() {});
     this.getLastProofFunc =
         Natives.builder(stateManager, REv2TransactionAndProofStore::getLastProof)
+            .measure(timer.label(new MethodId(REv2TransactionAndProofStore.class, "getLastProof")))
             .build(new TypeToken<>() {});
     this.getEpochProofFunc =
         Natives.builder(stateManager, REv2TransactionAndProofStore::getEpochProof)
+            .measure(timer.label(new MethodId(REv2TransactionAndProofStore.class, "getEpochProof")))
             .build(new TypeToken<>() {});
   }
 


### PR DESCRIPTION
Addresses point 5. of https://radixdlt.atlassian.net/browse/NODE-509.

Example new metrics:
```
rn_state_manager_native_call_seconds_count{cls="RustMempool",method="getTransactionsForProposal",} 3438.0
rn_state_manager_native_call_seconds_sum{cls="RustMempool",method="getTransactionsForProposal",} 0.029052403000000074
rn_state_manager_native_call_seconds_count{cls="RustStateComputer",method="validatorInfo",} 0.0
rn_state_manager_native_call_seconds_sum{cls="RustStateComputer",method="validatorInfo",} 0.0
rn_state_manager_native_call_seconds_count{cls="RustStateComputer",method="componentXrdAmount",} 0.0
rn_state_manager_native_call_seconds_sum{cls="RustStateComputer",method="componentXrdAmount",} 0.0
```