### PR TITLE
Propagating transaction and receipt hashes up to the ledger header

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/StateManagerSbor.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/StateManagerSbor.java
@@ -136,6 +136,7 @@ public final class StateManagerSbor {
     ECDSASecp256k1Signature.registerCodec(codecMap);
     EdDSAEd25519Signature.registerCodec(codecMap);
     SignatureWithPublicKey.registerCodec(codecMap);
+    LedgerHashes.registerCodec(codecMap);
     PrepareGenesisRequest.registerCodec(codecMap);
     PrepareGenesisResult.registerCodec(codecMap);
     PreviousVertex.registerCodec(codecMap);

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/LedgerHashes.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/LedgerHashes.java
@@ -64,20 +64,13 @@
 
 package com.radixdlt.statecomputer.commit;
 
-import com.radixdlt.lang.Option;
-import com.radixdlt.lang.Tuple;
+import com.google.common.hash.HashCode;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
-import java.util.List;
 
-public record PrepareResult(
-    List<byte[]> committed,
-    List<Tuple.Tuple2<byte[], String>> rejected,
-    Option<NextEpoch> nextEpoch,
-    LedgerHashes ledgerHashes) {
+public record LedgerHashes(HashCode stateRoot, HashCode transactionRoot, HashCode receiptRoot) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
-        PrepareResult.class,
-        codecs -> StructCodec.fromRecordComponents(PrepareResult.class, codecs));
+        LedgerHashes.class, codecs -> StructCodec.fromRecordComponents(LedgerHashes.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareGenesisResult.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareGenesisResult.java
@@ -64,7 +64,6 @@
 
 package com.radixdlt.statecomputer.commit;
 
-import com.google.common.hash.HashCode;
 import com.radixdlt.lang.Option;
 import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.sbor.codec.CodecMap;
@@ -72,7 +71,7 @@ import com.radixdlt.sbor.codec.StructCodec;
 import java.util.Map;
 
 public record PrepareGenesisResult(
-    Option<Map<ComponentAddress, ActiveValidatorInfo>> validatorSet, HashCode stateHash) {
+    Option<Map<ComponentAddress, ActiveValidatorInfo>> validatorSet, LedgerHashes ledgerHashes) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PrepareGenesisResult.class,

--- a/core-rust/state-manager/src/jni/common_types.rs
+++ b/core-rust/state-manager/src/jni/common_types.rs
@@ -62,22 +62,16 @@
  * permissions under this License.
  */
 
-package com.radixdlt.statecomputer.commit;
+use sbor::{Categorize, Decode, Encode};
 
-import com.radixdlt.lang.Option;
-import com.radixdlt.lang.Tuple;
-import com.radixdlt.sbor.codec.CodecMap;
-import com.radixdlt.sbor.codec.StructCodec;
-import java.util.List;
+#[derive(Debug, PartialEq, Eq, Categorize, Encode, Decode)]
+pub struct JavaHashCode(Vec<u8>);
 
-public record PrepareResult(
-    List<byte[]> committed,
-    List<Tuple.Tuple2<byte[], String>> rejected,
-    Option<NextEpoch> nextEpoch,
-    LedgerHashes ledgerHashes) {
-  public static void registerCodec(CodecMap codecMap) {
-    codecMap.register(
-        PrepareResult.class,
-        codecs -> StructCodec.fromRecordComponents(PrepareResult.class, codecs));
-  }
+impl JavaHashCode {
+    pub fn from_bytes<const S: usize>(bytes: [u8; S]) -> Self {
+        JavaHashCode(bytes.to_vec())
+    }
+    pub fn into_bytes<const S: usize>(self) -> [u8; S] {
+        self.0.as_slice().try_into().unwrap()
+    }
 }

--- a/core-rust/state-manager/src/jni/mod.rs
+++ b/core-rust/state-manager/src/jni/mod.rs
@@ -63,6 +63,7 @@
  */
 
 pub mod addressing;
+pub mod common_types;
 pub mod java_structure;
 pub mod mempool;
 pub mod scrypto_constants;

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -15,7 +15,7 @@ use radix_engine_interface::api::component::ComponentAddress;
 use radix_engine_interface::blueprints::logger::Level;
 use radix_engine_interface::*;
 
-use crate::AccumulatorHash;
+use crate::{AccumulatorHash, LedgerReceiptHash};
 
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct CommittedTransactionIdentifiers {
@@ -77,6 +77,12 @@ pub struct LedgerTransactionReceipt {
     pub entity_changes: EntityChanges,
     pub resource_changes: Vec<ResourceChange>,
     pub next_epoch: Option<(BTreeMap<ComponentAddress, Validator>, u64)>,
+}
+
+impl LedgerTransactionReceipt {
+    pub fn get_hash(&self) -> LedgerReceiptHash {
+        LedgerReceiptHash::for_receipt(self)
+    }
 }
 
 impl TryFrom<EngineTransactionReceipt> for LedgerTransactionReceipt {

--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -64,7 +64,10 @@
 
 use super::stage_tree::{DerivedStageKey, StageKey};
 use crate::staging::stage_tree::{Accumulator, Delta, StageTree};
-use crate::{AccumulatorHash, StateHash};
+use crate::{
+    AccumulatorHash, LedgerHashes, LedgerPayloadHash, LedgerTransactionReceipt, ReceiptHash,
+    StateHash, TransactionHash,
+};
 use im::hashmap::HashMap as ImmutableHashMap;
 use lazy_static::lazy_static;
 use radix_engine::ledger::{OutputValue, ReadableSubstateStore};
@@ -91,9 +94,10 @@ pub struct ExecutionCache {
 }
 
 pub struct ProcessedResult {
-    state_hash: StateHash,
+    /// Raw transaction receipt.
     receipt: TransactionReceipt,
-    hash_tree_diff: HashTreeDiff,
+    /// The processing results, applicable only for committed transactions (i.e. not rejected).
+    committed_results: Option<(LedgerHashes, HashTreeDiff)>,
 }
 
 #[derive(Clone)]
@@ -117,6 +121,7 @@ impl ExecutionCache {
         root_store: &S,
         state_version: Option<Version>,
         parent_hash: &AccumulatorHash,
+        transaction_hash: &LedgerPayloadHash,
         new_hash: &AccumulatorHash,
         transaction: T,
     ) -> &ProcessedResult {
@@ -127,8 +132,12 @@ impl ExecutionCache {
                 let staged_store =
                     StagedStore::new(root_store, self.stage_tree.get_accumulator(&parent_key));
                 let receipt = transaction(&staged_store);
-                let processed =
-                    ProcessedResult::from_processed(receipt, state_version, &staged_store);
+                let processed = ProcessedResult::from_processed(
+                    transaction_hash,
+                    receipt,
+                    state_version,
+                    &staged_store,
+                );
                 let new_key = self.stage_tree.new_child_node(parent_key, processed);
                 self.key_to_accumulator_hash.insert(new_key, *new_hash);
                 self.accumulator_hash_to_key.insert(*new_hash, new_key);
@@ -235,35 +244,29 @@ lazy_static! {
 }
 
 impl ProcessedResult {
-    fn from_processed<S: ReadableTreeStore>(
+    pub fn from_processed<S: ReadableTreeStore>(
+        transaction_hash: &LedgerPayloadHash,
         transaction_receipt: TransactionReceipt,
         state_version: Option<Version>,
         store: &S,
     ) -> ProcessedResult {
-        // TODO: currently, only the hashes of changed (or created) substates are tracked, since
-        // the hash tree wants to stay consistent with the substate store (which does not support
-        // deletes yet). The underlying JMT implementation already supports deletion - and to use
-        // it, we simply can include `down_substates` with `None` hashes in the vector below.
-        let hash_changes = match &transaction_receipt.result {
-            TransactionResult::Commit(commit) => commit
-                .state_updates
-                .up_substates
-                .iter()
-                .map(|(id, value)| {
-                    (
-                        id.clone(),
-                        Some(hash(scrypto_encode(&value.substate).unwrap())),
-                    )
-                })
-                .collect::<Vec<(SubstateId, Option<Hash>)>>(),
-            TransactionResult::Reject(_) | TransactionResult::Abort(_) => Vec::new(),
-        };
-        let mut collector = CollectingTreeStore::new(store);
-        let root_hash = put_at_next_version(&mut collector, state_version, &hash_changes);
+        let ledger_receipt = LedgerTransactionReceipt::try_from(transaction_receipt.clone()).ok();
+        let committed_results = ledger_receipt.map(|ledger_receipt| {
+            let state_diff = Self::extract_state_diff(&transaction_receipt);
+            let (state_tree_root_hash, state_tree_diff) =
+                Self::compute_state_tree_update(store, state_version, state_diff);
+            let ledger_hashes = LedgerHashes {
+                state_root: StateHash::from(state_tree_root_hash),
+                // TODO(wip): the values below are currently placeholders; they should be computed
+                // and returned together with "update slices" of their respective merkle trees.
+                transaction_root: TransactionHash::from_raw_bytes(transaction_hash.into_bytes()),
+                receipt_root: ReceiptHash::from_raw_bytes(ledger_receipt.get_hash().into_bytes()),
+            };
+            (ledger_hashes, state_tree_diff)
+        });
         Self {
-            state_hash: StateHash::from(root_hash),
             receipt: transaction_receipt,
-            hash_tree_diff: collector.diff,
+            committed_results,
         }
     }
 
@@ -272,25 +275,64 @@ impl ProcessedResult {
     }
 
     pub fn state_diff(&self) -> &StateDiff {
-        if let TransactionResult::Commit(commit) = &self.receipt.result {
+        Self::extract_state_diff(&self.receipt)
+    }
+
+    pub fn ledger_hashes(&self) -> &LedgerHashes {
+        &self.committed_results().0
+    }
+
+    pub fn hash_tree_diff(&self) -> &HashTreeDiff {
+        &self.committed_results().1
+    }
+
+    fn committed_results(&self) -> &(LedgerHashes, HashTreeDiff) {
+        self.committed_results
+            .as_ref()
+            .expect("available only for committed transactions")
+    }
+
+    fn extract_state_diff(receipt: &TransactionReceipt) -> &StateDiff {
+        if let TransactionResult::Commit(commit) = &receipt.result {
             &commit.state_updates
         } else {
             &EMPTY_STATE_DIFF
         }
     }
 
-    pub fn hash_tree_diff(&self) -> &HashTreeDiff {
-        &self.hash_tree_diff
-    }
-
-    pub fn state_hash(&self) -> &StateHash {
-        &self.state_hash
+    fn compute_state_tree_update<S: ReadableTreeStore>(
+        store: &S,
+        state_version: Option<Version>,
+        state_diff: &StateDiff,
+    ) -> (Hash, HashTreeDiff) {
+        // TODO: currently, only the hashes of changed (or created) substates are tracked, since
+        // the hash tree wants to stay consistent with the substate store (which does not support
+        // deletes yet). The underlying JMT implementation already supports deletion - and to use
+        // it, we simply can include `down_substates` with `None` hashes in the vector below.
+        let hash_changes = state_diff
+            .up_substates
+            .iter()
+            .map(|(id, value)| {
+                (
+                    id.clone(),
+                    Some(hash(scrypto_encode(&value.substate).unwrap())),
+                )
+            })
+            .collect::<Vec<(SubstateId, Option<Hash>)>>();
+        let mut collector = CollectingTreeStore::new(store);
+        let root_hash = put_at_next_version(&mut collector, state_version, &hash_changes);
+        (root_hash, collector.diff)
     }
 }
 
 impl Delta for ProcessedResult {
     fn weight(&self) -> usize {
-        self.state_diff().up_substates.len() + self.hash_tree_diff().new_hash_tree_nodes.len()
+        let state_diff_weight = self.state_diff().up_substates.len();
+        let hash_tree_diff_weight = self
+            .committed_results
+            .as_ref()
+            .map(|results| results.1.new_hash_tree_nodes.len());
+        state_diff_weight + hash_tree_diff_weight.unwrap_or(0)
     }
 }
 
@@ -325,13 +367,10 @@ impl Accumulator<ProcessedResult> for ImmutableStore {
                 .iter()
                 .map(|(id, value)| (id.clone(), value.clone())),
         );
-        self.hash_tree_nodes.extend(
-            processed
-                .hash_tree_diff()
-                .new_hash_tree_nodes
-                .iter()
-                .cloned(),
-        );
+        if let Some((_, hash_tree_diff)) = &processed.committed_results {
+            self.hash_tree_nodes
+                .extend(hash_tree_diff.new_hash_tree_nodes.iter().cloned());
+        }
     }
 
     fn constant_clone(&self) -> Self {

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -62,7 +62,9 @@
  * permissions under this License.
  */
 
-use crate::{jni::mempool::JavaHashCode, transaction::LedgerTransaction};
+use crate::{
+    jni::common_types::JavaHashCode, transaction::LedgerTransaction, LedgerTransactionReceipt,
+};
 use radix_engine::blueprints::epoch_manager::Validator;
 use radix_engine::types::*;
 use std::collections::BTreeMap;
@@ -99,6 +101,12 @@ impl AccumulatorHash {
 impl AsRef<[u8]> for AccumulatorHash {
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl From<JavaHashCode> for AccumulatorHash {
+    fn from(java_hash_code: JavaHashCode) -> Self {
+        AccumulatorHash::from_raw_bytes(java_hash_code.into_bytes())
     }
 }
 
@@ -162,12 +170,6 @@ impl From<Hash> for LedgerPayloadHash {
     }
 }
 
-impl From<JavaHashCode> for AccumulatorHash {
-    fn from(java_hash_code: JavaHashCode) -> Self {
-        AccumulatorHash::from_raw_bytes(java_hash_code.0.as_slice().try_into().unwrap())
-    }
-}
-
 impl fmt::Display for LedgerPayloadHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))
@@ -197,6 +199,54 @@ impl HasLedgerPayloadHash for NotarizedTransaction {
         // Could optimize this to remove the clone in future,
         // once SBOR/models are more stable
         LedgerTransaction::User(self.clone()).ledger_payload_hash()
+    }
+}
+
+#[derive(
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Copy,
+    PartialOrd,
+    Ord,
+    ScryptoCategorize,
+    ScryptoEncode,
+    ScryptoDecode,
+)]
+pub struct LedgerReceiptHash([u8; Self::LENGTH]);
+
+impl LedgerReceiptHash {
+    pub const LENGTH: usize = 32;
+
+    pub fn for_receipt(receipt: &LedgerTransactionReceipt) -> Self {
+        Self::for_receipt_bytes(&scrypto_encode(receipt).unwrap())
+    }
+
+    pub fn for_receipt_bytes(ledger_receipt_bytes: &[u8]) -> Self {
+        Self(blake2b_256_hash(ledger_receipt_bytes).0)
+    }
+
+    pub fn from_raw_bytes(hash_bytes: [u8; Self::LENGTH]) -> Self {
+        Self(hash_bytes)
+    }
+
+    pub fn into_bytes(self) -> [u8; Self::LENGTH] {
+        self.0
+    }
+}
+
+impl fmt::Display for LedgerReceiptHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
+    }
+}
+
+impl fmt::Debug for LedgerReceiptHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("LedgerReceiptHash")
+            .field(&hex::encode(self.0))
+            .finish()
     }
 }
 
@@ -428,6 +478,95 @@ impl fmt::Debug for StateHash {
     }
 }
 
+#[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Categorize, Encode, Decode)]
+pub struct TransactionHash([u8; Self::LENGTH]);
+
+impl TransactionHash {
+    pub const LENGTH: usize = 32;
+
+    pub fn from_raw_bytes(hash_bytes: [u8; Self::LENGTH]) -> Self {
+        Self(hash_bytes)
+    }
+
+    pub fn into_bytes(self) -> [u8; Self::LENGTH] {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for TransactionHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Hash> for TransactionHash {
+    fn from(hash: Hash) -> Self {
+        Self(hash.0)
+    }
+}
+
+impl fmt::Display for TransactionHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
+    }
+}
+
+impl fmt::Debug for TransactionHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TransactionHash")
+            .field(&hex::encode(self.0))
+            .finish()
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Categorize, Encode, Decode)]
+pub struct ReceiptHash([u8; Self::LENGTH]);
+
+impl ReceiptHash {
+    pub const LENGTH: usize = 32;
+
+    pub fn from_raw_bytes(hash_bytes: [u8; Self::LENGTH]) -> Self {
+        Self(hash_bytes)
+    }
+
+    pub fn into_bytes(self) -> [u8; Self::LENGTH] {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for ReceiptHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Hash> for ReceiptHash {
+    fn from(hash: Hash) -> Self {
+        Self(hash.0)
+    }
+}
+
+impl fmt::Display for ReceiptHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
+    }
+}
+
+impl fmt::Debug for ReceiptHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ReceiptHash")
+            .field(&hex::encode(self.0))
+            .finish()
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Debug, Categorize, Encode, Decode)]
+pub struct LedgerHashes {
+    pub state_root: StateHash,
+    pub transaction_root: TransactionHash,
+    pub receipt_root: ReceiptHash,
+}
+
 /// An uncommitted user transaction, in eg the mempool
 #[derive(Debug, PartialEq, Eq, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PendingTransaction {
