### PR TITLE
Feature/release artifacts

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -1,0 +1,30 @@
+name: 'Radixdlt version'
+description: 'Get radixdlt version'
+inputs:
+  is_release:
+    description: "Is release?"
+    required: true
+outputs:
+  radixdlt_version:
+    description: "Radixdlt version"
+    value: ${{ steps.get_release.outputs.radixdlt_version }}
+  docker_tag:
+    description: "Docker version"
+    value: ${{ steps.get_release.outputs.docker_tag }}
+runs:
+  using: "composite"
+  steps:
+    - id: get_release
+      run: |
+        IS_RELEASE="${{ inputs.is_release }}"
+        echo "IS_RELEASE $IS_RELEASE"
+        if [[ "$IS_RELEASE" == "false" ]] ;then
+          export CI_VERSION=true
+        fi
+        version=$(./gradlew radixCiVersion | grep radixdlt-version | cut -d: -f2)
+        echo "Version: $version"
+        echo "::set-output name=radixdlt_version::$(echo $version)"
+        docker_tag=$(echo $version | sed 's/~/-/g')
+        echo "Docker tag: $docker_tag"
+        echo "::set-output name=docker_tag::$(echo $docker_tag)"
+      shell: bash

--- a/.github/actions/gradle-task/action.yml
+++ b/.github/actions/gradle-task/action.yml
@@ -1,0 +1,23 @@
+name: 'Build'
+description: 'Build radixdlt and save artifacts. Uses github context'
+inputs:
+  is_release:
+    description: 'True if it is a release'
+    required: true
+    default: false
+  gradle_command:
+    description: 'Gradle command to run'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - id: set_variables
+      run: |
+        if [[ ${{ inputs.is_release }} == "false"  ]];then
+          echo "Workflow triggered by push to a branch"
+          export CI_VERSION=true
+        fi
+        version=$(./gradlew radixCiVersion | grep radixdlt-version | cut -d: -f2)
+        echo "Version: $version"
+        ./gradlew ${{ inputs.gradle_command }}
+      shell: bash

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -31,8 +31,7 @@ jobs:
         run: ./gradlew :core-rust:buildRustForDocker -P rustBinaryBuildType="release"
       - name: Package libcorerust
         run: |
-          cd ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/
-          zip babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip libcorerust.so
+          zip -j babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@f589ce0779c7bef1faf175f7488c972eb47dc046

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -1,4 +1,4 @@
-name: radixdlt-artifacts-to-release
+name: Release artifacts
 on:
   release:
     types: [published]

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Package libcorerust
         run: |
           zip babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so
-          gh release upload ${{ github.event.release.tag_name }} --repo radixdlt/babylon-node babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip --clobber
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@f589ce0779c7bef1faf175f7488c972eb47dc046

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./gradlew :core-rust:buildRustForDocker -P rustBinaryBuildType="release"
       - name: Package libcorerust
         run: |
