### PR TITLE
Removing some obsolete mempool metrics + Adding "from local API to commit" timer

### DIFF
--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -151,7 +151,6 @@ public record Metrics(
     Ledger ledger,
     LedgerSync sync,
     Mempool mempool,
-    V1Mempool v1Mempool,
     V1RadixEngine v1RadixEngine,
     Messages messages,
     Networking networking,
@@ -249,10 +248,7 @@ public record Metrics(
       Gauge currentStateVersion,
       Gauge targetStateVersion) {}
 
-  public record Mempool(Timer addTransaction) {}
-
-  public record V1Mempool(
-      Gauge size, Counter relaysSent, Counter addSuccesses, Counter addFailures) {}
+  public record Mempool(Counter relaysSent) {}
 
   public record V1RadixEngine(
       Counter invalidProposedTransactions, Counter userTransactions, Counter systemTransactions) {}

--- a/core-rust-bridge/src/main/java/com/radixdlt/mempool/RustMempool.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/mempool/RustMempool.java
@@ -66,7 +66,6 @@ package com.radixdlt.mempool;
 
 import static com.radixdlt.lang.Tuple.tuple;
 
-import com.google.common.base.Stopwatch;
 import com.google.common.hash.HashCode;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Result;
@@ -82,10 +81,7 @@ import java.util.List;
 
 public class RustMempool implements MempoolReader<RawNotarizedTransaction> {
 
-  private final Metrics metrics;
-
   public RustMempool(Metrics metrics, StateManager stateManager) {
-    this.metrics = metrics;
     LabelledTimer<MethodId> timer = metrics.stateManager().nativeCall();
     addFunc =
         Natives.builder(stateManager, RustMempool::add)
@@ -107,9 +103,7 @@ public class RustMempool implements MempoolReader<RawNotarizedTransaction> {
 
   public RawNotarizedTransaction addTransaction(RawNotarizedTransaction transaction)
       throws MempoolRejectedException {
-    final var stopwatch = Stopwatch.createStarted();
     final var result = addFunc.call(transaction);
-    metrics.mempool().addTransaction().observe(stopwatch.elapsed());
 
     // Handle Errors.
     if (result.isError()) {

--- a/core-rust/state-manager/src/mempool/mod.rs
+++ b/core-rust/state-manager/src/mempool/mod.rs
@@ -70,7 +70,7 @@ use crate::MetricLabel;
 
 pub use crate::pending_transaction_result_cache::*;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MempoolAddSource {
     CoreApi,
     MempoolSync,

--- a/core/src/main/java/com/radixdlt/mempool/MempoolRelayer.java
+++ b/core/src/main/java/com/radixdlt/mempool/MempoolRelayer.java
@@ -156,7 +156,7 @@ public final class MempoolRelayer {
         .limit(maxPeersToRelayTo)
         .forEach(
             peer -> {
-              metrics.v1Mempool().relaysSent().inc(transactions.size());
+              metrics.mempool().relaysSent().inc(transactions.size());
               this.remoteEventDispatcher.dispatch(peer, mempoolAddMsg);
             });
   }

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
@@ -111,9 +111,8 @@ public class MockedMempoolStateComputerModule extends AbstractModule {
 
   @Provides
   @Singleton
-  private Mempool<RawNotarizedTransaction, RawNotarizedTransaction> mempool(
-      Metrics metrics, Random random) {
-    return new SimpleMempool(metrics, mempoolMaxSize, random);
+  private Mempool<RawNotarizedTransaction, RawNotarizedTransaction> mempool(Random random) {
+    return new SimpleMempool(mempoolMaxSize, random);
   }
 
   @Provides
@@ -131,7 +130,6 @@ public class MockedMempoolStateComputerModule extends AbstractModule {
                 txn -> {
                   try {
                     mempool.addTransaction(txn);
-                    metrics.v1Mempool().size().set(mempool.getCount());
                   } catch (MempoolRejectedException e) {
                     log.error(e);
                   }
@@ -167,7 +165,6 @@ public class MockedMempoolStateComputerModule extends AbstractModule {
                 // This is a workaround for the mocking to keep things lightweight
                 .map(RawLedgerTransaction::INCORRECTInterpretDirectlyAsRawNotarizedTransaction)
                 .toList());
-        metrics.v1Mempool().size().set(mempool.getCount());
         var ledgerUpdate = new LedgerUpdate(txnsAndProof, ImmutableClassToInstanceMap.of());
         ledgerUpdateDispatcher.dispatch(ledgerUpdate);
       }


### PR DESCRIPTION
The first, no-brainer step towards https://radixdlt.atlassian.net/browse/NODE-545 (actually it is mentioned as point 4. there).

"You can't optimize what you don't measure."

_(by the power of flawed logic, now we measure it, so we'll definitely be able to optimize it)_

I decided to measure exactly the thing that end-client wants:
```
# HELP rn_mempool_from_local_api_to_commit_wait_seconds Time spent in the mempool, by a transaction coming from local API, until successful commit.
# TYPE rn_mempool_from_local_api_to_commit_wait_seconds histogram
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="0.01"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="0.1"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="0.5"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="1"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="2.5"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="5"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="10"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="25"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="50"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_bucket{le="+Inf"} 0
rn_mempool_from_local_api_to_commit_wait_seconds_sum 0
rn_mempool_from_local_api_to_commit_wait_seconds_count 0
```

Apart from that, some metric clean-up went in.