@@ -499,7 +638,7 @@ pub struct PrepareResult {
     pub committed: Vec<Vec<u8>>,
     pub rejected: Vec<(Vec<u8>, String)>,
     pub next_epoch: Option<NextEpoch>,
-    pub state_hash: StateHash,
+    pub ledger_hashes: LedgerHashes,
 }
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -516,5 +655,5 @@ pub struct PrepareGenesisRequest {
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PrepareGenesisResult {
     pub validator_set: Option<BTreeMap<ComponentAddress, Validator>>,
-    pub state_hash: StateHash,
+    pub ledger_hashes: LedgerHashes,
 }

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/OneByzantineGenesisTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/OneByzantineGenesisTest.java
@@ -68,6 +68,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.radixdlt.consensus.EpochNodeWeightMapping;
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.MockedEpochsConsensusRecoveryModule;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.crypto.HashUtils;
@@ -109,7 +110,7 @@ public class OneByzantineGenesisTest {
                         Round.of(1000000),
                         EpochNodeWeightMapping.constant(3, 1),
                         HashUtils.random256(),
-                        HashUtils.random256()))
+                        LedgerHashes.zero()))
             .addTestModules(ConsensusMonitors.noneCommitted())
             .build();
 

--- a/core/src/main/java/com/radixdlt/consensus/LedgerHashes.java
+++ b/core/src/main/java/com/radixdlt/consensus/LedgerHashes.java
@@ -97,11 +97,7 @@ public final class LedgerHashes {
   private final HashCode transactionRoot;
 
   @JsonProperty("receipt_root")
-  // TODO: restore `Output.ALL` after fixing non-determinism bugs
-  // The test `REv2ConsensusLedgerRecoveryTest.recovery_should_work_when_consensus_is_behind_ledger`
-  // fails when the receipt root is taken into account, which suggests that nodes can end up with
-  // different receipts in some special cases. We need to investigate and fix it.
-  @DsonOutput(value = DsonOutput.Output.HASH, include = false)
+  @DsonOutput(DsonOutput.Output.ALL)
   private final HashCode receiptRoot;
 
   @JsonCreator

--- a/core/src/main/java/com/radixdlt/consensus/LedgerHashes.java
+++ b/core/src/main/java/com/radixdlt/consensus/LedgerHashes.java
@@ -62,22 +62,99 @@
  * permissions under this License.
  */
 
-package com.radixdlt.statecomputer.commit;
+package com.radixdlt.consensus;
 
-import com.radixdlt.lang.Option;
-import com.radixdlt.lang.Tuple;
-import com.radixdlt.sbor.codec.CodecMap;
-import com.radixdlt.sbor.codec.StructCodec;
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.hash.HashCode;
+import com.radixdlt.crypto.HashUtils;
+import com.radixdlt.serialization.DsonOutput;
+import com.radixdlt.serialization.SerializerConstants;
+import com.radixdlt.serialization.SerializerDummy;
+import com.radixdlt.serialization.SerializerId2;
+import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
 
-public record PrepareResult(
-    List<byte[]> committed,
-    List<Tuple.Tuple2<byte[], String>> rejected,
-    Option<NextEpoch> nextEpoch,
-    LedgerHashes ledgerHashes) {
-  public static void registerCodec(CodecMap codecMap) {
-    codecMap.register(
-        PrepareResult.class,
-        codecs -> StructCodec.fromRecordComponents(PrepareResult.class, codecs));
+@Immutable
+@SerializerId2("consensus.ledger_hashes")
+public final class LedgerHashes {
+  @JsonProperty(SerializerConstants.SERIALIZER_NAME)
+  @DsonOutput(value = {DsonOutput.Output.API, DsonOutput.Output.WIRE, DsonOutput.Output.PERSIST})
+  SerializerDummy serializer = SerializerDummy.DUMMY;
+
+  @JsonProperty("state_root")
+  // TODO: restore `Output.ALL` after fixing non-determinism bugs
+  // We need to come up with a few tests that expose potential non-determinism bugs, and then fix
+  // them. Before that happens, it could be risky to include the state hash in the DSON-based
+  // hashing (used e.g. in `QuorumCertificate` to get a hash of `VoteData`, leading to nodes not
+  // being able to agree on the same hash).
+  @DsonOutput(value = DsonOutput.Output.HASH, include = false)
+  private final HashCode stateRoot;
+
+  @JsonProperty("transaction_root")
+  @DsonOutput(DsonOutput.Output.ALL)
+  private final HashCode transactionRoot;
+
+  @JsonProperty("receipt_root")
+  // TODO: restore `Output.ALL` after fixing non-determinism bugs
+  // The test `REv2ConsensusLedgerRecoveryTest.recovery_should_work_when_consensus_is_behind_ledger`
+  // fails when the receipt root is taken into account, which suggests that nodes can end up with
+  // different receipts in some special cases. We need to investigate and fix it.
+  @DsonOutput(value = DsonOutput.Output.HASH, include = false)
+  private final HashCode receiptRoot;
+
+  @JsonCreator
+  @VisibleForTesting
+  LedgerHashes(
+      @JsonProperty(value = "state_root", required = true) HashCode stateRoot,
+      @JsonProperty(value = "transaction_root", required = true) HashCode transactionRoot,
+      @JsonProperty(value = "receipt_root", required = true) HashCode receiptRoot) {
+    this.stateRoot = stateRoot;
+    this.transactionRoot = transactionRoot;
+    this.receiptRoot = receiptRoot;
+  }
+
+  public static LedgerHashes create(
+      HashCode stateRoot, HashCode transactionRoot, HashCode receiptRoot) {
+    return new LedgerHashes(stateRoot, transactionRoot, receiptRoot);
+  }
+
+  public static LedgerHashes zero() {
+    return create(HashUtils.zero256(), HashUtils.zero256(), HashUtils.zero256());
+  }
+
+  public HashCode getStateRoot() {
+    return stateRoot;
+  }
+
+  public HashCode getTransactionRoot() {
+    return transactionRoot;
+  }
+
+  public HashCode getReceiptRoot() {
+    return receiptRoot;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    return object instanceof LedgerHashes other
+        && stateRoot.equals(other.stateRoot)
+        && transactionRoot.equals(other.transactionRoot)
+        && receiptRoot.equals(other.receiptRoot);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stateRoot, transactionRoot, receiptRoot);
+  }
+
+  @Override
+  public String toString() {
+    return "%s{stateRoot=%s, transactionRoot=%s, receiptRoot=%s}"
+        .formatted(LedgerHashes.class.getSimpleName(), stateRoot, transactionRoot, receiptRoot);
   }
 }

--- a/core/src/main/java/com/radixdlt/consensus/LedgerProof.java
+++ b/core/src/main/java/com/radixdlt/consensus/LedgerProof.java
@@ -118,7 +118,7 @@ public final class LedgerProof {
 
   public static LedgerProof mockAtStateVersion(long stateVersion) {
     final var acc = new AccumulatorState(stateVersion, HashUtils.zero256());
-    final var header = LedgerHeader.create(0, Round.genesis(), acc, HashUtils.zero256(), 0, 0);
+    final var header = LedgerHeader.create(0, Round.genesis(), acc, LedgerHashes.zero(), 0, 0);
     return new LedgerProof(HashUtils.zero256(), header, new TimestampedECDSASignatures());
   }
 
@@ -128,14 +128,14 @@ public final class LedgerProof {
 
   public static LedgerProof genesis(
       AccumulatorState accumulatorState,
-      HashCode stateHash,
+      LedgerHashes ledgerHashes,
       BFTValidatorSet nextValidators,
       long consensusParentRoundTimestamp,
       long ledgerTimestamp) {
     var genesisLedgerHeader =
         LedgerHeader.genesis(
             accumulatorState,
-            stateHash,
+            ledgerHashes,
             nextValidators,
             consensusParentRoundTimestamp,
             ledgerTimestamp);
@@ -192,8 +192,8 @@ public final class LedgerProof {
     return ledgerHeader.getAccumulatorState();
   }
 
-  public HashCode getStateHash() {
-    return ledgerHeader.getStateHash();
+  public LedgerHashes getLedgerHashes() {
+    return ledgerHeader.getHashes();
   }
 
   // TODO: Remove

--- a/core/src/main/java/com/radixdlt/consensus/vertexstore/VertexStoreState.java
+++ b/core/src/main/java/com/radixdlt/consensus/vertexstore/VertexStoreState.java
@@ -127,7 +127,7 @@ public final class VertexStoreState {
             nextEpoch.getEpoch(),
             Round.genesis(),
             epochProof.getAccumulatorState(),
-            epochProof.getStateHash(),
+            epochProof.getLedgerHashes(),
             epochProof.consensusParentRoundTimestamp(),
             epochProof.proposerTimestamp());
     final var initialEpochQC =

--- a/core/src/main/java/com/radixdlt/ledger/MockedLedgerRecoveryModule.java
+++ b/core/src/main/java/com/radixdlt/ledger/MockedLedgerRecoveryModule.java
@@ -79,7 +79,7 @@ public class MockedLedgerRecoveryModule extends AbstractModule {
   @LastEpochProof
   public LedgerProof lastEpochProof(BFTValidatorSet validatorSet) {
     var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
-    return LedgerProof.genesis(accumulatorState, HashUtils.zero256(), validatorSet, 0, 0);
+    return LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), validatorSet, 0, 0);
   }
 
   @Provides

--- a/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
+++ b/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
@@ -95,32 +95,32 @@ public final class StateComputerLedger implements Ledger, ProposalGenerator {
     private final List<ExecutedTransaction> executedTransactions;
     private final Map<RawNotarizedTransaction, Exception> failedTransactions;
     private final NextEpoch nextEpoch;
-    private final HashCode stateHash;
+    private final LedgerHashes ledgerHashes;
 
     public StateComputerResult(
         List<ExecutedTransaction> executedTransactions,
         Map<RawNotarizedTransaction, Exception> failedTransactions,
         NextEpoch nextEpoch,
-        HashCode stateHash) {
+        LedgerHashes ledgerHashes) {
       this.executedTransactions = Objects.requireNonNull(executedTransactions);
       this.failedTransactions = Objects.requireNonNull(failedTransactions);
       this.nextEpoch = nextEpoch;
-      this.stateHash = stateHash;
+      this.ledgerHashes = ledgerHashes;
     }
 
     public StateComputerResult(
         List<ExecutedTransaction> executedTransactions,
         Map<RawNotarizedTransaction, Exception> failedTransactions,
-        HashCode stateHash) {
-      this(executedTransactions, failedTransactions, null, stateHash);
+        LedgerHashes ledgerHashes) {
+      this(executedTransactions, failedTransactions, null, ledgerHashes);
     }
 
     public Optional<NextEpoch> getNextEpoch() {
       return Optional.ofNullable(nextEpoch);
     }
 
-    public HashCode getStateHash() {
-      return stateHash;
+    public LedgerHashes getLedgerHashes() {
+      return ledgerHashes;
     }
 
     public List<ExecutedTransaction> getSuccessfullyExecutedTransactions() {
@@ -310,7 +310,7 @@ public final class StateComputerLedger implements Ledger, ProposalGenerator {
               parentHeader.getEpoch(),
               vertex.getRound(),
               accumulatorState,
-              result.getStateHash(),
+              result.getLedgerHashes(),
               vertex.getQCToParent().getWeightedTimestampOfSignatures(),
               vertex.proposerTimestamp(),
               result.getNextEpoch().orElse(null));

--- a/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
@@ -264,9 +264,9 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
                     roundDetails, rejected, exception)));
 
     var nextEpoch = result.nextEpoch().map(REv2ToConsensus::nextEpoch).or((NextEpoch) null);
-
+    var ledgerHashes = REv2ToConsensus.ledgerHashes(result.ledgerHashes());
     return new StateComputerLedger.StateComputerResult(
-        committableTransactions, rejectedTransactions, nextEpoch, result.stateHash());
+        committableTransactions, rejectedTransactions, nextEpoch, ledgerHashes);
   }
 
   @Override
@@ -284,7 +284,7 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
         new CommitRequest(
             txnsAndProof.getTransactions(),
             UInt64.fromNonNegativeLong(proof.getStateVersion()),
-            proof.getStateHash(),
+            proof.getLedgerHashes().getStateRoot(),
             serialization.toDson(proof, DsonOutput.Output.ALL),
             vertexStoreBytes);
 

--- a/core/src/main/java/com/radixdlt/rev2/REv2ToConsensus.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2ToConsensus.java
@@ -65,6 +65,7 @@
 package com.radixdlt.rev2;
 
 import com.google.common.collect.ImmutableSet;
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.NextEpoch;
 import com.radixdlt.consensus.bft.BFTValidator;
 import com.radixdlt.consensus.bft.BFTValidatorId;
@@ -96,5 +97,11 @@ public final class REv2ToConsensus {
             .map(e -> REv2ToConsensus.validator(e.getKey(), e.getValue()))
             .collect(ImmutableSet.toImmutableSet());
     return NextEpoch.create(nextEpoch.epoch().toNonNegativeLong().unwrap(), validators);
+  }
+
+  public static LedgerHashes ledgerHashes(
+      com.radixdlt.statecomputer.commit.LedgerHashes ledgerHashes) {
+    return LedgerHashes.create(
+        ledgerHashes.stateRoot(), ledgerHashes.transactionRoot(), ledgerHashes.receiptRoot());
   }
 }

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2LedgerRecoveryModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2LedgerRecoveryModule.java
@@ -126,14 +126,15 @@ public final class REv2LedgerRecoveryModule extends AbstractModule {
                       .or((BFTValidatorSet) null);
               var accumulatorState =
                   ledgerAccumulator.accumulate(initialAccumulatorState, genesis.getPayloadHash());
+              var ledgerHashes = REv2ToConsensus.ledgerHashes(result.ledgerHashes());
               var proof =
                   LedgerProof.genesis(
-                      accumulatorState, result.stateHash(), validatorSet, timestamp, timestamp);
+                      accumulatorState, ledgerHashes, validatorSet, timestamp, timestamp);
               var commitRequest =
                   new CommitRequest(
                       List.of(genesis),
                       UInt64.fromNonNegativeLong(proof.getStateVersion()),
-                      proof.getStateHash(),
+                      proof.getLedgerHashes().getStateRoot(),
                       serialization.toDson(proof, DsonOutput.Output.ALL),
                       Option.none());
               var commitResult = stateComputer.commit(commitRequest);

--- a/core/src/test-core/java/com/radixdlt/consensus/MockedEpochsConsensusRecoveryModule.java
+++ b/core/src/test-core/java/com/radixdlt/consensus/MockedEpochsConsensusRecoveryModule.java
@@ -86,7 +86,7 @@ import java.util.function.Function;
 public class MockedEpochsConsensusRecoveryModule extends AbstractModule {
 
   private final HashCode preGenesisAccumulatorHash;
-  private final HashCode preGenesisStateHash;
+  private final LedgerHashes preGenesisLedgerHashes;
   private final Round epochMaxRound;
   private final EpochNodeWeightMapping epochNodeWeightMapping;
 
@@ -94,11 +94,11 @@ public class MockedEpochsConsensusRecoveryModule extends AbstractModule {
       Round epochMaxRound,
       EpochNodeWeightMapping epochNodeWeightMapping,
       HashCode preGenesisAccumulatorHash,
-      HashCode preGenesisStateHash) {
+      LedgerHashes preGenesisLedgerHashes) {
     this.epochMaxRound = epochMaxRound;
     this.epochNodeWeightMapping = epochNodeWeightMapping;
     this.preGenesisAccumulatorHash = preGenesisAccumulatorHash;
-    this.preGenesisStateHash = preGenesisStateHash;
+    this.preGenesisLedgerHashes = preGenesisLedgerHashes;
   }
 
   public MockedEpochsConsensusRecoveryModule(
@@ -106,7 +106,7 @@ public class MockedEpochsConsensusRecoveryModule extends AbstractModule {
     this.epochMaxRound = epochMaxRound;
     this.epochNodeWeightMapping = epochNodeWeightMapping;
     this.preGenesisAccumulatorHash = HashUtils.zero256();
-    this.preGenesisStateHash = HashUtils.zero256();
+    this.preGenesisLedgerHashes = LedgerHashes.zero();
   }
 
   @Override
@@ -150,14 +150,14 @@ public class MockedEpochsConsensusRecoveryModule extends AbstractModule {
     VertexWithHash genesisVertex =
         Vertex.createInitialEpochVertex(
                 LedgerHeader.genesis(
-                    accumulatorState, this.preGenesisStateHash, validatorSet, 0, 0))
+                    accumulatorState, this.preGenesisLedgerHashes, validatorSet, 0, 0))
             .withId(hasher);
     LedgerHeader nextLedgerHeader =
         LedgerHeader.create(
             proof.getNextEpoch().orElseThrow().getEpoch(),
             Round.genesis(),
             proof.getAccumulatorState(),
-            proof.getStateHash(),
+            proof.getLedgerHashes(),
             proof.consensusParentRoundTimestamp(),
             proof.proposerTimestamp());
     final var initialEpochQC =

--- a/core/src/test-core/java/com/radixdlt/consensus/MockedNoEpochsConsensusRecoveryModule.java
+++ b/core/src/test-core/java/com/radixdlt/consensus/MockedNoEpochsConsensusRecoveryModule.java
@@ -111,14 +111,14 @@ public final class MockedNoEpochsConsensusRecoveryModule extends AbstractModule 
     var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
     VertexWithHash genesisVertex =
         Vertex.createInitialEpochVertex(
-                LedgerHeader.genesis(accumulatorState, HashUtils.zero256(), validatorSet, 0, 0))
+                LedgerHeader.genesis(accumulatorState, LedgerHashes.zero(), validatorSet, 0, 0))
             .withId(hasher);
     LedgerHeader nextLedgerHeader =
         LedgerHeader.create(
             proof.getNextEpoch().orElseThrow().getEpoch(),
             Round.genesis(),
             proof.getAccumulatorState(),
-            proof.getStateHash(),
+            proof.getLedgerHashes(),
             proof.consensusParentRoundTimestamp(),
             proof.proposerTimestamp());
     final var initialEpochQC =

--- a/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
@@ -366,7 +366,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         withEpochs.epochMaxRound(),
                         withEpochs.mapping(),
                         withEpochs.preGenesisAccumulatorHash(),
-                        withEpochs.preGenesisStateHash()));
+                        withEpochs.preGenesisLedgerHashes()));
               }
             }
           }
