### PR TITLE
Adding a convenience method for easier record codec registration

### DIFF
--- a/common/src/main/java/com/radixdlt/sbor/codec/Fields.java
+++ b/common/src/main/java/com/radixdlt/sbor/codec/Fields.java
@@ -104,6 +104,12 @@ public interface Fields<T> extends UntypedCodec<T> {
     return new FieldsImpl<>(List.of(), decoder -> creator.apply());
   }
 
+  static <T> Fields<T> arbitrary(Functions.Func1<List<?>, T> creator, List<Field<T, ?>> fields) {
+    return new FieldsImpl<>(
+        fields,
+        decoder -> creator.apply(fields.stream().map(field -> field.decode(decoder)).toList()));
+  }
+
   static <T, T1> Fields<T> of(Functions.Func1<T1, T> creator, Field<T, T1> field1) {
     return new FieldsImpl<>(List.of(field1), decoder -> creator.apply(field1.decode(decoder)));
   }

--- a/common/src/test/java/com/radixdlt/sbor/SborTest.java
+++ b/common/src/test/java/com/radixdlt/sbor/SborTest.java
@@ -518,7 +518,7 @@ public class SborTest {
   }
 
   @Test
-  public void objectTreeCanBeEncodedAndDecodedWithEitherStructCodec() {
+  public void objectTreeCanBeEncodedAndDecodedWithAnyStructCodec() {
     var testValue = new SimpleRecord(1234567, "Some string", Either.left(4567L), some(false));
 
     // PART 1 - We use codec variant 1 (StructCodec.with)
@@ -548,6 +548,20 @@ public class SborTest {
     var decoded2 = sborUsingFromFields.decode_payload(encoded2, SimpleRecord.class);
 
     assertEquals(testValue, decoded2);
+
+    // PART 3 - We use codec variant 3 (StructCodec.fromRecordComponents), and check they match
+    var sborUsingFromRecordComponents =
+        new BasicSbor(
+            new CodecMap()
+                .register(SimpleRecord::registerCodecUsingStructCodecFromRecordComponents));
+
+    var encoded3 = sborUsingFromRecordComponents.encode_payload(testValue, SimpleRecord.class);
+
+    assertArrayEquals(encoded2, encoded3);
+
+    var decoded3 = sborUsingFromRecordComponents.decode_payload(encoded3, SimpleRecord.class);
+
+    assertEquals(testValue, decoded3);
   }
 
   @Test

--- a/common/src/test/java/com/radixdlt/sbor/dto/SimpleRecord.java
+++ b/common/src/test/java/com/radixdlt/sbor/dto/SimpleRecord.java
@@ -106,4 +106,9 @@ public record SimpleRecord(
                 Field.of(SimpleRecord::third, codecs.of(new TypeToken<>() {})),
                 Field.of(SimpleRecord::fourth, codecs.of(new TypeToken<>() {}))));
   }
