### PR TITLE
fix: Numeric NF type is now Integer

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -1885,7 +1885,7 @@ components:
       type: string
       enum:
         - String
-        - Number
+        - Integer
         - Bytes
         - UUID
     NonFungibleId:

--- a/core-rust/core-api-server/src/core_api/conversions/substate.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substate.rs
@@ -198,7 +198,7 @@ pub fn to_api_resource_manager_substate(
 pub fn to_api_fungible_id_type(id_type: &NonFungibleIdType) -> models::NonFungibleIdType {
     match id_type {
         NonFungibleIdType::String => models::NonFungibleIdType::String,
-        NonFungibleIdType::Integer => models::NonFungibleIdType::Number,
+        NonFungibleIdType::Integer => models::NonFungibleIdType::Integer,
         NonFungibleIdType::Bytes => models::NonFungibleIdType::Bytes,
         NonFungibleIdType::UUID => models::NonFungibleIdType::UUID,
     }

--- a/core-rust/core-api-server/src/core_api/generated/models/non_fungible_id_type.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/non_fungible_id_type.rs
@@ -14,8 +14,8 @@
 pub enum NonFungibleIdType {
     #[serde(rename = "String")]
     String,
-    #[serde(rename = "Number")]
-    Number,
+    #[serde(rename = "Integer")]
+    Integer,
     #[serde(rename = "Bytes")]
     Bytes,
     #[serde(rename = "UUID")]
@@ -27,7 +27,7 @@ impl ToString for NonFungibleIdType {
     fn to_string(&self) -> String {
         match self {
             Self::String => String::from("String"),
-            Self::Number => String::from("Number"),
+            Self::Integer => String::from("Integer"),
             Self::Bytes => String::from("Bytes"),
             Self::UUID => String::from("UUID"),
         }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/NonFungibleIdType.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/NonFungibleIdType.java
@@ -30,7 +30,7 @@ public enum NonFungibleIdType {
   
   STRING("String"),
   
-  NUMBER("Number"),
+  INTEGER("Integer"),
   
   BYTES("Bytes"),
   


### PR DESCRIPTION
Updates `Numeric` > `Integer` in line with Scrypto, following input from Matt a few weeks ago.