@@ -398,7 +398,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                           Vertex.createInitialEpochVertex(
                                   LedgerHeader.genesis(
                                       initialAccumulatorState,
-                                      HashUtils.zero256(),
+                                      LedgerHashes.zero(),
                                       validatorSet,
                                       0,
                                       0))
@@ -408,7 +408,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                               proof.getNextEpoch().orElseThrow().getEpoch(),
                               Round.genesis(),
                               proof.getAccumulatorState(),
-                              proof.getStateHash(),
+                              proof.getLedgerHashes(),
                               proof.consensusParentRoundTimestamp(),
                               proof.proposerTimestamp());
                       var initialEpochQC =

--- a/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
+++ b/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
@@ -66,6 +66,7 @@ package com.radixdlt.modules;
 
 import com.google.common.hash.HashCode;
 import com.radixdlt.consensus.EpochNodeWeightMapping;
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.consensus.liveness.ProposalGenerator;
 import com.radixdlt.crypto.HashUtils;
@@ -85,17 +86,17 @@ public sealed interface StateComputerConfig {
   static StateComputerConfig mockedWithEpochs(
       Round epochMaxRound, EpochNodeWeightMapping mapping, MockedMempoolConfig mempoolType) {
     return new MockedStateComputerConfigWithEpochs(
-        epochMaxRound, mapping, HashUtils.zero256(), HashUtils.zero256(), mempoolType);
+        epochMaxRound, mapping, HashUtils.zero256(), LedgerHashes.zero(), mempoolType);
   }
 
   static StateComputerConfig mockedWithEpochs(
       Round epochMaxRound,
       EpochNodeWeightMapping mapping,
       HashCode preGenesisAccumulatorHash,
-      HashCode preGenesisStateHash,
+      LedgerHashes preGenesisLedgerHashes,
       MockedMempoolConfig mempoolType) {
     return new MockedStateComputerConfigWithEpochs(
-        epochMaxRound, mapping, preGenesisAccumulatorHash, preGenesisStateHash, mempoolType);
+        epochMaxRound, mapping, preGenesisAccumulatorHash, preGenesisLedgerHashes, mempoolType);
   }
 
   static StateComputerConfig mockedNoEpochs(int numValidators, MockedMempoolConfig mempoolType) {
@@ -140,7 +141,7 @@ public sealed interface StateComputerConfig {
       Round epochMaxRound,
       EpochNodeWeightMapping mapping,
       HashCode preGenesisAccumulatorHash,
-      HashCode preGenesisStateHash,
+      LedgerHashes preGenesisLedgerHashes,
       MockedMempoolConfig mempoolType)
       implements MockedStateComputerConfig {
     @Override

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
@@ -67,9 +67,9 @@ package com.radixdlt.statecomputer;
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.hash.HashCode;
 import com.google.inject.*;
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.vertexstore.ExecutedVertex;
 import com.radixdlt.consensus.vertexstore.VertexStoreState;
-import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.ledger.CommittedTransactionsWithProof;
 import com.radixdlt.ledger.LedgerUpdate;
@@ -156,7 +156,7 @@ public class MockedMempoolStateComputerModule extends AbstractModule {
                 .map(tx -> new MockExecuted(tx.INCORRECTInterpretDirectlyAsRawLedgerTransaction()))
                 .collect(Collectors.toList()),
             Map.of(),
-            HashUtils.zero256());
+            LedgerHashes.zero());
       }
 
       @Override

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputerWithEpochs.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedStateComputerWithEpochs.java
@@ -67,12 +67,12 @@ package com.radixdlt.statecomputer;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.HashCode;
 import com.google.inject.Inject;
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.NextEpoch;
 import com.radixdlt.consensus.bft.*;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.consensus.vertexstore.ExecutedVertex;
 import com.radixdlt.consensus.vertexstore.VertexStoreState;