+
+  public static void registerCodecUsingStructCodecFromRecordComponents(CodecMap codecMap) {
+    codecMap.register(
+        SimpleRecord.class, codecs -> StructCodec.fromRecordComponents(SimpleRecord.class, codecs));
+  }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/rev2/NetworkDefinition.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/rev2/NetworkDefinition.java
@@ -72,13 +72,7 @@ public record NetworkDefinition(byte id, String logical_name, String hrp_suffix)
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         NetworkDefinition.class,
-        codecs ->
-            StructCodec.with(
-                NetworkDefinition::new,
-                codecs.of(byte.class),
-                codecs.of(String.class),
-                codecs.of(String.class),
-                (t, encoder) -> encoder.encode(t.id, t.logical_name, t.hrp_suffix)));
+        codecs -> StructCodec.fromRecordComponents(NetworkDefinition.class, codecs));
   }
 
   public static NetworkDefinition from(Network network) {

--- a/core-rust-bridge/src/main/java/com/radixdlt/rev2/TransactionHeader.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/rev2/TransactionHeader.java
@@ -87,29 +87,7 @@ public record TransactionHeader(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         TransactionHeader.class,
-        codecs ->
-            StructCodec.with(
-                TransactionHeader::new,
-                codecs.of(byte.class),
-                codecs.of(byte.class),
-                codecs.of(UInt64.class),
-                codecs.of(UInt64.class),
-                codecs.of(UInt64.class),
-                codecs.of(PublicKey.class),
-                codecs.of(boolean.class),
-                codecs.of(UInt32.class),
-                codecs.of(UInt16.class),
-                (t, encoder) ->
-                    encoder.encode(
-                        t.version,
-                        t.networkId,
-                        t.startEpochInclusive,
-                        t.endEpochExclusive,
-                        t.nonce,
-                        t.notaryPublicKey,
-                        t.notaryAsSignatory,
-                        t.costUnitLimit,
-                        t.tipPercentage)));
+        codecs -> StructCodec.fromRecordComponents(TransactionHeader.class, codecs));
   }
 
   public static TransactionHeader defaults(

--- a/core-rust-bridge/src/main/java/com/radixdlt/rev2/ValidatorInfo.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/rev2/ValidatorInfo.java
@@ -71,11 +71,6 @@ public record ValidatorInfo(ResourceAddress lpTokenAddress, ResourceAddress unst
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         ValidatorInfo.class,
-        codecs ->
-            StructCodec.with(
-                ValidatorInfo::new,
-                codecs.of(ResourceAddress.class),
-                codecs.of(ResourceAddress.class),
-                (t, encoder) -> encoder.encode(t.lpTokenAddress, t.unstakeResource)));
+        codecs -> StructCodec.fromRecordComponents(ValidatorInfo.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/ActiveValidatorInfo.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/ActiveValidatorInfo.java
@@ -64,7 +64,6 @@
 
 package com.radixdlt.statecomputer.commit;
 
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.crypto.ECDSASecp256k1PublicKey;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.sbor.codec.CodecMap;
@@ -75,11 +74,6 @@ public record ActiveValidatorInfo(ECDSASecp256k1PublicKey key, Decimal stake) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         ActiveValidatorInfo.class,
-        codecs ->
-            StructCodec.with(
-                ActiveValidatorInfo::new,
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) -> encoder.encode(t.key, t.stake)));
+        codecs -> StructCodec.fromRecordComponents(ActiveValidatorInfo.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/CommitRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/CommitRequest.java
@@ -65,7 +65,6 @@
 package com.radixdlt.statecomputer.commit;
 
 import com.google.common.hash.HashCode;
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
@@ -84,21 +83,7 @@ public record CommitRequest(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         CommitRequest.class,
-        codecs ->
-            StructCodec.with(
-                CommitRequest::new,
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(UInt64.class),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) ->
-                    encoder.encode(
-                        t.transactions,
-                        t.stateVersion,
-                        t.stateHash,
-                        t.proofBytes,
-                        t.postCommitVertexStoreBytes)));
+        codecs -> StructCodec.fromRecordComponents(CommitRequest.class, codecs));
   }
 
   @Override

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/NextEpoch.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/NextEpoch.java
@@ -65,7 +65,6 @@
 package com.radixdlt.statecomputer.commit;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
@@ -75,12 +74,6 @@ public record NextEpoch(
     ImmutableMap<ComponentAddress, ActiveValidatorInfo> validators, UInt64 epoch) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
