### PR TITLE
Using a merkle tree for substate changes' hash inside consensus receipt

### DIFF
--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -18,6 +18,8 @@ use radix_engine_interface::data::scrypto::model::ComponentAddress;
 use radix_engine_interface::*;
 use sbor::rust::collections::IndexMap;
 
+use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, WriteableAccuTreeStore};
+use crate::accumulator_tree::tree_builder::{AccuTree, Merklizable};
 use crate::{AccumulatorHash, ConsensusReceipt, SubstateChangeHash};
 
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -36,20 +38,25 @@ impl CommittedTransactionIdentifiers {
 }
 
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-pub struct SubstateChanges {
-    pub created: BTreeMap<SubstateId, OutputValue>,
-    pub updated: BTreeMap<SubstateId, OutputValue>,
-    pub deleted: BTreeMap<SubstateId, DeletedSubstateVersion>,
+pub struct SubstateChange {
+    pub substate_id: SubstateId,
+    pub action: ChangeAction,
 }
 
-impl SubstateChanges {
-    pub fn upserted(&self) -> impl Iterator<Item = (&SubstateId, &OutputValue)> {
-        self.created.iter().chain(self.updated.iter())
+impl SubstateChange {
+    pub fn new(substate_id: SubstateId, action: ChangeAction) -> Self {
+        Self {
+            substate_id,
+            action,
+        }
     }
+}
 
-    pub fn deleted_ids(&self) -> impl Iterator<Item = &SubstateId> {
-        self.deleted.keys()
-    }
+#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+pub enum ChangeAction {
+    Create(OutputValue),
+    Update(OutputValue),
+    Delete(DeletedSubstateVersion),
 }
 
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -110,7 +117,7 @@ pub struct LocalTransactionReceipt {
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct LedgerTransactionReceipt {
     pub outcome: LedgerTransactionOutcome,
-    pub substate_changes: SubstateChanges,
+    pub substate_changes: Vec<SubstateChange>,
 }
 
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -125,15 +132,16 @@ pub struct LocalTransactionExecution {
 
 impl LedgerTransactionReceipt {
     pub fn get_consensus_receipt(&self) -> ConsensusReceipt {
+        let substate_change_hashes = self
+            .substate_changes
+            .iter()
+            .map(|substate_change| scrypto_encode(substate_change).unwrap())
+            .map(|change_bytes| SubstateChangeHash::from(blake2b_256_hash(change_bytes)))
+            .collect::<Vec<_>>();
         ConsensusReceipt {
             outcome: self.outcome.clone(),
-            substate_change_root: Self::compute_substate_change_root(&self.substate_changes),
+            substate_change_root: compute_merkle_root(substate_change_hashes),
         }
-    }
-
-    fn compute_substate_change_root(substate_changes: &SubstateChanges) -> SubstateChangeHash {
-        // TODO: implement using a merkle tree
-        SubstateChangeHash::from(blake2b_256_hash(scrypto_encode(substate_changes).unwrap()))
     }
 }
 
@@ -175,7 +183,7 @@ impl From<(CommitResult, FeeSummary)> for LocalTransactionReceipt {
     }
 }
 
-fn map_state_updates(state_updates: StateDiff) -> SubstateChanges {
+fn map_state_updates(state_updates: StateDiff) -> Vec<SubstateChange> {
     // As of end of August 2022, the engine's statediff erroneously includes substate reads
     // (even if the content didn't change) as ups and downs.
     // This needs fixing, but for now, we work around this here, by removing such up/down pairs.
@@ -215,9 +223,78 @@ fn map_state_updates(state_updates: StateDiff) -> SubstateChanges {
     // The remaining up_substates which didn't match with a down_substate are all creates
     let created = possible_creations;
 
-    SubstateChanges {
-        created,
-        updated,
-        deleted,
+    into_change_list(created, updated, deleted)
+}
+
+/// Turns the sets of changes (of different kind) into a flat list of `SubstateChange`s, ordered by
+/// `SubstateId` (i.e. suitable for merklization).
+fn into_change_list(
+    created: BTreeMap<SubstateId, OutputValue>,
+    updated: BTreeMap<SubstateId, OutputValue>,
+    deleted: BTreeMap<SubstateId, DeletedSubstateVersion>,
+) -> Vec<SubstateChange> {
+    let mut changes = created
+        .into_iter()
+        .map(|(id, value)| SubstateChange::new(id, ChangeAction::Create(value)))
+        .chain(
+            updated
+                .into_iter()
+                .map(|(id, value)| SubstateChange::new(id, ChangeAction::Update(value))),
+        )
+        .chain(
+            deleted
+                .into_iter()
+                .map(|(id, version)| SubstateChange::new(id, ChangeAction::Delete(version))),
+        )
+        .collect::<Vec<_>>();
+    changes.sort_by(|left, right| left.substate_id.cmp(&right.substate_id));
+    changes
+}
+
+fn compute_merkle_root<M: Merklizable>(leaves: Vec<M>) -> M {
+    let mut store = RootCapturingAccuTreeStore::default();
+    let mut tree = AccuTree::new(&mut store, 0);
+    tree.append(leaves);
+    store.into_captured_root()
+}
+
+struct RootCapturingAccuTreeStore<M> {
+    captured: Option<M>,
+}
+
+impl<M> RootCapturingAccuTreeStore<M> {
+    pub fn into_captured_root(self) -> M {
+        self.captured.expect("not captured yet")
+    }
+}
+
+impl<M> Default for RootCapturingAccuTreeStore<M> {
+    fn default() -> Self {
+        Self { captured: None }
+    }
+}
+
+impl<M: Merklizable> ReadableAccuTreeStore<usize, M> for RootCapturingAccuTreeStore<M> {
+    fn get_tree_slice(&self, key: &usize) -> Option<TreeSlice<M>> {
+        panic!("unexpected get of slice {key}, since the build should be one-shot")
+    }
+}
+
+impl<M: Merklizable> WriteableAccuTreeStore<usize, M> for RootCapturingAccuTreeStore<M> {
+    fn put_tree_slice(&mut self, _key: usize, slice: TreeSlice<M>) {
+        if self.captured.is_some() {
+            panic!("unexpected repeated put, since the build should be one-shot")
+        }
+        self.captured = Some(
+            slice
+                .levels
+                .into_iter()
+                .next_back()
+                .unwrap()
+                .nodes
+                .into_iter()
+                .next()
+                .unwrap(),
+        )
     }
 }

--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -70,7 +70,7 @@ use crate::staging::{
     AccuTreeDiff, HashStructuresDiff, HashTreeDiff, HashUpdateContext, ProcessedTransactionReceipt,
 };
 use crate::{
-    AccumulatorHash, CommittedTransactionIdentifiers, EpochTransactionIdentifiers,
+    AccumulatorHash, ChangeAction, CommittedTransactionIdentifiers, EpochTransactionIdentifiers,
     LedgerPayloadHash, ReceiptTreeHash, TransactionTreeHash,
 };
 use im::hashmap::HashMap as ImmutableHashMap;
@@ -251,10 +251,7 @@ impl Delta for ProcessedTransactionReceipt {
     fn weight(&self) -> usize {
         match self {
             ProcessedTransactionReceipt::Commit(commit) => {
-                let substate_changes = &commit.complete_receipt.on_ledger.substate_changes;
-                substate_changes.created.len()
-                    + substate_changes.updated.len()
-                    + substate_changes.deleted.len()
+                commit.complete_receipt.on_ledger.substate_changes.len()
                     + commit.hash_structures_diff.weight()
             }
             ProcessedTransactionReceipt::Reject(_) | ProcessedTransactionReceipt::Abort(_) => 0,
@@ -311,11 +308,14 @@ impl Accumulator<ProcessedTransactionReceipt> for ImmutableStore {
     fn accumulate(&mut self, processed: &ProcessedTransactionReceipt) {
         if let ProcessedTransactionReceipt::Commit(commit) = processed {
             let substate_changes = &commit.complete_receipt.on_ledger.substate_changes;
-            for (id, value) in substate_changes.upserted() {
-                self.substate_values.insert(id.clone(), value.clone());
-            }
-            for deleted_id in substate_changes.deleted_ids() {
-                self.substate_values.remove(deleted_id);
+            for substate_change in substate_changes {
+                let id = &substate_change.substate_id;
+                match &substate_change.action {
+                    ChangeAction::Create(value) | ChangeAction::Update(value) => {
+                        self.substate_values.insert(id.clone(), value.clone())
+                    }
+                    ChangeAction::Delete(_) => self.substate_values.remove(id),
+                };
             }
             let hash_structures_diff = &commit.hash_structures_diff;
             let state_tree_diff = &hash_structures_diff.state_tree_diff;

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -143,7 +143,7 @@ pub mod proofs {
 pub mod commit {
     use super::*;
     use crate::accumulator_tree::storage::TreeSlice;
-    use crate::{ReceiptTreeHash, SubstateChanges, TransactionTreeHash};
+    use crate::{ChangeAction, ReceiptTreeHash, SubstateChange, TransactionTreeHash};
     use radix_engine::ledger::OutputValue;
     use radix_engine_interface::api::types::{SubstateId, SubstateOffset};
     use radix_engine_stores::hash_tree::tree_store::{NodeKey, ReNodeModulePayload, TreeNode};
@@ -172,18 +172,23 @@ pub mod commit {
             }
         }
 
-        pub fn apply(&mut self, changes: &SubstateChanges) {
-            for (id, value) in &changes.created {
-                self.deleted_ids.remove(id);
-                self.upserted.insert(id.clone(), value.clone());
-            }
-            for (id, value) in &changes.updated {
-                self.upserted.insert(id.clone(), value.clone());
-            }
-            for (id, _) in &changes.deleted {
-                let previous_value = self.upserted.remove(id);
-                if previous_value.is_none() {
-                    self.deleted_ids.insert(id.clone());
+        pub fn apply(&mut self, changes: &Vec<SubstateChange>) {
+            for change in changes {
+                let id = &change.substate_id;
+                match &change.action {
+                    ChangeAction::Create(value) => {
+                        self.deleted_ids.remove(id);
+                        self.upserted.insert(id.clone(), value.clone());
+                    }
+                    ChangeAction::Update(value) => {
+                        self.upserted.insert(id.clone(), value.clone());
+                    }
+                    ChangeAction::Delete(_) => {
+                        let previous_value = self.upserted.remove(id);
+                        if previous_value.is_none() {
+                            self.deleted_ids.insert(id.clone());
+                        }
+                    }
                 }
             }
         }

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -241,6 +241,8 @@ impl From<Hash> for SubstateChangeHash {
     }
 }
 
+impl IsHash for SubstateChangeHash {}
+
 impl fmt::Display for SubstateChangeHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(self.0))


### PR DESCRIPTION
⚠️ This stacks on top of https://github.com/radixdlt/babylon-node/pull/372

This conceptually addresses one very focused `TODO` (replace a naive hash with a merkle tree root - the motivation is explained at the end of https://radixdlt.atlassian.net/wiki/spaces/S/pages/3016884225/REP-65+Consensus+Transaction+Receipt#Splitting-the-Engine-Receipt chapter).
To achieve this, I also had to shuffle the structure of `SubstateChanges` (see `fn into_change_list()`).