-import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.crypto.Hasher;
 import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.ledger.CommittedTransactionsWithProof;
@@ -131,7 +131,7 @@ public final class MockedStateComputerWithEpochs implements StateComputer {
           NextEpoch.create(
               roundDetails.epoch() + 1,
               validatorSetMapping.apply(roundDetails.epoch() + 1).getValidators()),
-          HashUtils.zero256());
+          LedgerHashes.zero());
     } else {
       return stateComputer.prepare(
           parentAccumulator, previousVertices, proposedTransactions, roundDetails);

--- a/core/src/test-core/java/com/radixdlt/statecomputer/StatelessComputer.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/StatelessComputer.java
@@ -73,7 +73,6 @@ import com.radixdlt.consensus.epoch.EpochChange;
 import com.radixdlt.consensus.liveness.WeightedRotatingLeaders;
 import com.radixdlt.consensus.vertexstore.ExecutedVertex;
 import com.radixdlt.consensus.vertexstore.VertexStoreState;
-import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.crypto.Hasher;
 import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.ledger.CommittedTransactionsWithProof;
@@ -152,7 +151,7 @@ public final class StatelessComputer implements StateComputerLedger.StateCompute
     invalidCount += invalidTransactions.size();
 
     return new StateComputerLedger.StateComputerResult(
-        successfulTransactions, invalidTransactions, HashUtils.zero256());
+        successfulTransactions, invalidTransactions, LedgerHashes.zero());
   }
 
   private LedgerUpdate generateLedgerUpdate(CommittedTransactionsWithProof txnsAndProof) {
@@ -162,17 +161,17 @@ public final class StatelessComputer implements StateComputerLedger.StateCompute
             .getNextEpoch()
             .map(
                 nextEpoch -> {
-                  LedgerProof header = txnsAndProof.getProof();
+                  LedgerProof proof = txnsAndProof.getProof();
                   VertexWithHash genesisVertex =
-                      Vertex.createInitialEpochVertex(header.getHeader()).withId(hasher);
+                      Vertex.createInitialEpochVertex(proof.getHeader()).withId(hasher);
                   LedgerHeader nextLedgerHeader =
                       LedgerHeader.create(
                           nextEpoch.getEpoch(),
                           Round.genesis(),
-                          header.getAccumulatorState(),
-                          header.getStateHash(),
-                          header.consensusParentRoundTimestamp(),
-                          header.proposerTimestamp());
+                          proof.getAccumulatorState(),
+                          proof.getLedgerHashes(),
+                          proof.consensusParentRoundTimestamp(),
+                          proof.proposerTimestamp());
                   QuorumCertificate initialEpochQC =
                       QuorumCertificate.createInitialEpochQC(genesisVertex, nextLedgerHeader);
                   final var initialState =
@@ -182,7 +181,7 @@ public final class StatelessComputer implements StateComputerLedger.StateCompute
                   var proposerElection = new WeightedRotatingLeaders(validatorSet);
                   var bftConfiguration =
                       new BFTConfiguration(proposerElection, validatorSet, initialState);
-                  return new EpochChange(header, bftConfiguration);
+                  return new EpochChange(proof, bftConfiguration);
                 })
             .map(e -> ImmutableClassToInstanceMap.<Object, EpochChange>of(EpochChange.class, e))
             .orElse(ImmutableClassToInstanceMap.of());