-        NextEpoch.class,
-        codecs ->
-            StructCodec.with(
-                NextEpoch::new,
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) -> encoder.encode(t.validators, t.epoch)));
+        NextEpoch.class, codecs -> StructCodec.fromRecordComponents(NextEpoch.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareGenesisRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareGenesisRequest.java
@@ -64,7 +64,6 @@
 
 package com.radixdlt.statecomputer.commit;
 
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawLedgerTransaction;
@@ -73,10 +72,6 @@ public record PrepareGenesisRequest(RawLedgerTransaction genesis) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PrepareGenesisRequest.class,
-        codecs ->
-            StructCodec.with(
-                PrepareGenesisRequest::new,
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) -> encoder.encode(t.genesis)));
+        codecs -> StructCodec.fromRecordComponents(PrepareGenesisRequest.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareGenesisResult.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareGenesisResult.java
@@ -65,7 +65,6 @@
 package com.radixdlt.statecomputer.commit;
 
 import com.google.common.hash.HashCode;
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.sbor.codec.CodecMap;
@@ -77,11 +76,6 @@ public record PrepareGenesisResult(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PrepareGenesisResult.class,
-        codecs ->
-            StructCodec.with(
-                PrepareGenesisResult::new,
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) -> encoder.encode(t.validatorSet, t.stateHash)));
+        codecs -> StructCodec.fromRecordComponents(PrepareGenesisResult.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
@@ -65,7 +65,6 @@
 package com.radixdlt.statecomputer.commit;
 
 import com.google.common.hash.HashCode;
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawNotarizedTransaction;
@@ -82,22 +81,6 @@ public record PrepareRequest(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PrepareRequest.class,
-        codecs ->
-            StructCodec.with(
-                PrepareRequest::new,
-                codecs.of(HashCode.class),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) ->
-                    encoder.encode(
-                        t.parentAccumulatorHash,
-                        t.previousVertices,
-                        t.proposed,
-                        t.epoch,
-                        t.roundNumber,
-                        t.proposerTimestampMs)));
+        codecs -> StructCodec.fromRecordComponents(PrepareRequest.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareResult.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareResult.java
@@ -65,7 +65,6 @@
 package com.radixdlt.statecomputer.commit;
 
 import com.google.common.hash.HashCode;
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.lang.Tuple;
 import com.radixdlt.sbor.codec.CodecMap;
@@ -80,13 +79,6 @@ public record PrepareResult(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PrepareResult.class,
-        codecs ->
-            StructCodec.with(
-                PrepareResult::new,
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) -> encoder.encode(t.committed, t.rejected, t.nextEpoch, t.stateHash)));
+        codecs -> StructCodec.fromRecordComponents(PrepareResult.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PreviousVertex.java
@@ -65,7 +65,6 @@
 package com.radixdlt.statecomputer.commit;
 
 import com.google.common.hash.HashCode;
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawLedgerTransaction;
@@ -76,11 +75,6 @@ public record PreviousVertex(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PreviousVertex.class,
-        codecs ->
-            StructCodec.with(
-                PreviousVertex::new,
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(HashCode.class),
-                (t, encoder) -> encoder.encode(t.transactions, t.resultantAccumulatorHash)));
+        codecs -> StructCodec.fromRecordComponents(PreviousVertex.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statemanager/CoreApiServerConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statemanager/CoreApiServerConfig.java
@@ -72,11 +72,6 @@ public record CoreApiServerConfig(String bindInterface, UInt32 port) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         CoreApiServerConfig.class,
-        codecs ->
-            StructCodec.with(
-                CoreApiServerConfig::new,
-                codecs.of(String.class),
-                codecs.of(UInt32.class),
-                (t, encoder) -> encoder.encode(t.bindInterface, t.port)));
+        codecs -> StructCodec.fromRecordComponents(CoreApiServerConfig.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statemanager/LoggingConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statemanager/LoggingConfig.java
@@ -64,7 +64,6 @@
 
 package com.radixdlt.statemanager;
 
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 
@@ -73,12 +72,7 @@ public record LoggingConfig(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         LoggingConfig.class,
-        codecs ->
-            StructCodec.with(
-                LoggingConfig::new,
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (s, encoder) -> encoder.encode(s.engineTrace, s.stateManagerLoggingConfig)));
+        codecs -> StructCodec.fromRecordComponents(LoggingConfig.class, codecs));
   }
 
   public static LoggingConfig getDefault() {

--- a/core-rust-bridge/src/main/java/com/radixdlt/statemanager/StateManagerConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statemanager/StateManagerConfig.java
@@ -64,7 +64,6 @@
 
 package com.radixdlt.statemanager;
 
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Option;
 import com.radixdlt.mempool.RustMempoolConfig;
 import com.radixdlt.rev2.NetworkDefinition;
@@ -79,18 +78,6 @@ public record StateManagerConfig(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         StateManagerConfig.class,
-        codecs ->
-            StructCodec.with(
-                StateManagerConfig::new,
-                codecs.of(NetworkDefinition.class),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (s, encoder) ->
-                    encoder.encode(
-                        s.networkDefinition,
-                        s.mempoolConfigOpt,
-                        s.databaseConfig,
-                        s.loggingConfig)));
+        codecs -> StructCodec.fromRecordComponents(StateManagerConfig.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statemanager/StateManagerLoggingConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statemanager/StateManagerLoggingConfig.java
@@ -64,7 +64,6 @@
 
 package com.radixdlt.statemanager;
 
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 
@@ -72,11 +71,7 @@ public record StateManagerLoggingConfig(boolean logOnTransactionRejection) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         StateManagerLoggingConfig.class,
-        codecs ->
-            StructCodec.with(
-                StateManagerLoggingConfig::new,
-                codecs.of(new TypeToken<>() {}),
-                (s, encoder) -> encoder.encode(s.logOnTransactionRejection)));
+        codecs -> StructCodec.fromRecordComponents(StateManagerLoggingConfig.class, codecs));
   }
 
   public static StateManagerLoggingConfig getDefault() {

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/ExecutedTransaction.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/ExecutedTransaction.java
@@ -64,7 +64,6 @@
 
 package com.radixdlt.transaction;
 
-import com.google.common.reflect.TypeToken;
 import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.rev2.ResourceAddress;
 import com.radixdlt.sbor.codec.CodecMap;
@@ -84,21 +83,7 @@ public record ExecutedTransaction(
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         ExecutedTransaction.class,
-        codecs ->
-            StructCodec.with(
-                ExecutedTransaction::new,
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                codecs.of(new TypeToken<>() {}),
-                (t, encoder) ->
-                    encoder.encode(
-                        t.status,
-                        t.ledgerReceiptBytes,
-                        t.transactionBytes,
-                        t.newComponentAddresses,
-                        t.newResourceAddresses)));
+        codecs -> StructCodec.fromRecordComponents(ExecutedTransaction.class, codecs));
   }
 
   public RawLedgerTransaction rawTransaction() {


### PR DESCRIPTION
As in the title: a convenience method built on top of existing `Fields`-style codec.
Allows to register a codec for any standard `record` in a single line, without caring about `TypeToken<>`s or the record's component names.

Note: the impl actually does not do any _custom_ reflection "magic"; it relies 100% on documented guarantees of `record` classes.