### PR TITLE
Calling the actual accu tree for computing transaction and receipt hashes

### DIFF
--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -17,10 +17,6 @@ pub(crate) fn handle_status_network_status_internal(
     request: models::NetworkStatusRequest,
 ) -> Result<models::NetworkStatusResponse, ResponseError<()>> {
     assert_matching_network(&request.network, &state_manager.network)?;
-
-    let pre_genesis =
-        to_api_committed_state_identifier(CommittedTransactionIdentifiers::pre_genesis())?;
-
     Ok(models::NetworkStatusResponse {
         post_genesis_state_identifier: state_manager
             .store()
@@ -29,17 +25,12 @@ pub(crate) fn handle_status_network_status_internal(
                 Ok(Box::new(to_api_committed_state_identifier(identifiers)?))
             })
             .transpose()?,
-        current_state_identifier: Box::new(
-            state_manager
-                .store()
-                .get_top_of_ledger_transaction_identifiers()
-                .map(|identifiers| -> Result<_, MappingError> {
-                    to_api_committed_state_identifier(identifiers)
-                })
-                .transpose()?
-                .unwrap_or_else(|| pre_genesis.clone()),
-        ),
-        pre_genesis_state_identifier: Box::new(pre_genesis),
+        current_state_identifier: Box::new(to_api_committed_state_identifier(
+            state_manager.store().get_top_transaction_identifiers(),
+        )?),
+        pre_genesis_state_identifier: Box::new(to_api_committed_state_identifier(
+            CommittedTransactionIdentifiers::pre_genesis(),
+        )?),
     })
 }
 

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -66,8 +66,8 @@ use crate::jni::mempool::JavaRawTransaction;
 use crate::transaction::UserTransactionValidator;
 use crate::{
     AccumulatorHash, AccumulatorState, ActiveValidatorInfo, LedgerHashes, LedgerHeader,
-    LedgerProof, PreviousVertex, ReceiptHash, StateHash, TimestampedValidatorSignature,
-    TransactionHash,
+    LedgerProof, PreviousVertex, ReceiptTreeHash, StateHash, TimestampedValidatorSignature,
+    TransactionTreeHash,
 };
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
@@ -336,10 +336,10 @@ impl From<JavaLedgerHashes> for LedgerHashes {
     fn from(ledger_hashes: JavaLedgerHashes) -> Self {
         Self {
             state_root: StateHash::from_raw_bytes(ledger_hashes.state_root.into_bytes()),
-            transaction_root: TransactionHash::from_raw_bytes(
+            transaction_root: TransactionTreeHash::from_raw_bytes(
                 ledger_hashes.transaction_root.into_bytes(),
             ),
-            receipt_root: ReceiptHash::from_raw_bytes(ledger_hashes.receipt_root.into_bytes()),
+            receipt_root: ReceiptTreeHash::from_raw_bytes(ledger_hashes.receipt_root.into_bytes()),
         }
     }
 }

--- a/core-rust/state-manager/src/jni/transaction_store.rs
+++ b/core-rust/state-manager/src/jni/transaction_store.rs
@@ -177,13 +177,10 @@ extern "system" fn Java_com_radixdlt_transaction_REv2TransactionAndProofStore_ge
 }
 
 #[tracing::instrument(skip_all)]