--- a/core/src/test-core/java/com/radixdlt/sync/SometimesByzantineCommittedReader.java
+++ b/core/src/test-core/java/com/radixdlt/sync/SometimesByzantineCommittedReader.java
@@ -172,7 +172,7 @@ public final class SometimesByzantineCommittedReader implements TransactionsAndP
               base.getProof().getEpoch(),
               base.getProof().getRound(),
               accumulatorState,
-              base.getProof().getStateHash(),
+              base.getProof().getLedgerHashes(),
               base.getProof().consensusParentRoundTimestamp(),
               base.getProof().proposerTimestamp(),
               base.getProof()

--- a/core/src/test/java/com/radixdlt/benchmark/TxnCommitAndReadBenchmarkTest.java
+++ b/core/src/test/java/com/radixdlt/benchmark/TxnCommitAndReadBenchmarkTest.java
@@ -119,7 +119,7 @@ public final class TxnCommitAndReadBenchmarkTest extends DeterministicCoreApiTes
             new CommitRequest(
                 createUniqueTransactions(NUM_TXNS_IN_A_COMMIT, i),
                 UInt64.fromNonNegativeLong(proof.getStateVersion()),
-                proof.getStateHash(),
+                proof.getLedgerHashes().getStateRoot(),
                 proofBytes,
                 Option.none());
         stateComputer.commit(commitRequest);

