### PR TITLE
chore: cleanup core api default body limit

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -41,9 +41,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.16"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e3356844c4d6a6d6467b8da2cffb4a2820be256f50a3a386c9d152bab31043"
+checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -59,8 +59,10 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -72,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.8"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
+checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
 dependencies = [
  "async-trait",
  "bytes",
@@ -82,6 +84,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -1086,9 +1089,9 @@ checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -1833,6 +1836,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2231,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"

--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -353,7 +353,6 @@ dependencies = [
  "serde_json",
  "state-manager",
  "tokio",
- "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/core-rust/core-api-server/Cargo.toml
+++ b/core-rust/core-api-server/Cargo.toml
@@ -54,10 +54,6 @@ opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio"] }
 ### TYPES FOR THE SERVER
 # Axum - see https://docs.rs/axum/latest/axum/#required-dependencies
 axum = { version = "0.6.6", features = ["http1", "json"] }
-# Tower HTTP - Axum middleware
-tower-http = { version = "0.3.5", default-features = false, features = [
-  "limit",
-] }
 # Hyper - see https://docs.rs/axum/latest/axum/#required-dependencies
 hyper = { version = "0.14.20", features = ["server", "http1"] }
 # Tokio - see https://docs.rs/tokio/latest/tokio/

--- a/core-rust/core-api-server/Cargo.toml
+++ b/core-rust/core-api-server/Cargo.toml
@@ -53,9 +53,9 @@ opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio"] }
 
 ### TYPES FOR THE SERVER
 # Axum - see https://docs.rs/axum/latest/axum/#required-dependencies
-axum = { version = "0.5.15", features = ["http1", "json"] }
+axum = { version = "0.6.6", features = ["http1", "json"] }
 # Tower HTTP - Axum middleware
-tower-http = { version = "0.3.4", default-features = false, features = [
+tower-http = { version = "0.3.5", default-features = false, features = [
   "limit",
 ] }
 # Hyper - see https://docs.rs/axum/latest/axum/#required-dependencies

--- a/core-rust/core-api-server/src/core_api/errors.rs
+++ b/core-rust/core-api-server/src/core_api/errors.rs
@@ -109,3 +109,12 @@ pub(crate) fn detailed_error<E: ErrorDetails>(
         details: Some(details.into()),
     }
 }
+
+pub(crate) fn length_limit_error<E: ErrorDetails>() -> ResponseError<E> {
+    ResponseError {
+        status_code: StatusCode::PAYLOAD_TOO_LARGE,
+        public_error_message: "length limit exceeded".into(),
+        trace: None,
+        details: None,
+    }
+}

--- a/core-rust/core-api-server/src/core_api/extractors.rs
+++ b/core-rust/core-api-server/src/core_api/extractors.rs
@@ -1,36 +1,22 @@
 use axum::{
     async_trait,
     body::HttpBody,
-    extract::{rejection::JsonRejection, FromRequest, FromRequestParts},
-    http::request::Parts,
+    extract::{
+        rejection::{BytesRejection, FailedToBufferBody, JsonRejection},
+        FromRequest,
+    },
     http::Request,
     response::IntoResponse,
 };
 use serde::Serialize;
 
-use super::{client_error, ResponseError};
+use super::{client_error, length_limit_error, ResponseError};
 
 // We define our own `Json` extractor that customizes the error from `axum::Json`
 
 #[derive(Debug)]
 pub(crate) struct Json<T>(pub T);
-pub use axum::extract::State; // Re-export Extension so that it can be used easily
-
-#[async_trait]
-impl<S, T> FromRequestParts<S> for Json<T>
-where
-    axum::Json<T>: FromRequestParts<S, Rejection = JsonRejection>,
-    S: Send + Sync,
-{
-    type Rejection = ResponseError<()>;
-
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        match axum::Json::<T>::from_request_parts(parts, state).await {
-            Ok(value) => Ok(Self(value.0)),
-            Err(rejection) => Err(client_error(format!("{:?}", rejection))),
-        }
-    }
-}
+pub use axum::extract::State; // Re-export State so that it can be used easily
 
 #[async_trait]
 impl<S, B, T> FromRequest<S, B> for Json<T>
@@ -44,7 +30,12 @@ where
     async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
         match axum::Json::<T>::from_request(req, state).await {
             Ok(value) => Ok(Self(value.0)),
-            Err(rejection) => Err(client_error(format!("{rejection:?}"))),
+            Err(rejection) => match rejection {
+                JsonRejection::BytesRejection(BytesRejection::FailedToBufferBody(
+                    FailedToBufferBody::LengthLimitError(_),
+                )) => Err(length_limit_error()),
+                _ => Err(client_error(format!("{rejection:?}"))),
+            },
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
@@ -2,7 +2,7 @@ use crate::core_api::*;
 
 #[tracing::instrument(level = "debug", skip(state), err(Debug))]
 pub(crate) async fn handle_mempool_list(
-    Extension(state): Extension<CoreApiState>,
+    State(state): State<CoreApiState>,
     Json(request): Json<models::MempoolListRequest>,
 ) -> Result<Json<models::MempoolListResponse>, ResponseError<()>> {
     let state_manager = state.state_manager.read();

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_transaction.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_transaction.rs
@@ -5,7 +5,7 @@ use state_manager::jni::state_manager::ActualStateManager;
 use super::to_api_notarized_transaction;
 
 pub(crate) async fn handle_mempool_transaction(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::MempoolTransactionRequest>,
 ) -> Result<Json<models::MempoolTransactionResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_mempool_list_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
@@ -8,7 +8,7 @@ use state_manager::query::{dump_component_state, VaultData};
 use super::map_to_descendent_id;
 
 pub(crate) async fn handle_state_access_controller(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StateAccessControllerRequest>,
 ) -> Result<Json<models::StateAccessControllerResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_state_access_controller_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/state_clock.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_clock.rs
@@ -6,7 +6,7 @@ use state_manager::jni::state_manager::ActualStateManager;
 
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_state_clock(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StateClockRequest>,
 ) -> Result<Json<models::StateClockResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_state_clock_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/state_component.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_component.rs
@@ -8,7 +8,7 @@ use state_manager::jni::state_manager::ActualStateManager;
 use state_manager::query::{dump_component_state, VaultData};
 
 pub(crate) async fn handle_state_component(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StateComponentRequest>,
 ) -> Result<Json<models::StateComponentResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_state_component_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/state_epoch.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_epoch.rs
@@ -6,7 +6,7 @@ use state_manager::jni::state_manager::ActualStateManager;
 
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_state_epoch(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StateEpochRequest>,
 ) -> Result<Json<models::StateEpochResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_state_epoch_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
@@ -10,7 +10,7 @@ use crate::core_api::models::StateNonFungibleResponse;
 use state_manager::jni::state_manager::ActualStateManager;
 
 pub(crate) async fn handle_state_non_fungible(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StateNonFungibleRequest>,
 ) -> Result<Json<StateNonFungibleResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_state_non_fungible_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/state_package.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_package.rs
@@ -8,7 +8,7 @@ use radix_engine_interface::api::types::{
 use state_manager::jni::state_manager::ActualStateManager;
 
 pub(crate) async fn handle_state_package(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StatePackageRequest>,
 ) -> Result<Json<models::StatePackageResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_state_package_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
@@ -6,7 +6,7 @@ use radix_engine_interface::api::types::{AccessRulesOffset, NodeModuleId, RENode
 use state_manager::jni::state_manager::ActualStateManager;
 
 pub(crate) async fn handle_state_resource(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StateResourceRequest>,
 ) -> Result<Json<models::StateResourceResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_state_resource_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
@@ -8,7 +8,7 @@ use state_manager::query::{dump_component_state, VaultData};
 use super::map_to_descendent_id;
 
 pub(crate) async fn handle_state_validator(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StateValidatorRequest>,
 ) -> Result<Json<models::StateValidatorResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_state_validator_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
@@ -5,7 +5,7 @@ use state_manager::jni::state_manager::ActualStateManager;
 
 #[tracing::instrument(err(Debug), skip(state))]
 pub(crate) async fn handle_status_network_configuration(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
 ) -> Result<Json<models::NetworkConfigurationResponse>, ResponseError<()>> {
     core_api_handler_empty_request(state, handle_status_network_configuration_internal)
 }

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -6,7 +6,7 @@ use state_manager::CommittedTransactionIdentifiers;
 
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_status_network_status(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::NetworkStatusRequest>,
 ) -> Result<Json<models::NetworkStatusResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_status_network_status_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
@@ -20,7 +20,7 @@ use transaction::model::{
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_stream_transactions(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::StreamTransactionsRequest>,
 ) -> Result<Json<models::StreamTransactionsResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_stream_transactions_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -28,7 +28,7 @@ macro_rules! args_from_bytes_vec {
 
 #[tracing::instrument(level = "debug", skip_all, err(Debug))]
 pub(crate) async fn handle_transaction_callpreview(
-    Extension(state): Extension<CoreApiState>,
+    State(state): State<CoreApiState>,
     Json(request): Json<models::TransactionCallPreviewRequest>,
 ) -> Result<Json<models::TransactionCallPreviewResponse>, ResponseError<()>> {
     let state_manager = state.state_manager.read();

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_parse.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_parse.rs
@@ -20,7 +20,7 @@ use super::{
 };
 
 pub(crate) async fn handle_transaction_parse(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::TransactionParseRequest>,
 ) -> Result<Json<models::TransactionParseResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_transaction_parse_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
@@ -11,7 +11,7 @@ use transaction::manifest;
 use transaction::model::PreviewFlags;
 
 pub(crate) async fn handle_transaction_preview(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::TransactionPreviewRequest>,
 ) -> Result<Json<models::TransactionPreviewResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_preview_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
@@ -5,7 +5,7 @@ use state_manager::store::traits::*;
 
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_transaction_receipt(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::TransactionReceiptRequest>,
 ) -> Result<Json<models::TransactionReceiptResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_transaction_receipt_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -11,7 +11,7 @@ use state_manager::store::traits::*;
 
 #[tracing::instrument(err(Debug), skip(state))]
 pub(crate) async fn handle_transaction_status(
-    state: Extension<CoreApiState>,
+    state: State<CoreApiState>,
     request: Json<models::TransactionStatusRequest>,
 ) -> Result<Json<models::TransactionStatusResponse>, ResponseError<()>> {
     core_api_read_handler(state, request, handle_transaction_status_internal)

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
@@ -24,7 +24,7 @@ impl ErrorDetails for TransactionSubmitErrorDetails {
 
 #[tracing::instrument(level = "debug", skip(state), err(Debug))]
 pub(crate) async fn handle_transaction_submit(
-    Extension(state): Extension<CoreApiState>,
+    State(state): State<CoreApiState>,
     Json(request): Json<models::TransactionSubmitRequest>,
 ) -> Result<Json<models::TransactionSubmitResponse>, ResponseError<TransactionSubmitErrorDetails>> {
     let mut state_manager = state.state_manager.write();

--- a/core-rust/core-api-server/src/core_api/helpers.rs
+++ b/core-rust/core-api-server/src/core_api/helpers.rs
@@ -4,10 +4,10 @@ use radix_engine::types::{RENodeId, SubstateId, SubstateOffset};
 use radix_engine_interface::api::types::NodeModuleId;
 use state_manager::jni::state_manager::ActualStateManager;
 
-use super::{CoreApiState, Extension, Json, MappingError, ResponseError};
+use super::{CoreApiState, Json, MappingError, ResponseError, State};
 
 pub(crate) fn core_api_handler_empty_request<Response>(
-    Extension(state): Extension<CoreApiState>,
+    State(state): State<CoreApiState>,
     method: impl FnOnce(&mut ActualStateManager) -> Result<Response, ResponseError<()>>,
 ) -> Result<Json<Response>, ResponseError<()>> {
     let mut state_manager = state.state_manager.write();
@@ -17,7 +17,7 @@ pub(crate) fn core_api_handler_empty_request<Response>(
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn core_api_read_handler<Request, Response>(
-    Extension(state): Extension<CoreApiState>,
+    State(state): State<CoreApiState>,
     Json(request_body): Json<Request>,
     method: impl FnOnce(&ActualStateManager, Request) -> Result<Response, ResponseError<()>>,
 ) -> Result<Json<Response>, ResponseError<()>> {

--- a/core-rust/core-api-server/src/core_api/server.rs
+++ b/core-rust/core-api-server/src/core_api/server.rs
@@ -94,7 +94,7 @@ pub async fn create_server<F>(
 
     // TODO - Change this to be slightly larger than the double the max transaction payload size.
     // (We double due to the hex encoding of the payload)
-    const LARGE_REQUEST_MAX_BYTES: usize = 50 * 1024 * 1024;
+    const LARGE_REQUEST_MAX_BYTES: usize = 3 * 1024 * 1024;
 
     let router = Router::new()
         // This only adds a route for /core, /core/ doesn't seem possible using /nest


### PR DESCRIPTION
Update axum's version. Check breaking [changelog](https://github.com/tokio-rs/axum/blob/main/axum/CHANGELOG.md#060-25-november-2022).

Remove Tower `RequestBodyLimitLayer` middleware and use `DefaultBodyLimit::max` (see TODO and https://github.com/tokio-rs/axum/pull/1397).