-fn do_get_epoch_proof(
-    state_manager: &ActualStateManager,
-    state_version: u64,
-) -> Option<JavaLedgerProof> {
+fn do_get_epoch_proof(state_manager: &ActualStateManager, epoch: u64) -> Option<JavaLedgerProof> {
     state_manager
         .store()
-        .get_epoch_proof(state_version)
+        .get_epoch_proof(epoch)
         .map(|proof| proof.into())
 }
 

--- a/core-rust/state-manager/src/query/transaction_identifiers.rs
+++ b/core-rust/state-manager/src/query/transaction_identifiers.rs
@@ -1,17 +1,5 @@
-use crate::store::traits::*;
-use crate::{AccumulatorHash, CommittedTransactionIdentifiers};
-
-pub trait QueryableAccumulatorHash {
-    fn get_top_accumulator_hash(&self) -> AccumulatorHash;
-}
+use crate::CommittedTransactionIdentifiers;
 
 pub trait TransactionIdentifierLoader {
-    fn get_top_of_ledger_transaction_identifiers(&self) -> Option<CommittedTransactionIdentifiers>;
-}
-
-impl<T: QueryableProofStore + QueryableTransactionStore> TransactionIdentifierLoader for T {
-    fn get_top_of_ledger_transaction_identifiers(&self) -> Option<CommittedTransactionIdentifiers> {
-        let top_state_version = self.max_state_version();
-        self.get_committed_transaction_identifiers(top_state_version)
-    }
+    fn get_top_transaction_identifiers(&self) -> CommittedTransactionIdentifiers;
 }

--- a/core-rust/state-manager/src/staging/mod.rs
+++ b/core-rust/state-manager/src/staging/mod.rs
@@ -63,6 +63,41 @@
  */
 
 mod cache;
+mod result;
 mod stage_tree;
 
+use crate::accumulator_tree::storage::ReadableAccuTreeStore;
+use crate::{ReceiptHash, TransactionHash};
+use radix_engine::ledger::ReadableSubstateStore;
+use radix_engine_interface::api::types::SubstateOffset;
+use radix_engine_stores::hash_tree::tree_store::{ReNodeModulePayload, ReadableTreeStore};
+
 pub use cache::*;
+pub use result::*;
+
+pub trait ReadableLayeredTreeStore:
+    ReadableTreeStore<ReNodeModulePayload> + ReadableTreeStore<SubstateOffset>
+{
+}
+impl<T: ReadableTreeStore<ReNodeModulePayload> + ReadableTreeStore<SubstateOffset>>
+    ReadableLayeredTreeStore for T
+{
+}
+
+pub trait ReadableTxAndRxTreeStore:
+    ReadableAccuTreeStore<u64, TransactionHash> + ReadableAccuTreeStore<u64, ReceiptHash>
+{
+}
+impl<T: ReadableAccuTreeStore<u64, TransactionHash> + ReadableAccuTreeStore<u64, ReceiptHash>>
+    ReadableTxAndRxTreeStore for T
+{
+}
+
+pub trait RootStore:
+    ReadableSubstateStore + ReadableLayeredTreeStore + ReadableTxAndRxTreeStore
+{
+}
+impl<T: ReadableSubstateStore + ReadableLayeredTreeStore + ReadableTxAndRxTreeStore> RootStore
+    for T
+{
+}

--- a/core-rust/state-manager/src/staging/mod.rs
+++ b/core-rust/state-manager/src/staging/mod.rs
@@ -75,31 +75,30 @@ use radix_engine_stores::hash_tree::tree_store::{ReNodeModulePayload, ReadableTr
 pub use cache::*;
 pub use result::*;
 
-pub trait ReadableLayeredTreeStore:
+pub trait ReadableStateTreeStore:
     ReadableTreeStore<ReNodeModulePayload> + ReadableTreeStore<SubstateOffset>
 {
 }
-impl<T: ReadableTreeStore<ReNodeModulePayload> + ReadableTreeStore<SubstateOffset>>
-    ReadableLayeredTreeStore for T
+impl<T> ReadableStateTreeStore for T where
+    T: ReadableTreeStore<ReNodeModulePayload> + ReadableTreeStore<SubstateOffset>
 {
 }
 
-pub trait ReadableTxAndRxTreeStore:
+pub trait ReadableTransactionAndReceiptTreeStore:
     ReadableAccuTreeStore<u64, TransactionTreeHash> + ReadableAccuTreeStore<u64, ReceiptTreeHash>
 {
 }
-impl<
-        T: ReadableAccuTreeStore<u64, TransactionTreeHash>
-            + ReadableAccuTreeStore<u64, ReceiptTreeHash>,
-    > ReadableTxAndRxTreeStore for T
+impl<T> ReadableTransactionAndReceiptTreeStore for T where
+    T: ReadableAccuTreeStore<u64, TransactionTreeHash>
+        + ReadableAccuTreeStore<u64, ReceiptTreeHash>
 {
 }
 
 pub trait ReadableStore:
-    ReadableSubstateStore + ReadableLayeredTreeStore + ReadableTxAndRxTreeStore
+    ReadableSubstateStore + ReadableStateTreeStore + ReadableTransactionAndReceiptTreeStore
 {
 }
-impl<T: ReadableSubstateStore + ReadableLayeredTreeStore + ReadableTxAndRxTreeStore> ReadableStore
-    for T
+impl<T> ReadableStore for T where
+    T: ReadableSubstateStore + ReadableStateTreeStore + ReadableTransactionAndReceiptTreeStore
 {
 }

--- a/core-rust/state-manager/src/staging/mod.rs
+++ b/core-rust/state-manager/src/staging/mod.rs
@@ -67,7 +67,7 @@ mod result;
 mod stage_tree;
 
 use crate::accumulator_tree::storage::ReadableAccuTreeStore;
-use crate::{ReceiptHash, TransactionHash};
+use crate::{ReceiptTreeHash, TransactionTreeHash};
 use radix_engine::ledger::ReadableSubstateStore;
 use radix_engine_interface::api::types::SubstateOffset;
 use radix_engine_stores::hash_tree::tree_store::{ReNodeModulePayload, ReadableTreeStore};
@@ -85,19 +85,21 @@ impl<T: ReadableTreeStore<ReNodeModulePayload> + ReadableTreeStore<SubstateOffse
 }
 
 pub trait ReadableTxAndRxTreeStore:
-    ReadableAccuTreeStore<u64, TransactionHash> + ReadableAccuTreeStore<u64, ReceiptHash>
+    ReadableAccuTreeStore<u64, TransactionTreeHash> + ReadableAccuTreeStore<u64, ReceiptTreeHash>
 {
 }
-impl<T: ReadableAccuTreeStore<u64, TransactionHash> + ReadableAccuTreeStore<u64, ReceiptHash>>
-    ReadableTxAndRxTreeStore for T
+impl<
+        T: ReadableAccuTreeStore<u64, TransactionTreeHash>
+            + ReadableAccuTreeStore<u64, ReceiptTreeHash>,
+    > ReadableTxAndRxTreeStore for T
 {
 }
 
-pub trait RootStore:
+pub trait ReadableStore:
     ReadableSubstateStore + ReadableLayeredTreeStore + ReadableTxAndRxTreeStore
 {
 }
-impl<T: ReadableSubstateStore + ReadableLayeredTreeStore + ReadableTxAndRxTreeStore> RootStore
+impl<T: ReadableSubstateStore + ReadableLayeredTreeStore + ReadableTxAndRxTreeStore> ReadableStore
     for T
 {
 }

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -1,0 +1,360 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+use super::{ReadableLayeredTreeStore, ReadableTxAndRxTreeStore};
+use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, WriteableAccuTreeStore};
+use crate::accumulator_tree::tree_builder::{AccuTree, Merklizable};
+use crate::{
+    AccumulatorHash, CommittedTransactionIdentifiers, EpochTransactionIdentifiers, LedgerHashes,
+    LedgerPayloadHash, LedgerTransactionReceipt, ReceiptHash, StateHash, TransactionHash,
+};
+use lazy_static::lazy_static;
+use radix_engine::state_manager::StateDiff;
+use radix_engine::transaction::{TransactionReceipt, TransactionResult};
+use radix_engine_interface::api::types::SubstateOffset;
+use radix_engine_interface::crypto::{hash, Hash};
+use radix_engine_interface::data::scrypto::scrypto_encode;
+use radix_engine_stores::hash_tree::tree_store::{
+    NodeKey, Payload, ReNodeModulePayload, ReadableTreeStore, TreeNode, WriteableTreeStore,
+};
+use radix_engine_stores::hash_tree::{put_at_next_version, SubstateHashChange};
+
+lazy_static! {
+    static ref EMPTY_STATE_DIFF: StateDiff = StateDiff::new();
+}
+
+pub struct ProcessedResult {
+    /// Raw transaction receipt.
+    pub transaction_receipt: TransactionReceipt,
+    /// The processing results, applicable only for committed transactions (i.e. not rejected).
+    pub processed_commit: Option<ProcessedTransactionCommit>,
+}
+
+impl ProcessedResult {
+    pub fn from_processed<S: ReadableLayeredTreeStore + ReadableTxAndRxTreeStore>(
+        store: &S,
+        epoch_transaction_identifiers: &EpochTransactionIdentifiers,
+        parent_transaction_identifiers: &CommittedTransactionIdentifiers,
+        transaction_accumulator_hash: AccumulatorHash,
+        transaction_hash: &LedgerPayloadHash,
+        transaction_receipt: TransactionReceipt,
+    ) -> ProcessedResult {
+        let ledger_receipt = LedgerTransactionReceipt::try_from(transaction_receipt.clone()).ok();
+        let processed_commit = ledger_receipt.map(|ledger_receipt| {
+            let state_diff = Self::extract_state_diff(&transaction_receipt);
+            let state_tree_diff = Self::compute_state_tree_update(
+                store,
+                parent_transaction_identifiers.state_version,
+                state_diff,
+            );
+            let transaction_tree_diff = Self::compute_accu_tree_update::<S, TransactionHash>(
+                store,
+                epoch_transaction_identifiers.state_version,
+                &epoch_transaction_identifiers.transaction_hash,
+                parent_transaction_identifiers.state_version,
+                TransactionHash::from_raw_bytes((*transaction_hash).into_bytes()),
+            );
+            let receipt_tree_diff = Self::compute_accu_tree_update::<S, ReceiptHash>(
+                store,
+                epoch_transaction_identifiers.state_version,
+                &epoch_transaction_identifiers.receipt_hash,
+                parent_transaction_identifiers.state_version,
+                ReceiptHash::from_raw_bytes(ledger_receipt.get_hash().into_bytes()),
+            );
+            let ledger_hashes = LedgerHashes {
+                state_root: state_tree_diff.new_root,
+                transaction_root: *transaction_tree_diff.slice.root(),
+                receipt_root: *receipt_tree_diff.slice.root(),
+            };
+            ProcessedTransactionCommit {
+                transaction_accumulator_hash,
+                ledger_hashes,
+                state_tree_diff,
+                transaction_tree_diff,
+                receipt_tree_diff,
+            }
+        });
+        Self {
+            transaction_receipt,
+            processed_commit,
+        }
+    }
+
+    pub fn receipt(&self) -> &TransactionReceipt {
+        &self.transaction_receipt
+    }
+
+    pub fn state_diff(&self) -> &StateDiff {
+        Self::extract_state_diff(&self.transaction_receipt)
+    }
+
+    pub fn commit(&self) -> &ProcessedTransactionCommit {
+        self.processed_commit
+            .as_ref()
+            .expect("available only for committed transactions")
+    }
+
+    fn extract_state_diff(receipt: &TransactionReceipt) -> &StateDiff {
+        if let TransactionResult::Commit(commit) = &receipt.result {
+            &commit.state_updates
+        } else {
+            &EMPTY_STATE_DIFF
+        }
+    }
+
+    fn compute_accu_tree_update<S: ReadableAccuTreeStore<u64, M>, M: Merklizable + Clone>(
+        store: &S,
+        epoch_state_version: u64,
+        epoch_root: &M,
+        parent_state_version: u64,
+        new_leaf_hash: M,
+    ) -> AccuTreeDiff<u64, M> {
+        let epoch_transaction_count = parent_state_version - epoch_state_version;
+        let (epoch_tree_size, appended_hashes) = if epoch_transaction_count == 0 {
+            (0, vec![epoch_root.clone(), new_leaf_hash])
+        } else {
+            (
+                usize::try_from(epoch_transaction_count).unwrap() + 1,
+                vec![new_leaf_hash],
+            )
+        };
+        let mut collector = CollectingAccuTreeStore::new(store);
+        let mut epoch_scoped_store =
+            EpochScopedAccuTreeStore::new(&mut collector, epoch_state_version);
+        AccuTree::new(&mut epoch_scoped_store, epoch_tree_size).append(appended_hashes);
+        collector.into_diff()
+    }
+
+    fn compute_state_tree_update<S: ReadableLayeredTreeStore>(
+        store: &S,
+        parent_state_version: u64,
+        state_diff: &StateDiff,
+    ) -> HashTreeDiff {
+        // TODO: currently, only the hashes of changed (or created) substates are tracked, since
+        // the hash tree wants to stay consistent with the substate store (which does not support
+        // deletes yet). The underlying JMT implementation already supports deletion - and to use
+        // it, we simply can include `down_substates` with `None` hashes in the vector below.
+        let hash_changes = state_diff
+            .up_substates
+            .iter()
+            .map(|(id, value)| {
+                SubstateHashChange::new(
+                    id.clone(),
+                    Some(hash(scrypto_encode(&value.substate).unwrap())),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut collector = CollectingTreeStore::new(store);
+        let root_hash = put_at_next_version(
+            &mut collector,
+            Some(parent_state_version).filter(|v| *v > 0),
+            hash_changes,
+        );
+        collector.into_diff_with(root_hash)
+    }
+}
+
+pub struct ProcessedTransactionCommit {
+    pub transaction_accumulator_hash: AccumulatorHash,
+    pub ledger_hashes: LedgerHashes,
+    pub state_tree_diff: HashTreeDiff,
+    pub transaction_tree_diff: AccuTreeDiff<u64, TransactionHash>,
+    pub receipt_tree_diff: AccuTreeDiff<u64, ReceiptHash>,
+}
+
+pub struct HashTreeDiff {
+    pub new_root: StateHash,
+    pub new_re_node_layer_nodes: Vec<(NodeKey, TreeNode<ReNodeModulePayload>)>,
+    pub new_substate_layer_nodes: Vec<(NodeKey, TreeNode<SubstateOffset>)>,
+    pub stale_hash_tree_node_keys: Vec<NodeKey>,
+}
+
+impl HashTreeDiff {
+    pub fn new() -> Self {
+        Self {
+            new_root: StateHash::from_raw_bytes([0; StateHash::LENGTH]),
+            new_re_node_layer_nodes: Vec::new(),
+            new_substate_layer_nodes: Vec::new(),
+            stale_hash_tree_node_keys: Vec::new(),
+        }
+    }
+}
+
+pub struct AccuTreeDiff<K, N> {
+    pub key: K,
+    pub slice: TreeSlice<N>,
+}
+
+struct EpochScopedAccuTreeStore<'s, S> {
+    forest_store: &'s mut S,
+    epoch_state_version: u64,
+}
+
+impl<'s, S> EpochScopedAccuTreeStore<'s, S> {
+    pub fn new(forest_store: &'s mut S, epoch_state_version: u64) -> Self {
+        Self {
+            forest_store,
+            epoch_state_version,
+        }
+    }
+}
+
+impl<'s, S: ReadableAccuTreeStore<u64, N>, N> ReadableAccuTreeStore<usize, N>
+    for EpochScopedAccuTreeStore<'s, S>
+{
+    fn get_tree_slice(&self, epoch_tree_size: &usize) -> Option<TreeSlice<N>> {
+        let end_state_version = self.epoch_state_version + *epoch_tree_size as u64 - 1;
+        self.forest_store.get_tree_slice(&end_state_version)
+    }
+}
+
+impl<'s, S: WriteableAccuTreeStore<u64, N>, N> WriteableAccuTreeStore<usize, N>
+    for EpochScopedAccuTreeStore<'s, S>
+{
+    fn put_tree_slice(&mut self, epoch_tree_size: usize, slice: TreeSlice<N>) {
+        let end_state_version = self.epoch_state_version + epoch_tree_size as u64 - 1;
+        self.forest_store.put_tree_slice(end_state_version, slice)
+    }
+}
+
+struct CollectingAccuTreeStore<'s, S, K, N> {
+    readable_delegate: &'s S,
+    diff: Option<AccuTreeDiff<K, N>>,
+}
+
+impl<'s, S, K, N> CollectingAccuTreeStore<'s, S, K, N> {
+    pub fn new(readable_delegate: &'s S) -> Self {
+        Self {
+            readable_delegate,
+            diff: None,
+        }
+    }
+
+    pub fn into_diff(self) -> AccuTreeDiff<K, N> {
+        self.diff.expect("slice not collected")
+    }
+}
+
+impl<'s, S: ReadableAccuTreeStore<K, N>, K, N> ReadableAccuTreeStore<K, N>
+    for CollectingAccuTreeStore<'s, S, K, N>
+{
+    fn get_tree_slice(&self, key: &K) -> Option<TreeSlice<N>> {
+        self.readable_delegate.get_tree_slice(key)
+    }
+}
+
+impl<'s, S, K, N> WriteableAccuTreeStore<K, N> for CollectingAccuTreeStore<'s, S, K, N> {
+    fn put_tree_slice(&mut self, key: K, slice: TreeSlice<N>) {
+        if self.diff.is_some() {
+            panic!("slice already collected")
+        }
+        self.diff = Some(AccuTreeDiff { key, slice });
+    }
+}
+
+struct CollectingTreeStore<'s, S> {
+    readable_delegate: &'s S,
+    diff: HashTreeDiff,
+}
+
+impl<'s, S: ReadableLayeredTreeStore> CollectingTreeStore<'s, S> {
+    pub fn new(readable_delegate: &'s S) -> Self {
+        Self {
+            readable_delegate,
+            diff: HashTreeDiff::new(),
+        }
+    }
+
+    pub fn into_diff_with(self, new_root: Hash) -> HashTreeDiff {
+        let mut diff = self.diff;
+        diff.new_root = StateHash::from(new_root);
+        diff
+    }
+}
+
+impl<'s, S: ReadableTreeStore<P>, P: Payload> ReadableTreeStore<P> for CollectingTreeStore<'s, S> {
+    fn get_node(&self, key: &NodeKey) -> Option<TreeNode<P>> {
+        self.readable_delegate.get_node(key)
+    }
+}
+
+impl<'s, S> WriteableTreeStore<ReNodeModulePayload> for CollectingTreeStore<'s, S> {
+    fn insert_node(&mut self, key: NodeKey, node: TreeNode<ReNodeModulePayload>) {
+        self.diff.new_re_node_layer_nodes.push((key, node));
+    }
+
+    fn record_stale_node(&mut self, key: NodeKey) {
+        self.diff.stale_hash_tree_node_keys.push(key);
+    }
+}
+
+impl<'s, S> WriteableTreeStore<SubstateOffset> for CollectingTreeStore<'s, S> {
+    fn insert_node(&mut self, key: NodeKey, node: TreeNode<SubstateOffset>) {
+        self.diff.new_substate_layer_nodes.push((key, node));
+    }
+
+    fn record_stale_node(&mut self, key: NodeKey) {
+        self.diff.stale_hash_tree_node_keys.push(key);
+    }
+}

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use super::{ReadableLayeredTreeStore, ReadableTxAndRxTreeStore};
+use super::{ReadableStateTreeStore, ReadableTransactionAndReceiptTreeStore};
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, WriteableAccuTreeStore};
 use crate::accumulator_tree::tree_builder::{AccuTree, Merklizable};
 use crate::{
@@ -92,7 +92,7 @@ pub struct ProcessedResult {
 }
 
 impl ProcessedResult {
-    pub fn from_processed<S: ReadableLayeredTreeStore + ReadableTxAndRxTreeStore>(
+    pub fn from_processed<S: ReadableStateTreeStore + ReadableTransactionAndReceiptTreeStore>(
         store: &S,
         epoch_transaction_identifiers: &EpochTransactionIdentifiers,
         parent_transaction_identifiers: &CommittedTransactionIdentifiers,
@@ -149,7 +149,7 @@ impl ProcessedResult {
         Self::extract_state_diff(&self.transaction_receipt)
     }
 
-    pub fn commit(&self) -> &ProcessedTransactionCommit {
+    pub fn commit_details(&self) -> &ProcessedTransactionCommit {
         self.processed_commit
             .as_ref()
             .expect("available only for committed transactions")
@@ -186,7 +186,7 @@ impl ProcessedResult {
         collector.into_diff()
     }
 
-    fn compute_state_tree_update<S: ReadableLayeredTreeStore>(
+    fn compute_state_tree_update<S: ReadableStateTreeStore>(
         store: &S,
         parent_state_version: u64,
         state_diff: &StateDiff,
@@ -318,7 +318,7 @@ struct CollectingTreeStore<'s, S> {
     diff: HashTreeDiff,
 }
 
-impl<'s, S: ReadableLayeredTreeStore> CollectingTreeStore<'s, S> {
+impl<'s, S: ReadableStateTreeStore> CollectingTreeStore<'s, S> {
     pub fn new(readable_delegate: &'s S) -> Self {
         Self {
             readable_delegate,

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -67,7 +67,7 @@ use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, Writeab
 use crate::accumulator_tree::tree_builder::{AccuTree, Merklizable};
 use crate::{
     AccumulatorHash, CommittedTransactionIdentifiers, EpochTransactionIdentifiers, LedgerHashes,
-    LedgerPayloadHash, LedgerTransactionReceipt, ReceiptHash, StateHash, TransactionHash,
+    LedgerPayloadHash, LedgerTransactionReceipt, ReceiptTreeHash, StateHash, TransactionTreeHash,
 };
 use lazy_static::lazy_static;
 use radix_engine::state_manager::StateDiff;
@@ -108,19 +108,19 @@ impl ProcessedResult {
                 parent_transaction_identifiers.state_version,
                 state_diff,
             );
-            let transaction_tree_diff = Self::compute_accu_tree_update::<S, TransactionHash>(
+            let transaction_tree_diff = Self::compute_accu_tree_update::<S, TransactionTreeHash>(
                 store,
                 epoch_transaction_identifiers.state_version,
                 &epoch_transaction_identifiers.transaction_hash,
                 parent_transaction_identifiers.state_version,
-                TransactionHash::from_raw_bytes((*transaction_hash).into_bytes()),
+                TransactionTreeHash::from_raw_bytes((*transaction_hash).into_bytes()),
             );
-            let receipt_tree_diff = Self::compute_accu_tree_update::<S, ReceiptHash>(
+            let receipt_tree_diff = Self::compute_accu_tree_update::<S, ReceiptTreeHash>(
                 store,
                 epoch_transaction_identifiers.state_version,
                 &epoch_transaction_identifiers.receipt_hash,
                 parent_transaction_identifiers.state_version,
-                ReceiptHash::from_raw_bytes(ledger_receipt.get_hash().into_bytes()),
+                ReceiptTreeHash::from_raw_bytes(ledger_receipt.get_hash().into_bytes()),
             );
             let ledger_hashes = LedgerHashes {
                 state_root: state_tree_diff.new_root,
@@ -219,8 +219,8 @@ pub struct ProcessedTransactionCommit {
     pub transaction_accumulator_hash: AccumulatorHash,
     pub ledger_hashes: LedgerHashes,
     pub state_tree_diff: HashTreeDiff,
-    pub transaction_tree_diff: AccuTreeDiff<u64, TransactionHash>,
-    pub receipt_tree_diff: AccuTreeDiff<u64, ReceiptHash>,
+    pub transaction_tree_diff: AccuTreeDiff<u64, TransactionTreeHash>,
+    pub receipt_tree_diff: AccuTreeDiff<u64, ReceiptTreeHash>,
 }
 
 pub struct HashTreeDiff {

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -66,7 +66,7 @@ use crate::accumulator_tree::slice_merger::AccuTreeSliceMerger;
 use crate::jni::state_computer::JavaValidatorInfo;
 use crate::mempool::simple_mempool::SimpleMempool;
 use crate::query::*;
-use crate::staging::{ExecutionCache, ProcessedResult, ProcessedTransactionCommit, RootStore};
+use crate::staging::{ExecutionCache, ProcessedResult, ProcessedTransactionCommit, ReadableStore};
 use crate::store::traits::*;
 use crate::transaction::{
     LedgerTransaction, LedgerTransactionValidator, UserTransactionValidator, ValidatorTransaction,
@@ -262,7 +262,7 @@ where
     }
 }
 
-impl<S: RootStore> StateManager<S> {
+impl<S: ReadableStore> StateManager<S> {
     fn execute_for_staging_with_cache(
         &mut self,
         epoch_transaction_identifiers: &EpochTransactionIdentifiers,
@@ -315,7 +315,7 @@ enum AlreadyPreparedTransaction {
 
 impl<S> StateManager<S>
 where
-    S: RootStore,
+    S: ReadableStore,
     S: for<'a> TransactionIndex<&'a IntentHash>,
     S: QueryableProofStore + TransactionIdentifierLoader,
 {
@@ -929,7 +929,7 @@ where
 impl<'db, S> StateManager<S>
 where
     S: CommitStore,
-    S: RootStore,
+    S: ReadableStore,
     S: QueryableProofStore + TransactionIdentifierLoader,
 {
     pub fn commit(&'db mut self, commit_request: CommitRequest) -> Result<(), CommitError> {

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -587,7 +587,7 @@ where
                         .next_epoch
                         .clone()
                         .map(|next_epoch_result| NextEpoch::from(next_epoch_result).validator_set),
-                    ledger_hashes: processed.commit().ledger_hashes,
+                    ledger_hashes: processed.commit_details().ledger_hashes,
                 },
                 TransactionOutcome::Failure(error) => {
                     panic!("Genesis failed. Error: {error:?}")
@@ -685,7 +685,7 @@ where
             match &processed.receipt().result {
                 TransactionResult::Commit(_) => {
                     // TODO: Do we need to check that next epoch request has been prepared?
-                    state_tracker.update(processed.commit());
+                    state_tracker.update(processed.commit_details());
                 }
                 TransactionResult::Reject(reject_result) => {
                     panic!(
@@ -721,7 +721,7 @@ where
                 if let TransactionOutcome::Failure(error) = &commit_result.outcome {
                     panic!("Validator txn failed: {error:?}");
                 }
-                state_tracker.update(processed.commit());
+                state_tracker.update(processed.commit_details());
                 committed.push(manifest_encode(&validator_txn).unwrap());
 
                 commit_result.next_epoch.clone().map(NextEpoch::from)
@@ -803,7 +803,7 @@ where
 
                 match &processed.receipt().result {
                     TransactionResult::Commit(result) => {
-                        state_tracker.update(processed.commit());
+                        state_tracker.update(processed.commit_details());
 
                         already_committed_or_prepared_intent_hashes
                             .insert(intent_hash, AlreadyPreparedTransaction::Proposed);
@@ -1047,7 +1047,7 @@ where
                 intent_hashes.push(intent_hash);
             }
 
-            let processed_commit = processed.commit();
+            let processed_commit = processed.commit_details();
             state_tracker.update(processed_commit);
 
             committed_transaction_bundles.push((

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -82,7 +82,7 @@ use crate::store::traits::RecoverableVertexStore;
 use crate::transaction::LedgerTransaction;
 use crate::{
     CommittedTransactionIdentifiers, IntentHash, LedgerPayloadHash, LedgerProof,
-    LedgerTransactionReceipt, ReceiptHash, TransactionHash,
+    LedgerTransactionReceipt, ReceiptTreeHash, TransactionTreeHash,
 };
 use radix_engine::types::{KeyValueStoreId, SubstateId};
 use radix_engine_stores::hash_tree::tree_store::{NodeKey, Payload, ReadableTreeStore, TreeNode};
@@ -133,8 +133,8 @@ impl<P: Payload> ReadableTreeStore<P> for StateManagerDatabase {
     }
 }
 
-impl ReadableAccuTreeStore<u64, TransactionHash> for StateManagerDatabase {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionHash>> {
+impl ReadableAccuTreeStore<u64, TransactionTreeHash> for StateManagerDatabase {
+    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionTreeHash>> {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_tree_slice(state_version),
             StateManagerDatabase::RocksDB(store) => store.get_tree_slice(state_version),
@@ -143,8 +143,8 @@ impl ReadableAccuTreeStore<u64, TransactionHash> for StateManagerDatabase {
     }
 }
 
-impl ReadableAccuTreeStore<u64, ReceiptHash> for StateManagerDatabase {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptHash>> {
+impl ReadableAccuTreeStore<u64, ReceiptTreeHash> for StateManagerDatabase {
+    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptTreeHash>> {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_tree_slice(state_version),
             StateManagerDatabase::RocksDB(store) => store.get_tree_slice(state_version),

--- a/core-rust/state-manager/src/store/in_memory.rs
+++ b/core-rust/state-manager/src/store/in_memory.rs
@@ -68,8 +68,8 @@ use crate::transaction::LedgerTransaction;
 use crate::types::UserPayloadHash;
 use crate::{
     CommittedTransactionIdentifiers, HasIntentHash, HasLedgerPayloadHash, HasUserPayloadHash,
-    IntentHash, LedgerPayloadHash, LedgerProof, LedgerTransactionReceipt, ReceiptHash,
-    TransactionHash,
+    IntentHash, LedgerPayloadHash, LedgerProof, LedgerTransactionReceipt, ReceiptTreeHash,
+    TransactionTreeHash,
 };
 
 use crate::query::TransactionIdentifierLoader;
@@ -95,8 +95,8 @@ pub struct InMemoryStore {
     vertex_store: Option<Vec<u8>>,
     substate_store: SerializedInMemorySubstateStore,
     tree_node_store: SerializedInMemoryTreeStore,
-    transaction_tree_slices: BTreeMap<u64, TreeSlice<TransactionHash>>,
-    receipt_tree_slices: BTreeMap<u64, TreeSlice<ReceiptHash>>,
+    transaction_tree_slices: BTreeMap<u64, TreeSlice<TransactionTreeHash>>,
+    receipt_tree_slices: BTreeMap<u64, TreeSlice<ReceiptTreeHash>>,
 }
 
 impl InMemoryStore {
@@ -201,14 +201,14 @@ impl<P: Payload> ReadableTreeStore<P> for InMemoryStore {
     }
 }
 
-impl ReadableAccuTreeStore<u64, TransactionHash> for InMemoryStore {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionHash>> {
+impl ReadableAccuTreeStore<u64, TransactionTreeHash> for InMemoryStore {
+    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionTreeHash>> {
         self.transaction_tree_slices.get(state_version).cloned()
     }
 }
 
-impl ReadableAccuTreeStore<u64, ReceiptHash> for InMemoryStore {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptHash>> {
+impl ReadableAccuTreeStore<u64, ReceiptTreeHash> for InMemoryStore {
+    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptTreeHash>> {
         self.receipt_tree_slices.get(state_version).cloned()
     }
 }

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -70,7 +70,7 @@ use crate::store::traits::*;
 use crate::{
     AccumulatorHash, CommittedTransactionIdentifiers, HasIntentHash, HasLedgerPayloadHash,
     HasUserPayloadHash, IntentHash, LedgerPayloadHash, LedgerProof, LedgerTransactionReceipt,
-    ReceiptHash, TransactionHash,
+    ReceiptTreeHash, TransactionTreeHash,
 };
 use radix_engine::ledger::{OutputValue, QueryableSubstateStore, ReadableSubstateStore};
 use radix_engine::system::node_substates::PersistedSubstate;
@@ -275,7 +275,7 @@ impl RocksDBStore {
             .iterator_cf(self.cf_handle(cf), IteratorMode::End)
             .map(|res| res.unwrap())
             .next()
-            .map(|(_, proof)| scrypto_decode(proof.as_ref()).unwrap())
+            .map(|(_, value)| scrypto_decode(value.as_ref()).unwrap())
     }
 
     fn get_by_key<T: ScryptoDecode>(&self, cf: &RocksDBColumnFamily, key: &[u8]) -> Option<T> {
@@ -707,8 +707,8 @@ impl<P: Payload> ReadableTreeStore<P> for RocksDBStore {
     }
 }
 
-impl ReadableAccuTreeStore<u64, TransactionHash> for RocksDBStore {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionHash>> {
+impl ReadableAccuTreeStore<u64, TransactionTreeHash> for RocksDBStore {
+    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionTreeHash>> {
         self.get_by_key(
             &TransactionAccuTreeSliceByStateVersion,
             &state_version.to_be_bytes(),
@@ -716,8 +716,8 @@ impl ReadableAccuTreeStore<u64, TransactionHash> for RocksDBStore {
     }
 }
 
-impl ReadableAccuTreeStore<u64, ReceiptHash> for RocksDBStore {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptHash>> {
+impl ReadableAccuTreeStore<u64, ReceiptTreeHash> for RocksDBStore {
+    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptTreeHash>> {
         self.get_by_key(
             &ReceiptAccuTreeSliceByStateVersion,
             &state_version.to_be_bytes(),

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -143,7 +143,7 @@ pub mod proofs {
 pub mod commit {
     use super::*;
     use crate::accumulator_tree::storage::TreeSlice;
-    use crate::{ReceiptHash, TransactionHash};
+    use crate::{ReceiptTreeHash, TransactionTreeHash};
     use radix_engine::ledger::OutputValue;
     use radix_engine_interface::api::types::{SubstateId, SubstateOffset};
     use radix_engine_stores::hash_tree::tree_store::{NodeKey, ReNodeModulePayload, TreeNode};
@@ -155,8 +155,8 @@ pub mod commit {
         pub substates: BTreeMap<SubstateId, OutputValue>,
         pub vertex_store: Option<Vec<u8>>,
         pub state_tree_update: HashTreeUpdate,
-        pub transaction_tree_slice: TreeSlice<TransactionHash>,
-        pub receipt_tree_slice: TreeSlice<ReceiptHash>,
+        pub transaction_tree_slice: TreeSlice<TransactionTreeHash>,
+        pub receipt_tree_slice: TreeSlice<ReceiptTreeHash>,
     }
 
     pub struct HashTreeUpdate {

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -63,8 +63,8 @@
  */
 
 use crate::{
-    jni::common_types::JavaHashCode, transaction::LedgerTransaction, LedgerTransactionOutcome,
-    LedgerTransactionReceipt, SubstateChanges,
+    accumulator_tree::IsHash, jni::common_types::JavaHashCode, transaction::LedgerTransaction,
+    LedgerTransactionOutcome, LedgerTransactionReceipt, SubstateChanges,
 };
 use radix_engine::types::*;
 use std::fmt;
@@ -513,6 +513,8 @@ impl From<Hash> for TransactionHash {
     }
 }
 
+impl IsHash for TransactionHash {}
+
 impl fmt::Display for TransactionHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))
@@ -553,6 +555,8 @@ impl From<Hash> for ReceiptHash {
         Self(hash.0)
     }
 }
+
+impl IsHash for ReceiptHash {}
 
 impl fmt::Display for ReceiptHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -701,4 +705,28 @@ pub struct LedgerHeader {
 pub struct AccumulatorState {
     pub state_version: u64,
     pub accumulator_hash: AccumulatorHash,
+}
+
+pub struct EpochTransactionIdentifiers {
+    pub state_version: u64,
+    pub transaction_hash: TransactionHash,
+    pub receipt_hash: ReceiptHash,
+}
+
+impl EpochTransactionIdentifiers {
+    pub fn pre_genesis() -> Self {
+        Self {
+            state_version: 0,
+            transaction_hash: TransactionHash([0; TransactionHash::LENGTH]),
+            receipt_hash: ReceiptHash([0; TransactionHash::LENGTH]),
+        }
+    }
+
+    pub fn from(epoch_header: LedgerHeader) -> Self {
+        Self {
+            state_version: epoch_header.accumulator_state.state_version,
+            transaction_hash: epoch_header.hashes.transaction_root,
+            receipt_hash: epoch_header.hashes.receipt_root,
+        }
+    }
 }

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -487,9 +487,9 @@ impl fmt::Debug for StateHash {
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Categorize, Encode, Decode)]
-pub struct TransactionHash([u8; Self::LENGTH]);
+pub struct TransactionTreeHash([u8; Self::LENGTH]);
 
-impl TransactionHash {
+impl TransactionTreeHash {
     pub const LENGTH: usize = 32;
 
     pub fn from_raw_bytes(hash_bytes: [u8; Self::LENGTH]) -> Self {
@@ -501,38 +501,38 @@ impl TransactionHash {
     }
 }
 
-impl AsRef<[u8]> for TransactionHash {
+impl AsRef<[u8]> for TransactionTreeHash {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl From<Hash> for TransactionHash {
+impl From<Hash> for TransactionTreeHash {
     fn from(hash: Hash) -> Self {
         Self(hash.0)
     }
 }
 
-impl IsHash for TransactionHash {}
+impl IsHash for TransactionTreeHash {}
 
-impl fmt::Display for TransactionHash {
+impl fmt::Display for TransactionTreeHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))
     }
 }
 
-impl fmt::Debug for TransactionHash {
+impl fmt::Debug for TransactionTreeHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("TransactionHash")
+        f.debug_tuple("TransactionTreeHash")
             .field(&hex::encode(self.0))
             .finish()
     }
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Categorize, Encode, Decode)]
-pub struct ReceiptHash([u8; Self::LENGTH]);
+pub struct ReceiptTreeHash([u8; Self::LENGTH]);
 
-impl ReceiptHash {
+impl ReceiptTreeHash {
     pub const LENGTH: usize = 32;
 
     pub fn from_raw_bytes(hash_bytes: [u8; Self::LENGTH]) -> Self {
@@ -544,29 +544,29 @@ impl ReceiptHash {
     }
 }
 
-impl AsRef<[u8]> for ReceiptHash {
+impl AsRef<[u8]> for ReceiptTreeHash {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl From<Hash> for ReceiptHash {
+impl From<Hash> for ReceiptTreeHash {
     fn from(hash: Hash) -> Self {
         Self(hash.0)
     }
 }
 
-impl IsHash for ReceiptHash {}
+impl IsHash for ReceiptTreeHash {}
 
-impl fmt::Display for ReceiptHash {
+impl fmt::Display for ReceiptTreeHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))
     }
 }
 
-impl fmt::Debug for ReceiptHash {
+impl fmt::Debug for ReceiptTreeHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("ReceiptHash")
+        f.debug_tuple("ReceiptTreeHash")
             .field(&hex::encode(self.0))
             .finish()
     }
@@ -575,8 +575,8 @@ impl fmt::Debug for ReceiptHash {
 #[derive(PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Debug, Categorize, Encode, Decode)]
 pub struct LedgerHashes {
     pub state_root: StateHash,
-    pub transaction_root: TransactionHash,
-    pub receipt_root: ReceiptHash,
+    pub transaction_root: TransactionTreeHash,
+    pub receipt_root: ReceiptTreeHash,
 }
 
 /// An uncommitted user transaction, in eg the mempool
@@ -709,16 +709,16 @@ pub struct AccumulatorState {
 
 pub struct EpochTransactionIdentifiers {
     pub state_version: u64,
-    pub transaction_hash: TransactionHash,
-    pub receipt_hash: ReceiptHash,
+    pub transaction_hash: TransactionTreeHash,
+    pub receipt_hash: ReceiptTreeHash,
 }
 
 impl EpochTransactionIdentifiers {
     pub fn pre_genesis() -> Self {
         Self {
             state_version: 0,
-            transaction_hash: TransactionHash([0; TransactionHash::LENGTH]),
-            receipt_hash: ReceiptHash([0; TransactionHash::LENGTH]),
+            transaction_hash: TransactionTreeHash([0; TransactionTreeHash::LENGTH]),
+            receipt_hash: ReceiptTreeHash([0; TransactionTreeHash::LENGTH]),
         }
     }
 

--- a/core/src/main/java/com/radixdlt/consensus/LedgerHashes.java
+++ b/core/src/main/java/com/radixdlt/consensus/LedgerHashes.java
@@ -97,9 +97,9 @@ public final class LedgerHashes {
   private final HashCode transactionRoot;
 
   @JsonProperty("receipt_root")
-  // TODO(resolve during code review): this passes our tests, but shouldn't we exclude it from
-  // consensus currently as well? (see the `stateRoot` above)
-  @DsonOutput(DsonOutput.Output.ALL)
+  // TODO: restore `Output.ALL` after fixing non-determinism bugs
+  // The receipt root is as likely to contain such bugs as the state root (please see its comment).
+  @DsonOutput(value = DsonOutput.Output.HASH, include = false)
   private final HashCode receiptRoot;
 
   @JsonCreator

--- a/core/src/main/java/com/radixdlt/consensus/LedgerHashes.java
+++ b/core/src/main/java/com/radixdlt/consensus/LedgerHashes.java
@@ -97,6 +97,8 @@ public final class LedgerHashes {
   private final HashCode transactionRoot;
 
   @JsonProperty("receipt_root")
+  // TODO(resolve during code review): this passes our tests, but shouldn't we exclude it from
+  // consensus currently as well? (see the `stateRoot` above)
   @DsonOutput(DsonOutput.Output.ALL)
   private final HashCode receiptRoot;
 


### PR DESCRIPTION
⚠️ This relies on https://github.com/radixdlt/babylon-node/pull/356

This is an "integration" part of https://radixdlt.atlassian.net/browse/NODE-537 (the tx/rx hashes were exposed in our `LedgerHeader` earlier [as mocks], and the merkle tree builder was implemented earlier [with only UT usage], and this PR marries them).

In this PR, the storage approach follows the "per-slice" option (A) described at https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/2996600937/RNP-7+-+Transaction+Hash+Tree+Inclusion+Exclusion+verification#Option-A)-Per-slice-storage. The migration to Option B) is easy to perform as a standalone refactor later, should we decide so.