--- a/core/src/test/java/com/radixdlt/consensus/LedgerHeaderTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/LedgerHeaderTest.java
@@ -88,7 +88,7 @@ public class LedgerHeaderTest {
     this.accumulatorState = mock(AccumulatorState.class);
     this.ledgerHeader =
         LedgerHeader.create(
-            0, Round.genesis(), accumulatorState, HashUtils.zero256(), timestamp, timestamp);
+            0, Round.genesis(), accumulatorState, LedgerHashes.zero(), timestamp, timestamp);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class LedgerHeaderTest {
         -1L,
         1L,
         mock(AccumulatorState.class),
-        HashUtils.zero256(),
+        LedgerHashes.zero(),
         1L,
         1L,
         NextEpoch.create(1, ImmutableSet.of()));
@@ -129,7 +129,7 @@ public class LedgerHeaderTest {
         1L,
         -1L,
         mock(AccumulatorState.class),
-        HashUtils.zero256(),
+        LedgerHashes.zero(),
         1L,
         1L,
         NextEpoch.create(1, ImmutableSet.of()));
@@ -138,6 +138,6 @@ public class LedgerHeaderTest {
   @Test(expected = NullPointerException.class)
   public void deserializationWithNullAccumulatorStateThrowsException() {
     new LedgerHeader(
-        1L, 1L, null, HashUtils.zero256(), 1L, 1L, NextEpoch.create(1, ImmutableSet.of()));
+        1L, 1L, null, LedgerHashes.zero(), 1L, 1L, NextEpoch.create(1, ImmutableSet.of()));
   }
 }