-          mv ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so .
+          cd ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/
           zip babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip libcorerust.so
       - name: Get release
         id: get_release
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip
+          asset_path: ./${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip
           asset_name: babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
 

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -29,11 +29,24 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: Run local core-rust docker build
         run: ./gradlew :core-rust:buildRustForDocker -P rustBinaryBuildType="release"
-      - name: Upload libcorerust
-        run:
-          gh release upload ${{ github.event.release.tag_name }} --repo radixdlt/babylon-node ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so --clobber
+      - name: Package libcorerust
+        run: |
+          zip babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so
+          gh release upload ${{ github.event.release.tag_name }} --repo radixdlt/babylon-node babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip --clobber
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@f589ce0779c7bef1faf175f7488c972eb47dc046
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload distribution zip
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip
+          asset_name: babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip
+          asset_content_type: application/zip
 
   publish-distribution-zip:
     name: Upload and Build Binary
@@ -84,5 +97,5 @@ jobs:
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./core/build/distributions/core-${{ steps.get_version.outputs.radixdlt_version }}.zip
-          asset_name: radixdlt-dist-${{ steps.get_version.outputs.radixdlt_version }}.zip
+          asset_name: babylon-node-${{ steps.get_version.outputs.radixdlt_version }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -31,7 +31,8 @@ jobs:
         run: ./gradlew :core-rust:buildRustForDocker -P rustBinaryBuildType="release"
       - name: Package libcorerust
         run: |
-          zip babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so
+          mv ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so .
+          zip babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip libcorerust.so
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@f589ce0779c7bef1faf175f7488c972eb47dc046

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip
+          asset_path: ./babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip
           asset_name: babylon-node-rust-arch-linux-x86_64-release-${{ github.event.release.tag_name }}.zip
           asset_content_type: application/zip
 

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -1,0 +1,89 @@
+name: radixdlt-artifacts-to-release
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish_libcorerust:
+    name: Build and upload core-rust
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Run local core-rust docker build
+        run: ./gradlew :core-rust:buildRustForDocker -P rustBinaryBuildType="release"
+      - name: Upload libcorerust
+        run:
+          echo "This is used instead of the github action, because it closes the socket due to unrecognized file format errors."
+          gh release upload ${{ github.event.release.tag_name }} --repo radixdlt/babylon-node ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-distribution-zip:
+    name: Add artifacts release ${{ github.event.release.tag_name }}
+    runs-on: ubuntu-22.04
+    environment: publish-artifacts
+    steps:
+      - name: Dump context
+        uses: crazy-max/ghaction-dump-context@516dbb0c760f39b4cdd750ae095f1688780f68f4
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@3f07048e3d294f56e9b90ac5ea2c6f74e9ad0f98
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - name: Cache Gradle packages
+        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build radixdlt
+        uses: ./.github/actions/gradle-task
+        with:
+          is_release: true
+          gradle_command: clean build -x test
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@f589ce0779c7bef1faf175f7488c972eb47dc046
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - id: get_version
+        name: Get radixdlt version
+        uses: ./.github/actions/get-version
+        with:
+          is_release: true
+      - name: List files
+        run: ls -la ./core/build/distributions/
+      - name: Upload distribution zip
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./core/build/distributions/core-${{ steps.get_version.outputs.radixdlt_version }}.zip
+          asset_name: radixdlt-dist-${{ steps.get_version.outputs.radixdlt_version }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish_libcorerust:
-    name: Build and upload core-rust
+    name: Build and upload libcorerust
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
@@ -31,13 +31,12 @@ jobs:
         run: ./gradlew :core-rust:buildRustForDocker -P rustBinaryBuildType="release"
       - name: Upload libcorerust
         run:
-          echo "This is used instead of the github action, because it closes the socket due to unrecognized file format errors."
           gh release upload ${{ github.event.release.tag_name }} --repo radixdlt/babylon-node ${{ github.workspace }}/core-rust/target/x86_64-unknown-linux-gnu/release/libcorerust.so --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-distribution-zip:
-    name: Add artifacts release ${{ github.event.release.tag_name }}
+    name: Upload and Build Binary
     runs-on: ubuntu-22.04
     environment: publish-artifacts
     steps:

--- a/.github/workflows/deploy-and-smoke-test.yaml
+++ b/.github/workflows/deploy-and-smoke-test.yaml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy And SmokeTests
 
 on:
   push:


### PR DESCRIPTION
# Release artifacts to github release

This PR aims to publish the binary and the library necessary to run the node natively (as compared to only on docker) to the Github release. 

This enables the node-cli to download and configure them.
Also interested node-runners will not need to build the core-rust library themselves or copy it out of the docker image.

Please have a look at this release:
https://github.com/radixdlt/babylon-node/releases/tag/poc-release-artifacts
and also approve/merge this PR 
 https://github.com/radixdlt/babylon-node/pull/370
 
 
 Can also be compared to radixdlt/radixdlt.
 
 https://github.com/radixdlt/radixdlt/blob/main/.github/workflows/add-artifacts-to-release.yml