### PR TITLE
align java and rust hashing for tests

### DIFF
--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -614,6 +614,11 @@ where
             .get_top_of_ledger_transaction_identifiers()
             .unwrap_or_else(CommittedTransactionIdentifiers::pre_genesis);
 
+        debug_assert_eq!(
+            base_transaction_identifiers.accumulator_hash,
+            prepare_request.parent_accumulator
+        );
+
         // This hashmap is used to check for any proposed intents which have already been commited (or prepared)
         // in order to exclude them. This check will eventually live in the engine/executor.
         let mut already_committed_or_prepared_intent_hashes: HashMap<

--- a/core/src/test-core/java/com/radixdlt/modules/MockedCryptoModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/MockedCryptoModule.java
@@ -65,13 +65,12 @@
 package com.radixdlt.modules;
 
 import com.google.common.hash.HashCode;
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.radixdlt.consensus.Blake2b256Hasher;
 import com.radixdlt.consensus.HashVerifier;
 import com.radixdlt.crypto.ECDSASecp256k1Signature;
+import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.crypto.Hasher;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.serialization.DefaultSerialization;
@@ -79,18 +78,12 @@ import com.radixdlt.serialization.DsonOutput.Output;
 import com.radixdlt.serialization.Serialization;
 import java.math.BigInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /** For testing where verification and signing is skipped */
 public class MockedCryptoModule extends AbstractModule {
-  private static final Logger log = LogManager.getLogger();
-  private static final HashFunction hashFunction = Hashing.goodFastHash(8 * 32);
-
   @Override
   public void configure() {
     bind(Serialization.class).toInstance(DefaultSerialization.getInstance());
-    bind(HashFunction.class).toInstance(hashFunction);
   }
 
   @Provides
@@ -99,7 +92,7 @@ public class MockedCryptoModule extends AbstractModule {
       byte[] concat = new byte[64];
       System.arraycopy(hash.asBytes(), 0, concat, 0, hash.asBytes().length);
       System.arraycopy(pubKey.getBytes(), 0, concat, 32, 32);
-      var hashCode = hashFunction.hashBytes(concat).asBytes();
+      var hashCode = HashUtils.blake2b256(concat).asBytes();
       metrics.crypto().signaturesVerified().inc();
       var hashCodeBI = new BigInteger(1, hashCode);
       return sig.getR().equals(hashCodeBI);

--- a/core/src/test-core/java/com/radixdlt/modules/MockedCryptoModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/MockedCryptoModule.java
@@ -69,8 +69,8 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.radixdlt.consensus.Blake2b256Hasher;
 import com.radixdlt.consensus.HashVerifier;
-import com.radixdlt.consensus.Sha256Hasher;
 import com.radixdlt.crypto.ECDSASecp256k1Signature;
 import com.radixdlt.crypto.Hasher;
 import com.radixdlt.monitoring.Metrics;
@@ -111,7 +111,7 @@ public class MockedCryptoModule extends AbstractModule {
     AtomicBoolean running = new AtomicBoolean(false);
     Hasher hasher =
         new Hasher() {
-          private final Sha256Hasher hasher = new Sha256Hasher(serialization);
+          private final Blake2b256Hasher hasher = new Blake2b256Hasher(serialization);
 
           @Override
           public int hashSizeInBytes() {

--- a/core/src/test-core/java/com/radixdlt/modules/MockedKeyModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/MockedKeyModule.java
@@ -64,26 +64,25 @@
 
 package com.radixdlt.modules;
 
-import com.google.common.hash.HashFunction;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.radixdlt.consensus.HashSigner;
 import com.radixdlt.consensus.bft.Self;
 import com.radixdlt.crypto.ECDSASecp256k1PublicKey;
 import com.radixdlt.crypto.ECDSASecp256k1Signature;
+import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.monitoring.Metrics;
 import java.math.BigInteger;
 
 public final class MockedKeyModule extends AbstractModule {
   @Provides
-  private HashSigner hashSigner(
-      @Self ECDSASecp256k1PublicKey key, Metrics metrics, HashFunction hashFunction) {
+  private HashSigner hashSigner(@Self ECDSASecp256k1PublicKey key, Metrics metrics) {
     return h -> {
       var concat = new byte[64];
       System.arraycopy(h, 0, concat, 0, 32);
       System.arraycopy(key.getBytes(), 0, concat, 32, 32);
 
-      var hashCode = hashFunction.hashBytes(concat).asBytes();
+      var hashCode = HashUtils.blake2b256(concat).asBytes();
       metrics.crypto().signaturesSigned().inc();
 
       return ECDSASecp256k1Signature.create(


### PR DESCRIPTION
Change mocked hash functions to use real hashing in order to align hashing in Java and Rust while running tests.

This still keep the mocked signing - which is more computation intensive.
