### PR TITLE
fix: RCNet uses standard staking setup

### DIFF
--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -143,7 +143,9 @@ public final class RadixNodeModule extends AbstractModule {
           Network.HAMMUNET,
           Network.MARDUNET,
           Network.NERGALNET,
-          Network.NEBUNET);
+          Network.NEBUNET,
+          Network.ANSHARNET,
+          Network.KISHARNET);
   private static final Decimal GENESIS_POWERFUL_STAKING_ACCOUNT_INITIAL_XRD_BALANCE =
       Decimal.of(700_000_000_000L); // 70% XRD_MAX_SUPPLY
   private static final Decimal GENESIS_POWERFUL_STAKING_ACCOUNT_INITIAL_XRD_STAKE_PER_VALIDATOR =


### PR DESCRIPTION
# Summary

Ensure that RCNet uses the same staking account setup as Betanet, to allow us to stake/unstake from validators easily.