--- a/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
@@ -157,7 +157,7 @@ public class EpochManagerTest {
             List<ExecutedVertex> previousVertices,
             List<RawNotarizedTransaction> proposedTransactions,
             RoundDetails roundDetails) {
-          return new StateComputerResult(List.of(), Map.of(), HashUtils.zero256());
+          return new StateComputerResult(List.of(), Map.of(), LedgerHashes.zero());
         }
 
         @Override
@@ -263,14 +263,14 @@ public class EpochManagerTest {
       @LastProof
       LedgerProof verifiedLedgerHeaderAndProof(BFTValidatorSet validatorSet) {
         var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
-        return LedgerProof.genesis(accumulatorState, HashUtils.zero256(), validatorSet, 0, 0);
+        return LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), validatorSet, 0, 0);
       }
 
       @Provides
       @LastEpochProof
       LedgerProof lastEpochProof(BFTValidatorSet validatorSet) {
         var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
-        return LedgerProof.genesis(accumulatorState, HashUtils.zero256(), validatorSet, 0, 0);
+        return LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), validatorSet, 0, 0);
       }
 
       @Provides
@@ -279,12 +279,12 @@ public class EpochManagerTest {
         var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
         var vertex =
             Vertex.createInitialEpochVertex(
-                    LedgerHeader.genesis(accumulatorState, HashUtils.zero256(), validatorSet, 0, 0))
+                    LedgerHeader.genesis(accumulatorState, LedgerHashes.zero(), validatorSet, 0, 0))
                 .withId(hasher);
         var qc =
             QuorumCertificate.createInitialEpochQC(
                 vertex,
-                LedgerHeader.genesis(accumulatorState, HashUtils.zero256(), validatorSet, 0, 0));
+                LedgerHeader.genesis(accumulatorState, LedgerHashes.zero(), validatorSet, 0, 0));
         var proposerElection = new WeightedRotatingLeaders(validatorSet);
         return new BFTConfiguration(
             proposerElection,
@@ -313,14 +313,14 @@ public class EpochManagerTest {
         BFTValidatorSet.from(Stream.of(BFTValidator.from(BFTValidatorId.random(), UInt256.ONE)));
     var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
     LedgerHeader header =
-        LedgerHeader.genesis(accumulatorState, HashUtils.zero256(), nextValidatorSet, 0, 0);
+        LedgerHeader.genesis(accumulatorState, LedgerHashes.zero(), nextValidatorSet, 0, 0);
     VertexWithHash verifiedGenesisVertex = Vertex.createInitialEpochVertex(header).withId(hasher);
     LedgerHeader nextLedgerHeader =
         LedgerHeader.create(
             header.getEpoch() + 1,
             Round.genesis(),
             header.getAccumulatorState(),
-            header.getStateHash(),
+            header.getHashes(),
             header.consensusParentRoundTimestamp(),
             header.proposerTimestamp());
     var initialEpochQC =

--- a/core/src/test/java/com/radixdlt/consensus/vertexstore/VertexStoreStateCreationTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/vertexstore/VertexStoreStateCreationTest.java
@@ -86,7 +86,7 @@ public class VertexStoreStateCreationTest {
           0,
           Round.genesis(),
           new AccumulatorState(0, HashUtils.zero256()),
-          HashUtils.zero256(),
+          LedgerHashes.zero(),
           0,
           0);
 

--- a/core/src/test/java/com/radixdlt/consensus/vertexstore/VertexStoreTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/vertexstore/VertexStoreTest.java
@@ -122,7 +122,7 @@ public class VertexStoreTest {
           0,
           Round.genesis(),
           new AccumulatorState(0, HashUtils.zero256()),
-          HashUtils.zero256(),
+          LedgerHashes.zero(),
           0,
           0);
 

--- a/core/src/test/java/com/radixdlt/messaging/ledgersync/SyncRequestMessageSerializeTest.java
+++ b/core/src/test/java/com/radixdlt/messaging/ledgersync/SyncRequestMessageSerializeTest.java
@@ -64,6 +64,7 @@
 
 package com.radixdlt.messaging.ledgersync;
 
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.LedgerProof;
 import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.ledger.AccumulatorState;
@@ -77,6 +78,6 @@ public class SyncRequestMessageSerializeTest extends SerializeMessageObject<Sync
   private static SyncRequestMessage get() {
     var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
     return new SyncRequestMessage(
-        LedgerProof.genesis(accumulatorState, HashUtils.zero256(), null, 0, 0).toDto());
+        LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), null, 0, 0).toDto());
   }
 }

--- a/core/src/test/java/com/radixdlt/messaging/ledgersync/SyncResponseMessageSerializeTest.java
+++ b/core/src/test/java/com/radixdlt/messaging/ledgersync/SyncResponseMessageSerializeTest.java
@@ -65,6 +65,7 @@
 package com.radixdlt.messaging.ledgersync;
 
 import com.google.common.collect.ImmutableList;
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.LedgerProof;
 import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.ledger.AccumulatorState;
