### PR TITLE
Refactor: passing LedgerProof as a parsable struct rather than opaque bytes

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/rev2/Decimal.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/rev2/Decimal.java
@@ -100,6 +100,10 @@ public class Decimal implements Comparable<Decimal> {
     this.underlyingValue = Objects.requireNonNull(underlyingValue);
   }
 
+  public static Decimal from(UInt256 fixedPointRepresentation) {
+    return new Decimal(fixedPointRepresentation);
+  }
+
   public static Decimal of(long amount) {
     var underlying = UInt256.from(amount).multiply(UInt256.from(10).pow(SCALE));
     return new Decimal(underlying);

--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/StateManagerSbor.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/StateManagerSbor.java
@@ -137,6 +137,10 @@ public final class StateManagerSbor {
     EdDSAEd25519Signature.registerCodec(codecMap);
     SignatureWithPublicKey.registerCodec(codecMap);
     LedgerHashes.registerCodec(codecMap);
+    LedgerProof.registerCodec(codecMap);
+    LedgerHeader.registerCodec(codecMap);
+    AccumulatorState.registerCodec(codecMap);
+    TimestampedValidatorSignature.registerCodec(codecMap);
     PrepareGenesisRequest.registerCodec(codecMap);
     PrepareGenesisResult.registerCodec(codecMap);
     PreviousVertex.registerCodec(codecMap);

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/AccumulatorState.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/AccumulatorState.java
@@ -62,77 +62,17 @@
  * permissions under this License.
  */
 
-package com.radixdlt.consensus;
+package com.radixdlt.statecomputer.commit;
 
-import static java.util.Objects.requireNonNull;
+import com.google.common.hash.HashCode;
+import com.radixdlt.sbor.codec.CodecMap;
+import com.radixdlt.sbor.codec.StructCodec;
+import com.radixdlt.utils.UInt64;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
-import com.radixdlt.consensus.bft.BFTValidator;
-import com.radixdlt.serialization.DsonOutput;
-import com.radixdlt.serialization.SerializerConstants;
-import com.radixdlt.serialization.SerializerDummy;
-import com.radixdlt.serialization.SerializerId2;
-import java.util.Objects;
-import java.util.Set;
-import javax.annotation.concurrent.Immutable;
-
-@Immutable
-@SerializerId2("consensus.next_epoch")
-public final class NextEpoch {
-  @JsonProperty(SerializerConstants.SERIALIZER_NAME)
-  @DsonOutput(value = {DsonOutput.Output.API, DsonOutput.Output.WIRE, DsonOutput.Output.PERSIST})
-  SerializerDummy serializer = SerializerDummy.DUMMY;
-
-  @JsonProperty("validators")
-  @DsonOutput(DsonOutput.Output.ALL)
-  private final ImmutableSet<BFTValidator> validators;
-
-  @JsonProperty("epoch")
-  @DsonOutput(DsonOutput.Output.ALL)
-  private final long epoch;
-
-  @JsonCreator
-  @VisibleForTesting
-  NextEpoch(
-      @JsonProperty(value = "epoch", required = true) long epoch,
-      @JsonProperty(value = "validators", required = true) ImmutableSet<BFTValidator> validators) {
-    this.epoch = epoch;
-    if (epoch < 0) {
-      throw new IllegalArgumentException("Epoch can't be < 0");
-    }
-    this.validators = requireNonNull(validators);
-  }
-
-  public static NextEpoch create(long epoch, Set<BFTValidator> validators) {
-    return new NextEpoch(epoch, ImmutableSet.copyOf(validators));
-  }
-
-  public ImmutableSet<BFTValidator> getValidators() {
-    return validators;
-  }
-
-  public long getEpoch() {
-    return epoch;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    NextEpoch nextEpoch = (NextEpoch) o;
-    return epoch == nextEpoch.epoch && Objects.equals(validators, nextEpoch.validators);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(validators, epoch);
-  }
-
-  @Override
-  public String toString() {
-    return "NextEpoch{" + "validators=" + validators + ", epoch=" + epoch + '}';
+public record AccumulatorState(UInt64 stateVersion, HashCode accumulatorHash) {
+  public static void registerCodec(CodecMap codecMap) {
+    codecMap.register(
+        AccumulatorState.class,
+        codecs -> StructCodec.fromRecordComponents(AccumulatorState.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/ActiveValidatorInfo.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/ActiveValidatorInfo.java
@@ -65,11 +65,14 @@
 package com.radixdlt.statecomputer.commit;
 
 import com.radixdlt.crypto.ECDSASecp256k1PublicKey;
+import com.radixdlt.lang.Option;
+import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 
-public record ActiveValidatorInfo(ECDSASecp256k1PublicKey key, Decimal stake) {
+public record ActiveValidatorInfo(
+    Option<ComponentAddress> address, ECDSASecp256k1PublicKey key, Decimal stake) {
 
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/CommitRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/CommitRequest.java
@@ -64,21 +64,17 @@
 
 package com.radixdlt.statecomputer.commit;
 
-import com.google.common.hash.HashCode;
 import com.radixdlt.lang.Option;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawLedgerTransaction;
-import com.radixdlt.utils.UInt64;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
 public record CommitRequest(
     List<RawLedgerTransaction> transactions,
-    UInt64 stateVersion,
-    HashCode stateHash,
-    byte[] proofBytes,
+    LedgerProof proof,
     Option<byte[]> postCommitVertexStoreBytes) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
@@ -92,17 +88,16 @@ public record CommitRequest(
     if (o == null || getClass() != o.getClass()) return false;
     CommitRequest that = (CommitRequest) o;
     return Objects.equals(transactions, that.transactions)
-        && Objects.equals(stateVersion, that.stateVersion)
-        && Objects.equals(stateHash, that.stateHash)
-        && Arrays.equals(proofBytes, that.proofBytes)
-        && Objects.equals(postCommitVertexStoreBytes, that.postCommitVertexStoreBytes);
+        && Objects.equals(proof, that.proof)
+        && Arrays.equals(
+            postCommitVertexStoreBytes.or((byte[]) null),
+            that.postCommitVertexStoreBytes.or((byte[]) null));
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(transactions, stateVersion, stateHash, postCommitVertexStoreBytes);
-    result = 31 * result + Arrays.hashCode(proofBytes);
-    return result;
+    return Objects.hash(
+        transactions, proof, Arrays.hashCode(postCommitVertexStoreBytes.or((byte[]) null)));
   }
 
   @Override
@@ -110,14 +105,10 @@ public record CommitRequest(
     return "CommitRequest{"
         + "transactions="
         + transactions
-        + ", stateVersion="
-        + stateVersion
-        + ", stateHash="
-        + stateHash
-        + ", proofBytes="
-        + Arrays.toString(proofBytes)
+        + ", proof="
+        + proof
         + ", postCommitVertexStoreBytes="
-        + postCommitVertexStoreBytes
+        + postCommitVertexStoreBytes.map(Arrays::toString)
         + '}';
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/LedgerHeader.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/LedgerHeader.java
@@ -62,77 +62,23 @@
  * permissions under this License.
  */
 
-package com.radixdlt.consensus;
+package com.radixdlt.statecomputer.commit;
 
-import static java.util.Objects.requireNonNull;
+import com.radixdlt.lang.Option;
+import com.radixdlt.sbor.codec.CodecMap;
+import com.radixdlt.sbor.codec.StructCodec;
+import com.radixdlt.utils.UInt64;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
-import com.radixdlt.consensus.bft.BFTValidator;
-import com.radixdlt.serialization.DsonOutput;
-import com.radixdlt.serialization.SerializerConstants;
-import com.radixdlt.serialization.SerializerDummy;
-import com.radixdlt.serialization.SerializerId2;
-import java.util.Objects;
-import java.util.Set;
-import javax.annotation.concurrent.Immutable;
-
-@Immutable
-@SerializerId2("consensus.next_epoch")
-public final class NextEpoch {
-  @JsonProperty(SerializerConstants.SERIALIZER_NAME)
-  @DsonOutput(value = {DsonOutput.Output.API, DsonOutput.Output.WIRE, DsonOutput.Output.PERSIST})
-  SerializerDummy serializer = SerializerDummy.DUMMY;
-
-  @JsonProperty("validators")
-  @DsonOutput(DsonOutput.Output.ALL)
-  private final ImmutableSet<BFTValidator> validators;
-
-  @JsonProperty("epoch")
-  @DsonOutput(DsonOutput.Output.ALL)
-  private final long epoch;
-
-  @JsonCreator
-  @VisibleForTesting
-  NextEpoch(
-      @JsonProperty(value = "epoch", required = true) long epoch,
-      @JsonProperty(value = "validators", required = true) ImmutableSet<BFTValidator> validators) {
-    this.epoch = epoch;
-    if (epoch < 0) {
-      throw new IllegalArgumentException("Epoch can't be < 0");
-    }
-    this.validators = requireNonNull(validators);
-  }
-
-  public static NextEpoch create(long epoch, Set<BFTValidator> validators) {
-    return new NextEpoch(epoch, ImmutableSet.copyOf(validators));
-  }
-
-  public ImmutableSet<BFTValidator> getValidators() {
-    return validators;
-  }
-
-  public long getEpoch() {
-    return epoch;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    NextEpoch nextEpoch = (NextEpoch) o;
-    return epoch == nextEpoch.epoch && Objects.equals(validators, nextEpoch.validators);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(validators, epoch);
-  }
-
-  @Override
-  public String toString() {
-    return "NextEpoch{" + "validators=" + validators + ", epoch=" + epoch + '}';
+public record LedgerHeader(
+    UInt64 epoch,
+    UInt64 round,
+    AccumulatorState accumulatorState,
+    LedgerHashes hashes,
+    long consensusParentRoundTimestampMs,
+    long proposerTimestampMs,
+    Option<NextEpoch> nextEpoch) {
+  public static void registerCodec(CodecMap codecMap) {
+    codecMap.register(
+        LedgerHeader.class, codecs -> StructCodec.fromRecordComponents(LedgerHeader.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/LedgerProof.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/LedgerProof.java
@@ -62,77 +62,45 @@
  * permissions under this License.
  */
 
-package com.radixdlt.consensus;
+package com.radixdlt.statecomputer.commit;
 
-import static java.util.Objects.requireNonNull;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
-import com.radixdlt.consensus.bft.BFTValidator;
-import com.radixdlt.serialization.DsonOutput;
-import com.radixdlt.serialization.SerializerConstants;
-import com.radixdlt.serialization.SerializerDummy;
-import com.radixdlt.serialization.SerializerId2;
+import com.google.common.hash.HashCode;
+import com.radixdlt.sbor.codec.CodecMap;
+import com.radixdlt.sbor.codec.StructCodec;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import javax.annotation.concurrent.Immutable;
 
-@Immutable
-@SerializerId2("consensus.next_epoch")
-public final class NextEpoch {
-  @JsonProperty(SerializerConstants.SERIALIZER_NAME)
-  @DsonOutput(value = {DsonOutput.Output.API, DsonOutput.Output.WIRE, DsonOutput.Output.PERSIST})
-  SerializerDummy serializer = SerializerDummy.DUMMY;
-
-  @JsonProperty("validators")
-  @DsonOutput(DsonOutput.Output.ALL)
-  private final ImmutableSet<BFTValidator> validators;
-
-  @JsonProperty("epoch")
-  @DsonOutput(DsonOutput.Output.ALL)
-  private final long epoch;
-
-  @JsonCreator
-  @VisibleForTesting
-  NextEpoch(
-      @JsonProperty(value = "epoch", required = true) long epoch,
-      @JsonProperty(value = "validators", required = true) ImmutableSet<BFTValidator> validators) {
-    this.epoch = epoch;
-    if (epoch < 0) {
-      throw new IllegalArgumentException("Epoch can't be < 0");
-    }
-    this.validators = requireNonNull(validators);
-  }
-
-  public static NextEpoch create(long epoch, Set<BFTValidator> validators) {
-    return new NextEpoch(epoch, ImmutableSet.copyOf(validators));
-  }
-
-  public ImmutableSet<BFTValidator> getValidators() {
-    return validators;
-  }
-
-  public long getEpoch() {
-    return epoch;
+public record LedgerProof(
+    HashCode opaque, LedgerHeader ledgerHeader, List<TimestampedValidatorSignature> signatures) {
+  public static void registerCodec(CodecMap codecMap) {
+    codecMap.register(
+        LedgerProof.class, codecs -> StructCodec.fromRecordComponents(LedgerProof.class, codecs));
   }
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    NextEpoch nextEpoch = (NextEpoch) o;
-    return epoch == nextEpoch.epoch && Objects.equals(validators, nextEpoch.validators);
+    LedgerProof that = (LedgerProof) o;
+    return Objects.equals(opaque, that.opaque)
+        && Objects.equals(ledgerHeader, that.ledgerHeader)
+        && Objects.equals(signatures, that.signatures);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(validators, epoch);
+    return Objects.hash(opaque, ledgerHeader, signatures);
   }
 
   @Override
   public String toString() {
-    return "NextEpoch{" + "validators=" + validators + ", epoch=" + epoch + '}';
+    return "LedgerProof{"
+        + "opaque="
+        + opaque
+        + ", ledgerHeader="
+        + ledgerHeader
+        + ", signatures="
+        + signatures
+        + '}';
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/NextEpoch.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/NextEpoch.java
@@ -64,14 +64,12 @@
 
 package com.radixdlt.statecomputer.commit;
 
-import com.google.common.collect.ImmutableMap;
-import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.utils.UInt64;
+import java.util.Set;
 
-public record NextEpoch(
-    ImmutableMap<ComponentAddress, ActiveValidatorInfo> validators, UInt64 epoch) {
+public record NextEpoch(Set<ActiveValidatorInfo> validators, UInt64 epoch) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         NextEpoch.class, codecs -> StructCodec.fromRecordComponents(NextEpoch.class, codecs));

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareGenesisResult.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareGenesisResult.java
@@ -65,13 +65,12 @@
 package com.radixdlt.statecomputer.commit;
 
 import com.radixdlt.lang.Option;
-import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
-import java.util.Map;
+import java.util.Set;
 
 public record PrepareGenesisResult(
-    Option<Map<ComponentAddress, ActiveValidatorInfo>> validatorSet, LedgerHashes ledgerHashes) {
+    Option<Set<ActiveValidatorInfo>> validatorSet, LedgerHashes ledgerHashes) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PrepareGenesisResult.class,

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/TimestampedValidatorSignature.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/TimestampedValidatorSignature.java
@@ -62,77 +62,22 @@
  * permissions under this License.
  */
 
-package com.radixdlt.consensus;
+package com.radixdlt.statecomputer.commit;
 
-import static java.util.Objects.requireNonNull;
+import com.radixdlt.crypto.ECDSASecp256k1PublicKey;
+import com.radixdlt.crypto.ECDSASecp256k1Signature;
+import com.radixdlt.rev2.ComponentAddress;
+import com.radixdlt.sbor.codec.CodecMap;
+import com.radixdlt.sbor.codec.StructCodec;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
-import com.radixdlt.consensus.bft.BFTValidator;
-import com.radixdlt.serialization.DsonOutput;
-import com.radixdlt.serialization.SerializerConstants;
-import com.radixdlt.serialization.SerializerDummy;
-import com.radixdlt.serialization.SerializerId2;
-import java.util.Objects;
-import java.util.Set;
-import javax.annotation.concurrent.Immutable;
-
-@Immutable
-@SerializerId2("consensus.next_epoch")
-public final class NextEpoch {
-  @JsonProperty(SerializerConstants.SERIALIZER_NAME)
-  @DsonOutput(value = {DsonOutput.Output.API, DsonOutput.Output.WIRE, DsonOutput.Output.PERSIST})
-  SerializerDummy serializer = SerializerDummy.DUMMY;
-
-  @JsonProperty("validators")
-  @DsonOutput(DsonOutput.Output.ALL)
-  private final ImmutableSet<BFTValidator> validators;
-
-  @JsonProperty("epoch")
-  @DsonOutput(DsonOutput.Output.ALL)
-  private final long epoch;
-
-  @JsonCreator
-  @VisibleForTesting
-  NextEpoch(
-      @JsonProperty(value = "epoch", required = true) long epoch,
-      @JsonProperty(value = "validators", required = true) ImmutableSet<BFTValidator> validators) {
-    this.epoch = epoch;
-    if (epoch < 0) {
-      throw new IllegalArgumentException("Epoch can't be < 0");
-    }
-    this.validators = requireNonNull(validators);
-  }
-
-  public static NextEpoch create(long epoch, Set<BFTValidator> validators) {
-    return new NextEpoch(epoch, ImmutableSet.copyOf(validators));
-  }
-
-  public ImmutableSet<BFTValidator> getValidators() {
-    return validators;
-  }
-
-  public long getEpoch() {
-    return epoch;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    NextEpoch nextEpoch = (NextEpoch) o;
-    return epoch == nextEpoch.epoch && Objects.equals(validators, nextEpoch.validators);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(validators, epoch);
-  }
-
-  @Override
-  public String toString() {
-    return "NextEpoch{" + "validators=" + validators + ", epoch=" + epoch + '}';
+public record TimestampedValidatorSignature(
+    ECDSASecp256k1PublicKey key,
+    ComponentAddress validatorAddress,
+    long timestampMs,
+    ECDSASecp256k1Signature signature) {
+  public static void registerCodec(CodecMap codecMap) {
+    codecMap.register(
+        TimestampedValidatorSignature.class,
+        codecs -> StructCodec.fromRecordComponents(TimestampedValidatorSignature.class, codecs));
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
@@ -71,6 +71,7 @@ import com.radixdlt.monitoring.LabelledTimer;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.monitoring.Metrics.MethodId;
 import com.radixdlt.sbor.Natives;
+import com.radixdlt.statecomputer.commit.LedgerProof;
 import com.radixdlt.statemanager.StateManager;
 import com.radixdlt.utils.UInt32;
 import com.radixdlt.utils.UInt64;
@@ -109,7 +110,7 @@ public final class REv2TransactionAndProofStore {
     return this.getTransactionAtStateVersionFunc.call(UInt64.fromNonNegativeLong(stateVersion));
   }
 
-  public Option<Tuple.Tuple2<List<byte[]>, byte[]>> getTxnsAndProof(
+  public Option<Tuple.Tuple2<List<byte[]>, LedgerProof>> getTxnsAndProof(
       long startStateVersionInclusive,
       int maxNumberOfTxnsIfMoreThanOneProof,
       int maxPayloadSizeInBytes) {
@@ -120,11 +121,11 @@ public final class REv2TransactionAndProofStore {
             UInt32.fromNonNegativeInt(maxPayloadSizeInBytes)));
   }
 
-  public Optional<byte[]> getLastProof() {
+  public Optional<LedgerProof> getLastProof() {
     return this.getLastProofFunc.call(Tuple.tuple()).toOptional();
   }
 
-  public Optional<byte[]> getEpochProof(long epoch) {
+  public Optional<LedgerProof> getEpochProof(long epoch) {
     return this.getEpochProofFunc.call(UInt64.fromNonNegativeLong(epoch)).toOptional();
   }
 
@@ -134,16 +135,16 @@ public final class REv2TransactionAndProofStore {
       StateManager stateManager, byte[] payload);
 
   private final Natives.Call1<
-          Tuple.Tuple3<UInt64, UInt32, UInt32>, Option<Tuple.Tuple2<List<byte[]>, byte[]>>>
+          Tuple.Tuple3<UInt64, UInt32, UInt32>, Option<Tuple.Tuple2<List<byte[]>, LedgerProof>>>
       getTxnsAndProof;
 
   private static native byte[] getTxnsAndProof(StateManager stateManager, byte[] payload);
 
-  private final Natives.Call1<Tuple.Tuple0, Option<byte[]>> getLastProofFunc;
+  private final Natives.Call1<Tuple.Tuple0, Option<LedgerProof>> getLastProofFunc;
 
   private static native byte[] getLastProof(StateManager stateManager, byte[] payload);
 
-  private final Natives.Call1<UInt64, Option<byte[]>> getEpochProofFunc;
+  private final Natives.Call1<UInt64, Option<LedgerProof>> getEpochProofFunc;
 
   private static native byte[] getEpochProof(StateManager stateManager, byte[] payload);
 }

--- a/core-rust/core-api-server/src/core_api/conversions/addressing.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/addressing.rs
@@ -583,7 +583,7 @@ pub fn to_global_entity_reference(
     global_address: &Address,
 ) -> Result<models::GlobalEntityReference, MappingError> {
     let reference = models::GlobalEntityReference {
-        entity_reference: Box::new(to_api_entity_reference(global_address.clone().into())?),
+        entity_reference: Box::new(to_api_entity_reference((*global_address).into())?),
         global_address_hex: to_hex(global_address_to_vec(global_address)),
         global_address: to_api_address(context, global_address),
     };

--- a/core-rust/core-api-server/src/core_api/conversions/receipt.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/receipt.rs
@@ -37,8 +37,10 @@ pub fn to_api_receipt(
     for (id, output) in substate_changes.created {
         match id {
             SubstateId(RENodeId::GlobalPackage(package_address), NodeModuleId::TypeInfo, ..) => {
-                new_global_entities
-                    .push(to_global_entity_reference(context, &package_address.into())?);
+                new_global_entities.push(to_global_entity_reference(
+                    context,
+                    &package_address.into(),
+                )?);
             }
             SubstateId(
                 RENodeId::GlobalComponent(component_address),
@@ -220,10 +222,9 @@ pub fn to_api_fee_summary(
                     _ => return None,
                 };
                 let payment = models::RoyaltyPayment {
-                    royalty_receiver: Box::new(to_global_entity_reference(
-                        context,
-                        &global_address,
-                    ).ok()?),
+                    royalty_receiver: Box::new(
+                        to_global_entity_reference(context, &global_address).ok()?,
+                    ),
                     cost_unit_amount: to_api_u32_as_i64(cost_unit_amount),
                 };
                 Some(payment)

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -65,8 +65,9 @@
 use crate::jni::mempool::JavaRawTransaction;
 use crate::transaction::UserTransactionValidator;
 use crate::{
-    AccumulatorHash, AccumulatorState, LedgerHashes, LedgerHeader, LedgerProof, PreviousVertex,
-    ReceiptHash, StateHash, TimestampedValidatorSignature, TransactionHash, ValidatorInfo,
+    AccumulatorHash, AccumulatorState, ActiveValidatorInfo, LedgerHashes, LedgerHeader,
+    LedgerProof, PreviousVertex, ReceiptHash, StateHash, TimestampedValidatorSignature,
+    TransactionHash,
 };
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
@@ -377,7 +378,7 @@ impl From<JavaPrepareGenesisRequest> for PrepareGenesisRequest {
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct JavaPrepareGenesisResult {
-    pub validator_set: Option<Vec<ValidatorInfo>>,
+    pub validator_set: Option<Vec<ActiveValidatorInfo>>,
     pub ledger_hashes: JavaLedgerHashes,
 }
 

--- a/core-rust/state-manager/src/mempool/simple_mempool.rs
+++ b/core-rust/state-manager/src/mempool/simple_mempool.rs
@@ -152,7 +152,7 @@ impl SimpleMempool {
         intent_hashes: &[IntentHash],
     ) -> Vec<PendingTransaction> {
         intent_hashes
-            .into_iter()
+            .iter()
             .filter_map(|intent_hash| self.intent_lookup.remove(intent_hash))
             .flat_map(|payload_hashes| payload_hashes.into_iter())
             .map(|payload_hash| {

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -1,6 +1,6 @@
 use radix_engine::blueprints::epoch_manager::Validator;
 use radix_engine::blueprints::transaction_processor::InstructionOutput;
-use std::collections::BTreeMap;
+use std::collections::btree_map::BTreeMap;
 
 use radix_engine::errors::RuntimeError;
 use radix_engine::ledger::OutputValue;

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -1,6 +1,6 @@
 use radix_engine::blueprints::epoch_manager::Validator;
 use radix_engine::blueprints::transaction_processor::InstructionOutput;
-use std::collections::btree_map::BTreeMap;
+use std::collections::BTreeMap;
 
 use radix_engine::errors::RuntimeError;
 use radix_engine::ledger::OutputValue;

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -98,6 +98,7 @@ use radix_engine::state_manager::StateDiff;
 use radix_engine_interface::api::types::{
     NodeModuleId, SubstateId, SubstateOffset, ValidatorOffset,
 };
+
 use std::collections::HashMap;
 use std::convert::TryInto;
 
@@ -586,10 +587,16 @@ where
         match &processed.receipt().result {
             TransactionResult::Commit(commit) => match &commit.outcome {
                 TransactionOutcome::Success(..) => PrepareGenesisResult {
-                    validator_set: commit
-                        .next_epoch
-                        .clone()
-                        .map(|(validator_set, _)| validator_set),
+                    validator_set: commit.next_epoch.clone().map(|(validator_set, _)| {
+                        validator_set
+                            .into_iter()
+                            .map(|(address, validator)| ValidatorInfo {
+                                address: Some(address),
+                                key: validator.key,
+                                stake: validator.stake,
+                            })
+                            .collect()
+                    }),
                     ledger_hashes: *processed.ledger_hashes(),
                 },
                 TransactionOutcome::Failure(error) => {
@@ -721,7 +728,15 @@ where
                 committed.push(manifest_encode(&validator_txn).unwrap());
 
                 commit_result.next_epoch.clone().map(|e| NextEpoch {
-                    validator_set: e.0,
+                    validator_set: e
+                        .0
+                        .into_iter()
+                        .map(|(address, validator)| ValidatorInfo {
+                            address: Some(address),
+                            key: validator.key,
+                            stake: validator.stake,
+                        })
+                        .collect(),
                     epoch: e.1,
                 })
             }
@@ -815,7 +830,15 @@ where
 
                         if let Some(e) = &result.next_epoch {
                             next_epoch = Some(NextEpoch {
-                                validator_set: e.0.clone(),
+                                validator_set: e
+                                    .0
+                                    .iter()
+                                    .map(|(address, validator)| ValidatorInfo {
+                                        address: Some(*address),
+                                        key: validator.key,
+                                        stake: validator.stake,
+                                    })
+                                    .collect(),
                                 epoch: e.1,
                             });
                             break;
@@ -941,8 +964,10 @@ where
             );
         }
 
+        let commit_ledger_header = &commit_request.proof.ledger_header;
+        let commit_accumulator_state = &commit_ledger_header.accumulator_state;
         let commit_request_start_state_version =
-            commit_request.proof_state_version - (commit_transactions_len as u64);
+            commit_accumulator_state.state_version - (commit_transactions_len as u64);
 
         // Whilst we should probably validate intent hash duplicates here, these are checked by validators on prepare already,
         // and the check will move into the engine at some point and we'll get it for free then...
@@ -972,7 +997,6 @@ where
         }
 
         let mut state_tracker = StateTracker::initial(base_transaction_identifiers);
-        let mut epoch_boundary = None;
         let mut committed_transaction_bundles = Vec::new();
         let mut state_diff = StateDiff::new();
         let mut state_hash_tree_update = HashTreeUpdate::new();
@@ -981,7 +1005,7 @@ where
         for (i, transaction) in parsed_transactions.into_iter().enumerate() {
             if let LedgerTransaction::System(..) = transaction {
                 // TODO: Cleanup and use real system transaction logic
-                if commit_request.proof_state_version != 1 && i != 0 {
+                if commit_accumulator_state.state_version != 1 && i != 0 {
                     panic!("Non Genesis system transaction cannot be committed.");
                 }
             }
@@ -1005,26 +1029,27 @@ where
 
             let commit_result = match &processed.receipt().result {
                 TransactionResult::Commit(result) => {
-                    if let Some((_, next_epoch)) = result.next_epoch {
+                    if let Some((_, _next_epoch)) = result.next_epoch {
                         let is_last = i == (commit_transactions_len - 1);
                         if !is_last {
                             return Err(CommitError::MissingEpochProof);
                         }
-                        // TODO: Use actual result and verify proof validator set matches transaction receipt validator set
-                        epoch_boundary = Some(next_epoch);
+                        // TODO: verify that `next_epoch == commit_ledger_header.next_epoch`
+                        // (currently it would fail for some of our tests which create genesis proof
+                        // directly, without caring about validator addresses)
                     }
                     result.clone()
                 }
                 TransactionResult::Reject(error) => {
                     panic!(
                         "Failed to commit a txn at state version {}: {:?}",
-                        commit_request.proof_state_version, error
+                        commit_accumulator_state.state_version, error
                     )
                 }
                 TransactionResult::Abort(abort_result) => {
                     panic!(
                         "Failed to commit a txn at state version {}: {:?}",
-                        commit_request.proof_state_version, abort_result
+                        commit_accumulator_state.state_version, abort_result
                     );
                 }
             };
@@ -1057,13 +1082,14 @@ where
             );
         }
 
+        let commit_ledger_hashes = &commit_ledger_header.hashes;
         let final_state_hash = &state_tracker.latest_ledger_hashes().state_root;
-        if *final_state_hash != commit_request.proof_state_hash {
+        if *final_state_hash != commit_ledger_hashes.state_root {
             warn!(
                 "computed state hash at version {} differs from the one in proof ({} != {})",
-                commit_request.proof_state_version,
+                commit_accumulator_state.state_version,
                 final_state_hash,
-                commit_request.proof_state_hash
+                commit_ledger_hashes.state_root
             );
         }
         let final_transaction_identifiers = state_tracker.latest_transaction_identifiers().clone();
@@ -1073,9 +1099,7 @@ where
 
         self.store.commit(CommitBundle {
             transactions: committed_transaction_bundles,
-            proof_bytes: commit_request.proof,
-            proof_state_version: commit_request.proof_state_version,
-            epoch_boundary,
+            proof: commit_request.proof,
             substates: state_diff.up_substates,
             vertex_store: commit_request.vertex_store,
             state_hash_tree_update,

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -80,7 +80,7 @@ use radix_engine::system::node_substates::PersistedSubstate;
 use crate::store::traits::RecoverableVertexStore;
 use crate::transaction::LedgerTransaction;
 use crate::{
-    AccumulatorHash, CommittedTransactionIdentifiers, IntentHash, LedgerPayloadHash,
+    AccumulatorHash, CommittedTransactionIdentifiers, IntentHash, LedgerPayloadHash, LedgerProof,
     LedgerTransactionReceipt,
 };
 use radix_engine::types::{KeyValueStoreId, SubstateId};
@@ -272,7 +272,7 @@ impl QueryableProofStore for StateManagerDatabase {
         start_state_version_inclusive: u64,
         max_number_of_txns_if_more_than_one_proof: u32,
         max_payload_size_in_bytes: u32,
-    ) -> Option<(Vec<Vec<u8>>, Vec<u8>)> {
+    ) -> Option<(Vec<Vec<u8>>, LedgerProof)> {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_txns_and_proof(
                 start_state_version_inclusive,
@@ -288,7 +288,7 @@ impl QueryableProofStore for StateManagerDatabase {
         }
     }
 
-    fn get_epoch_proof(&self, epoch: u64) -> Option<Vec<u8>> {
+    fn get_epoch_proof(&self, epoch: u64) -> Option<LedgerProof> {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_epoch_proof(epoch),
             StateManagerDatabase::RocksDB(store) => store.get_epoch_proof(epoch),
@@ -296,7 +296,7 @@ impl QueryableProofStore for StateManagerDatabase {
         }
     }
 
-    fn get_last_proof(&self) -> Option<Vec<u8>> {
+    fn get_last_proof(&self) -> Option<LedgerProof> {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_last_proof(),
             StateManagerDatabase::RocksDB(store) => store.get_last_proof(),

--- a/core-rust/state-manager/src/store/in_memory.rs
+++ b/core-rust/state-manager/src/store/in_memory.rs
@@ -77,8 +77,7 @@ use radix_engine_stores::hash_tree::tree_store::{
     NodeKey, Payload, ReadableTreeStore, SerializedInMemoryTreeStore, TreeNode, WriteableTreeStore,
 };
 use radix_engine_stores::memory_db::SerializedInMemorySubstateStore;
-use std::collections::btree_map::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 #[derive(Debug)]
 pub struct InMemoryStore {

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -146,7 +146,7 @@ pub mod commit {
     use radix_engine_stores::hash_tree::tree_store::{
         NodeKey, ReNodeModulePayload, TreeNode, Version,
     };
-    use std::collections::btree_map::BTreeMap;
+    use std::collections::BTreeMap;
 
     pub struct CommitBundle {
         pub transactions: Vec<CommittedTransactionBundle>,

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -62,8 +62,9 @@
  * permissions under this License.
  */
 
+use crate::staging::HashTreeDiff;
 use crate::transaction::LedgerTransaction;
-use crate::{CommittedTransactionIdentifiers, LedgerTransactionReceipt};
+use crate::{CommittedTransactionIdentifiers, LedgerProof, LedgerTransactionReceipt};
 pub use commit::*;
 pub use proofs::*;
 pub use substate::*;
@@ -123,6 +124,8 @@ pub mod transactions {
 }
 
 pub mod proofs {
+    use super::*;
+
     pub trait QueryableProofStore {
         fn max_state_version(&self) -> u64;
         fn get_txns_and_proof(
@@ -130,27 +133,24 @@ pub mod proofs {
             start_state_version_inclusive: u64,
             max_number_of_txns_if_more_than_one_proof: u32,
             max_payload_size_in_bytes: u32,
-        ) -> Option<(Vec<Vec<u8>>, Vec<u8>)>;
-        fn get_epoch_proof(&self, epoch: u64) -> Option<Vec<u8>>;
-        fn get_last_proof(&self) -> Option<Vec<u8>>;
+        ) -> Option<(Vec<Vec<u8>>, LedgerProof)>;
+        fn get_epoch_proof(&self, epoch: u64) -> Option<LedgerProof>;
+        fn get_last_proof(&self) -> Option<LedgerProof>;
     }
 }
 
 pub mod commit {
     use super::*;
-    use crate::staging::HashTreeDiff;
     use radix_engine::ledger::OutputValue;
     use radix_engine_interface::api::types::{SubstateId, SubstateOffset};
     use radix_engine_stores::hash_tree::tree_store::{
         NodeKey, ReNodeModulePayload, TreeNode, Version,
     };
-    use std::collections::BTreeMap;
+    use std::collections::btree_map::BTreeMap;
 
     pub struct CommitBundle {
         pub transactions: Vec<CommittedTransactionBundle>,
-        pub proof_bytes: Vec<u8>,
-        pub proof_state_version: u64,
-        pub epoch_boundary: Option<u64>,
+        pub proof: LedgerProof,
         pub substates: BTreeMap<SubstateId, OutputValue>,
         pub vertex_store: Option<Vec<u8>>,
         pub state_hash_tree_update: HashTreeUpdate,

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -648,7 +648,7 @@ pub struct PrepareResult {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-pub struct ValidatorInfo {
+pub struct ActiveValidatorInfo {
     pub address: Option<ComponentAddress>,
     pub key: EcdsaSecp256k1PublicKey,
     pub stake: Decimal,
@@ -656,7 +656,7 @@ pub struct ValidatorInfo {
 
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct NextEpoch {
-    pub validator_set: Vec<ValidatorInfo>,
+    pub validator_set: Vec<ActiveValidatorInfo>,
     pub epoch: u64,
 }
 
@@ -667,7 +667,7 @@ pub struct PrepareGenesisRequest {
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PrepareGenesisResult {
-    pub validator_set: Option<Vec<ValidatorInfo>>,
+    pub validator_set: Option<Vec<ActiveValidatorInfo>>,
     pub ledger_hashes: LedgerHashes,
 }
 

--- a/core/src/main/java/com/radixdlt/consensus/LedgerProof.java
+++ b/core/src/main/java/com/radixdlt/consensus/LedgerProof.java
@@ -164,6 +164,10 @@ public final class LedgerProof {
     return new DtoLedgerProof(opaque, ledgerHeader, signatures);
   }
 
+  public HashCode getOpaque() {
+    return this.opaque;
+  }
+
   public LedgerHeader getHeader() {
     return ledgerHeader;
   }

--- a/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
@@ -282,11 +282,7 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
 
     var commitRequest =
         new CommitRequest(
-            txnsAndProof.getTransactions(),
-            UInt64.fromNonNegativeLong(proof.getStateVersion()),
-            proof.getLedgerHashes().getStateRoot(),
-            serialization.toDson(proof, DsonOutput.Output.ALL),
-            vertexStoreBytes);
+            txnsAndProof.getTransactions(), REv2ToConsensus.ledgerProof(proof), vertexStoreBytes);
 
     var result = stateComputer.commit(commitRequest);
     if (result.isError()) {

--- a/core/src/main/java/com/radixdlt/rev2/REv2ToConsensus.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2ToConsensus.java
@@ -65,43 +65,144 @@
 package com.radixdlt.rev2;
 
 import com.google.common.collect.ImmutableSet;
-import com.radixdlt.consensus.LedgerHashes;
-import com.radixdlt.consensus.NextEpoch;
+import com.google.common.collect.Maps;
+import com.radixdlt.consensus.*;
 import com.radixdlt.consensus.bft.BFTValidator;
 import com.radixdlt.consensus.bft.BFTValidatorId;
 import com.radixdlt.consensus.bft.BFTValidatorSet;
+import com.radixdlt.consensus.bft.Round;
+import com.radixdlt.lang.Option;
+import com.radixdlt.ledger.AccumulatorState;
 import com.radixdlt.statecomputer.commit.ActiveValidatorInfo;
+import com.radixdlt.statecomputer.commit.TimestampedValidatorSignature;
+import com.radixdlt.utils.UInt64;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class REv2ToConsensus {
   private REv2ToConsensus() {
     throw new IllegalStateException("Cannot instantiate.");
   }
 
-  public static BFTValidator validator(ComponentAddress address, ActiveValidatorInfo validator) {
+  public static BFTValidator validator(ActiveValidatorInfo validator) {
     return BFTValidator.from(
-        BFTValidatorId.create(address, validator.key()), validator.stake().toUInt256());
+        BFTValidatorId.create(validator.address().or((ComponentAddress) null), validator.key()),
+        validator.stake().toUInt256());
   }
 
-  public static BFTValidatorSet validatorSet(
-      Map<ComponentAddress, ActiveValidatorInfo> validators) {
-    var bftValidators =
-        validators.entrySet().stream()
-            .map(e -> REv2ToConsensus.validator(e.getKey(), e.getValue()));
-    return BFTValidatorSet.from(bftValidators);
+  public static ActiveValidatorInfo validator(BFTValidator validator) {
+    BFTValidatorId id = validator.getValidatorId();
+    return new ActiveValidatorInfo(
+        Option.from(id.getValidatorAddress()), id.getKey(), Decimal.from(validator.getPower()));
+  }
+
+  public static BFTValidatorSet validatorSet(Set<ActiveValidatorInfo> validators) {
+    return BFTValidatorSet.from(validators.stream().map(REv2ToConsensus::validator));
   }
 
   public static NextEpoch nextEpoch(com.radixdlt.statecomputer.commit.NextEpoch nextEpoch) {
     var validators =
-        nextEpoch.validators().entrySet().stream()
-            .map(e -> REv2ToConsensus.validator(e.getKey(), e.getValue()))
+        nextEpoch.validators().stream()
+            .map(REv2ToConsensus::validator)
             .collect(ImmutableSet.toImmutableSet());
     return NextEpoch.create(nextEpoch.epoch().toNonNegativeLong().unwrap(), validators);
+  }
+
+  public static com.radixdlt.statecomputer.commit.NextEpoch nextEpoch(NextEpoch nextEpoch) {
+    ImmutableSet<ActiveValidatorInfo> validators =
+        nextEpoch.getValidators().stream()
+            .map(REv2ToConsensus::validator)
+            .collect(ImmutableSet.toImmutableSet());
+    return new com.radixdlt.statecomputer.commit.NextEpoch(
+        validators, UInt64.fromNonNegativeLong(nextEpoch.getEpoch()));
   }
 
   public static LedgerHashes ledgerHashes(
       com.radixdlt.statecomputer.commit.LedgerHashes ledgerHashes) {
     return LedgerHashes.create(
         ledgerHashes.stateRoot(), ledgerHashes.transactionRoot(), ledgerHashes.receiptRoot());
+  }
+
+  public static com.radixdlt.statecomputer.commit.LedgerHashes ledgerHashes(
+      LedgerHashes ledgerHashes) {
+    return new com.radixdlt.statecomputer.commit.LedgerHashes(
+        ledgerHashes.getStateRoot(),
+        ledgerHashes.getTransactionRoot(),
+        ledgerHashes.getReceiptRoot());
+  }
+
+  public static LedgerProof ledgerProof(com.radixdlt.statecomputer.commit.LedgerProof ledgerProof) {
+    return new LedgerProof(
+        ledgerProof.opaque(),
+        REv2ToConsensus.ledgerHeader(ledgerProof.ledgerHeader()),
+        new TimestampedECDSASignatures(
+            ledgerProof.signatures().stream()
+                .map(REv2ToConsensus::timestampedValidatorSignature)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+  }
+
+  public static com.radixdlt.statecomputer.commit.LedgerProof ledgerProof(LedgerProof ledgerProof) {
+    return new com.radixdlt.statecomputer.commit.LedgerProof(
+        ledgerProof.getOpaque(),
+        REv2ToConsensus.ledgerHeader(ledgerProof.getHeader()),
+        ledgerProof.getSignatures().getSignatures().entrySet().stream()
+            .map(e -> REv2ToConsensus.timestampedValidatorSignature(e.getKey(), e.getValue()))
+            .toList());
+  }
+
+  public static Map.Entry<BFTValidatorId, TimestampedECDSASignature> timestampedValidatorSignature(
+      TimestampedValidatorSignature timestampedSignature) {
+    return Maps.immutableEntry(
+        BFTValidatorId.create(timestampedSignature.validatorAddress(), timestampedSignature.key()),
+        TimestampedECDSASignature.from(
+            timestampedSignature.timestampMs(), timestampedSignature.signature()));
+  }
+
+  public static TimestampedValidatorSignature timestampedValidatorSignature(
+      BFTValidatorId id, TimestampedECDSASignature timestampedSignature) {
+    return new TimestampedValidatorSignature(
+        id.getKey(),
+        id.getValidatorAddress().get(),
+        timestampedSignature.timestamp(),
+        timestampedSignature.signature());
+  }
+
+  public static LedgerHeader ledgerHeader(
+      com.radixdlt.statecomputer.commit.LedgerHeader ledgerHeader) {
+    return LedgerHeader.create(
+        ledgerHeader.epoch().toNonNegativeLong().unwrap(),
+        Round.of(ledgerHeader.round().toNonNegativeLong().unwrap()),
+        REv2ToConsensus.accumulatorState(ledgerHeader.accumulatorState()),
+        REv2ToConsensus.ledgerHashes(ledgerHeader.hashes()),
+        ledgerHeader.consensusParentRoundTimestampMs(),
+        ledgerHeader.proposerTimestampMs(),
+        ledgerHeader.nextEpoch().map(REv2ToConsensus::nextEpoch).or((NextEpoch) null));
+  }
+
+  public static com.radixdlt.statecomputer.commit.LedgerHeader ledgerHeader(
+      LedgerHeader ledgerHeader) {
+    return new com.radixdlt.statecomputer.commit.LedgerHeader(
+        UInt64.fromNonNegativeLong(ledgerHeader.getEpoch()),
+        UInt64.fromNonNegativeLong(ledgerHeader.getRound().number()),
+        REv2ToConsensus.accumulatorState(ledgerHeader.getAccumulatorState()),
+        REv2ToConsensus.ledgerHashes(ledgerHeader.getHashes()),
+        ledgerHeader.consensusParentRoundTimestamp(),
+        ledgerHeader.proposerTimestamp(),
+        Option.from(ledgerHeader.getNextEpoch().map(REv2ToConsensus::nextEpoch)));
+  }
+
+  public static AccumulatorState accumulatorState(
+      com.radixdlt.statecomputer.commit.AccumulatorState accumulatorState) {
+    return new AccumulatorState(
+        accumulatorState.stateVersion().toNonNegativeLong().unwrap(),
+        accumulatorState.accumulatorHash());
+  }
+
+  public static com.radixdlt.statecomputer.commit.AccumulatorState accumulatorState(
+      AccumulatorState accumulatorState) {
+    return new com.radixdlt.statecomputer.commit.AccumulatorState(
+        UInt64.fromNonNegativeLong(accumulatorState.getStateVersion()),
+        accumulatorState.getAccumulatorHash());
   }
 }

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2LedgerRecoveryModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2LedgerRecoveryModule.java
@@ -77,7 +77,6 @@ import com.radixdlt.ledger.LedgerAccumulator;
 import com.radixdlt.recovery.VertexStoreRecovery;
 import com.radixdlt.rev2.REv2ToConsensus;
 import com.radixdlt.serialization.DeserializeException;
-import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.Serialization;
 import com.radixdlt.statecomputer.RustStateComputer;
 import com.radixdlt.statecomputer.commit.CommitRequest;
@@ -87,7 +86,6 @@ import com.radixdlt.store.LastProof;
 import com.radixdlt.store.LastStoredProof;
 import com.radixdlt.sync.TransactionsAndProofReader;
 import com.radixdlt.transactions.RawLedgerTransaction;
-import com.radixdlt.utils.UInt64;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -132,11 +130,7 @@ public final class REv2LedgerRecoveryModule extends AbstractModule {
                       accumulatorState, ledgerHashes, validatorSet, timestamp, timestamp);
               var commitRequest =
                   new CommitRequest(
-                      List.of(genesis),
-                      UInt64.fromNonNegativeLong(proof.getStateVersion()),
-                      proof.getLedgerHashes().getStateRoot(),
-                      serialization.toDson(proof, DsonOutput.Output.ALL),
-                      Option.none());
+                      List.of(genesis), REv2ToConsensus.ledgerProof(proof), Option.none());
               var commitResult = stateComputer.commit(commitRequest);
               commitResult.unwrap();
 

--- a/core/src/test/java/com/radixdlt/benchmark/TxnCommitAndReadBenchmarkTest.java
+++ b/core/src/test/java/com/radixdlt/benchmark/TxnCommitAndReadBenchmarkTest.java
@@ -77,15 +77,13 @@ import com.radixdlt.ledger.DtoLedgerProof;
 import com.radixdlt.rev2.NetworkDefinition;
 import com.radixdlt.rev2.REv2TestTransactions;
 import com.radixdlt.rev2.REv2TestTransactions.NotarizedTransactionBuilder;
+import com.radixdlt.rev2.REv2ToConsensus;
 import com.radixdlt.rev2.REv2TransactionsAndProofReader;
-import com.radixdlt.serialization.DefaultSerialization;
-import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.statecomputer.RustStateComputer;
 import com.radixdlt.statecomputer.commit.CommitRequest;
 import com.radixdlt.transaction.TransactionBuilder;
 import com.radixdlt.transactions.RawLedgerTransaction;
 import com.radixdlt.utils.Longs;
-import com.radixdlt.utils.UInt64;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -113,14 +111,10 @@ public final class TxnCommitAndReadBenchmarkTest extends DeterministicCoreApiTes
         When that happens, make sure this benchmark is still relevant before spending the time
         fixing the lines below :) */
         final var proof = LedgerProof.mockAtStateVersion(stateVersion + NUM_TXNS_IN_A_COMMIT);
-        final var proofBytes =
-            DefaultSerialization.getInstance().toDson(proof, DsonOutput.Output.ALL);
         final var commitRequest =
             new CommitRequest(
                 createUniqueTransactions(NUM_TXNS_IN_A_COMMIT, i),
-                UInt64.fromNonNegativeLong(proof.getStateVersion()),
-                proof.getLedgerHashes().getStateRoot(),
-                proofBytes,
+                REv2ToConsensus.ledgerProof(proof),
                 Option.none());
         stateComputer.commit(commitRequest);
         stateVersion = proof.getStateVersion();

--- a/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
@@ -91,7 +91,6 @@ import com.radixdlt.statemanager.REv2DatabaseConfig;
 import com.radixdlt.transaction.TransactionBuilder;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.PrivateKeys;
-import com.radixdlt.utils.UInt256;
 import com.radixdlt.utils.UInt64;
 import java.util.List;
 import org.junit.Test;
@@ -122,15 +121,18 @@ public class REv2StateComputerTest {
 
   private CommittedTransactionsWithProof buildGenesis(LedgerAccumulator accumulator) {
     var initialAccumulatorState = new AccumulatorState(0, HashUtils.zero256());
+    var stake = Decimal.of(1);
     var genesis =
-        TransactionBuilder.createGenesisWithNumValidators(
-            1, Decimal.of(1), UInt64.fromNonNegativeLong(10));
+        TransactionBuilder.createGenesisWithNumValidators(1, stake, UInt64.fromNonNegativeLong(10));
     var accumulatorState =
         accumulator.accumulate(initialAccumulatorState, genesis.getPayloadHash());
     var validatorSet =
         BFTValidatorSet.from(
             PrivateKeys.numeric(1)
-                .map(k -> BFTValidator.from(BFTValidatorId.create(k.getPublicKey()), UInt256.ONE))
+                .map(
+                    k ->
+                        BFTValidator.from(
+                            BFTValidatorId.create(k.getPublicKey()), stake.toUInt256()))
                 .limit(1));
     var proof = LedgerProof.genesis(accumulatorState, LedgerHashes.zero(), validatorSet, 0, 0);
     return CommittedTransactionsWithProof.create(List.of(genesis), proof);

--- a/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
@@ -84,7 +84,6 @@ import com.radixdlt.mempool.RustMempool;
 import com.radixdlt.mempool.RustMempoolConfig;
 import com.radixdlt.monitoring.MetricsInitializer;
 import com.radixdlt.serialization.DefaultSerialization;
-import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.statecomputer.RustStateComputer;
 import com.radixdlt.statecomputer.commit.CommitRequest;
 import com.radixdlt.statemanager.*;
@@ -127,13 +126,7 @@ public final class RustMempoolTest {
     var transactions = transactionsWithProof.getTransactions();
     var proof = transactionsWithProof.getProof();
     stateComputer
-        .commit(
-            new CommitRequest(
-                transactions,
-                UInt64.fromNonNegativeLong(proof.getStateVersion()),
-                proof.getLedgerHashes().getStateRoot(),
-                DefaultSerialization.getInstance().toDson(proof, DsonOutput.Output.ALL),
-                Option.none()))
+        .commit(new CommitRequest(transactions, REv2ToConsensus.ledgerProof(proof), Option.none()))
         .unwrap();
   }
 


### PR DESCRIPTION
This is something that was apparently postponed via a TODO.
I decided to finally do it, since I plan to use the actual proof's fields in the logic (in particular: I want a state version of an epoch proof during transaction tree update [and later even more fields from every ledger proof, during generation of transaction inclusion proofs])