@@ -81,7 +82,7 @@ public class SyncResponseMessageSerializeTest extends SerializeMessageObject<Syn
     return new SyncResponseMessage(
         new CommittedTransactionsWithProofDto(
             ImmutableList.of(),
-            LedgerProof.genesis(accumulatorState, HashUtils.zero256(), null, 0, 0).toDto(),
-            LedgerProof.genesis(accumulatorState, HashUtils.zero256(), null, 0, 0).toDto()));
+            LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), null, 0, 0).toDto(),
+            LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), null, 0, 0).toDto()));
   }
 }

--- a/core/src/test/java/com/radixdlt/messaging/p2p/LedgerStatusUpdateMessageSerializeTest.java
+++ b/core/src/test/java/com/radixdlt/messaging/p2p/LedgerStatusUpdateMessageSerializeTest.java
@@ -64,6 +64,7 @@
 
 package com.radixdlt.messaging.p2p;
 
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.LedgerProof;
 import com.radixdlt.crypto.HashUtils;
 import com.radixdlt.ledger.AccumulatorState;
@@ -79,6 +80,6 @@ public class LedgerStatusUpdateMessageSerializeTest
   private static LedgerStatusUpdateMessage get() {
     var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
     return new LedgerStatusUpdateMessage(
-        LedgerProof.genesis(accumulatorState, HashUtils.zero256(), null, 0, 0));
+        LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), null, 0, 0));
   }
 }

--- a/core/src/test/java/com/radixdlt/modules/ConsensusModuleTest.java
+++ b/core/src/test/java/com/radixdlt/modules/ConsensusModuleTest.java
@@ -132,11 +132,11 @@ public class ConsensusModuleTest {
     var accumulatorState = new AccumulatorState(0, HashUtils.zero256());
     var genesisVertex =
         Vertex.createInitialEpochVertex(
-                LedgerHeader.genesis(accumulatorState, HashUtils.zero256(), null, 0, 0))
+                LedgerHeader.genesis(accumulatorState, LedgerHashes.zero(), null, 0, 0))
             .withId(ZeroHasher.INSTANCE);
     var qc =
         QuorumCertificate.createInitialEpochQC(
-            genesisVertex, LedgerHeader.genesis(accumulatorState, HashUtils.zero256(), null, 0, 0));
+            genesisVertex, LedgerHeader.genesis(accumulatorState, LedgerHashes.zero(), null, 0, 0));
     this.validatorKeyPair = ECKeyPair.generateNew();
     this.validatorId = BFTValidatorId.create(this.validatorKeyPair.getPublicKey());
     var validatorSet =
@@ -259,7 +259,7 @@ public class ConsensusModuleTest {
                 1,
                 Round.of(1),
                 new AccumulatorState(1, HashUtils.zero256()),
-                HashUtils.zero256(),
+                LedgerHashes.zero(),
                 1,
                 1));
     final var voteData = new VoteData(next, parent.getProposedHeader(), parent.getParentHeader());

--- a/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
@@ -71,6 +71,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.TypeLiteral;
 import com.radixdlt.consensus.ConsensusByzantineEvent;
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.LedgerProof;
 import com.radixdlt.consensus.bft.BFTValidator;
 import com.radixdlt.consensus.bft.BFTValidatorId;
@@ -126,14 +127,12 @@ public class REv2StateComputerTest {
             1, Decimal.of(1), UInt64.fromNonNegativeLong(10));
     var accumulatorState =
         accumulator.accumulate(initialAccumulatorState, genesis.getPayloadHash());
-    // The accumulator state is computed correctly, but we cannot easily do the same for state hash
-    var stateHash = HashUtils.random256();
     var validatorSet =
         BFTValidatorSet.from(
             PrivateKeys.numeric(1)
                 .map(k -> BFTValidator.from(BFTValidatorId.create(k.getPublicKey()), UInt256.ONE))
                 .limit(1));
-    var proof = LedgerProof.genesis(accumulatorState, stateHash, validatorSet, 0, 0);
+    var proof = LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), validatorSet, 0, 0);
     return CommittedTransactionsWithProof.create(List.of(genesis), proof);
   }
 

--- a/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
@@ -69,6 +69,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.radixdlt.consensus.Blake2b256Hasher;
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.LedgerProof;
 import com.radixdlt.consensus.bft.BFTValidatorSet;
 import com.radixdlt.crypto.HashUtils;
@@ -110,10 +111,9 @@ public final class RustMempoolTest {
             UInt64.fromNonNegativeLong(1));
     var accumulatorState =
         accumulator.accumulate(initialAccumulatorState, genesis.getPayloadHash());
-    // The accumulator state is computed correctly, but we cannot easily do the same for state hash
-    var stateHash = HashUtils.random256();
     var proof =
-        LedgerProof.genesis(accumulatorState, stateHash, BFTValidatorSet.from(Stream.of()), 0, 0);
+        LedgerProof.genesis(
+            accumulatorState, LedgerHashes.zero(), BFTValidatorSet.from(Stream.of()), 0, 0);
     return CommittedTransactionsWithProof.create(List.of(genesis), proof);
   }
 
@@ -131,7 +131,7 @@ public final class RustMempoolTest {
             new CommitRequest(
                 transactions,
                 UInt64.fromNonNegativeLong(proof.getStateVersion()),
-                proof.getStateHash(),
+                proof.getLedgerHashes().getStateRoot(),
                 DefaultSerialization.getInstance().toDson(proof, DsonOutput.Output.ALL),
                 Option.none()))
         .unwrap();

--- a/core/src/test/java/com/radixdlt/utils/LedgerHeaderMock.java
+++ b/core/src/test/java/com/radixdlt/utils/LedgerHeaderMock.java
@@ -64,6 +64,7 @@
 
 package com.radixdlt.utils;
 
+import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.LedgerHeader;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.crypto.HashUtils;
@@ -75,7 +76,7 @@ public class LedgerHeaderMock {
         0,
         Round.genesis(),
         new AccumulatorState(0, HashUtils.zero256()),
-        HashUtils.zero256(),
+        LedgerHashes.zero(),
         0,
         0);
   }

--- a/core/src/test/java/com/radixdlt/utils/SerializerTestDataGenerator.java
+++ b/core/src/test/java/com/radixdlt/utils/SerializerTestDataGenerator.java
@@ -123,7 +123,8 @@ public class SerializerTestDataGenerator {
             Math.abs(random.nextLong()),
             randomRound(),
             new AccumulatorState(Math.abs(random.nextLong()) + 1, HashUtils.random256()),
-            HashUtils.random256(),
+            LedgerHashes.create(
+                HashUtils.random256(), HashUtils.random256(), HashUtils.random256()),
             Math.abs(random.nextLong()) + 1,
             Math.abs(random.nextLong()) + 1,
             NextEpoch.create(


### PR DESCRIPTION
This PR is a work-in-progress, first part of https://radixdlt.atlassian.net/browse/NODE-537.

Here I only introduce the transaction root hash and receipt root hash into `LedgerHeader` (unified together with state root hash, in `LedgerHashes`).
The actual values of these root hashes are not yet computed, but just placeholders. They are of course not yet used in any logic.