### PR TITLE
Refactor: Separate the StateManagerDatabase from StateManager (Rust-only)

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/StateManagerSbor.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/StateManagerSbor.java
@@ -79,6 +79,8 @@ import com.radixdlt.statecomputer.commit.*;
 import com.radixdlt.statemanager.*;
 import com.radixdlt.transaction.CommittedTransactionStatus;
 import com.radixdlt.transaction.ExecutedTransaction;
+import com.radixdlt.transaction.TxnsAndProof;
+import com.radixdlt.transaction.TxnsAndProofRequest;
 import com.radixdlt.transactions.RawLedgerTransaction;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt16;
@@ -129,6 +131,8 @@ public final class StateManagerSbor {
     MempoolError.registerCodec(codecMap);
     CommittedTransactionStatus.registerCodec(codecMap);
     ExecutedTransaction.registerCodec(codecMap);
+    TxnsAndProofRequest.registerCodec(codecMap);
+    TxnsAndProof.registerCodec(codecMap);
     PublicKey.registerCodec(codecMap);
     ECDSASecp256k1PublicKey.registerCodec(codecMap);
     EdDSAEd25519PublicKey.registerCodec(codecMap);

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
@@ -73,14 +73,12 @@ import com.radixdlt.mempool.RustMempool;
 import com.radixdlt.monitoring.LabelledTimer;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.monitoring.Metrics.MethodId;
-import com.radixdlt.recovery.VertexStoreRecovery;
 import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.ValidatorInfo;
 import com.radixdlt.sbor.Natives;
 import com.radixdlt.statecomputer.commit.*;
 import com.radixdlt.statemanager.StateManager;
-import com.radixdlt.transaction.REv2TransactionAndProofStore;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt64;
 import java.util.List;
@@ -88,24 +86,16 @@ import java.util.Objects;
 
 public class RustStateComputer {
   private final RustMempool mempool;
-  private final REv2TransactionAndProofStore transactionStore;
-  private final VertexStoreRecovery vertexStoreRecovery;
 
   public RustStateComputer(Metrics metrics, StateManager stateManager) {
     Objects.requireNonNull(stateManager);
 
     this.mempool = new RustMempool(metrics, stateManager);
-    this.transactionStore = new REv2TransactionAndProofStore(metrics, stateManager);
-    this.vertexStoreRecovery = new VertexStoreRecovery(metrics, stateManager);
 
     LabelledTimer<MethodId> timer = metrics.stateManager().nativeCall();
     this.verifyFunc =
         Natives.builder(stateManager, RustStateComputer::verify)
             .measure(timer.label(new MethodId(RustStateComputer.class, "verify")))
-            .build(new TypeToken<>() {});
-    this.saveVertexStoreFunc =
-        Natives.builder(stateManager, RustStateComputer::saveVertexStore)
-            .measure(timer.label(new MethodId(RustStateComputer.class, "saveVertexStore")))
             .build(new TypeToken<>() {});
     this.prepareGenesisFunc =
         Natives.builder(stateManager, RustStateComputer::prepareGenesis)
@@ -133,14 +123,6 @@ public class RustStateComputer {
             .build(new TypeToken<>() {});
   }
 
-  public VertexStoreRecovery getVertexStoreRecovery() {
-    return vertexStoreRecovery;
-  }
-
-  public REv2TransactionAndProofStore getTransactionAndProofStore() {
-    return this.transactionStore;
-  }
-
   public MempoolReader<RawNotarizedTransaction> getMempoolReader() {
     return this.mempool;
   }
@@ -162,14 +144,6 @@ public class RustStateComputer {
   private final Natives.Call1<RawNotarizedTransaction, Result<Tuple.Tuple0, String>> verifyFunc;
 
   private static native byte[] verify(StateManager stateManager, byte[] payload);
-
-  public void saveVertexStore(byte[] vertexStoreBytes) {
-    saveVertexStoreFunc.call(vertexStoreBytes);
-  }
-
-  private final Natives.Call1<byte[], Tuple.Tuple0> saveVertexStoreFunc;
-
-  private static native byte[] saveVertexStore(StateManager stateManager, byte[] payload);
 
   public PrepareGenesisResult prepareGenesis(PrepareGenesisRequest prepareGenesisRequest) {
     return prepareGenesisFunc.call(prepareGenesisRequest);

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
@@ -75,14 +75,10 @@ import com.radixdlt.statecomputer.commit.LedgerProof;
 import com.radixdlt.statemanager.StateManager;
 import com.radixdlt.utils.UInt32;
 import com.radixdlt.utils.UInt64;
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public final class REv2TransactionAndProofStore {
   public REv2TransactionAndProofStore(Metrics metrics, StateManager stateManager) {
-    Objects.requireNonNull(stateManager);
-
     LabelledTimer<MethodId> timer = metrics.stateManager().nativeCall();
     this.getTransactionAtStateVersionFunc =
         Natives.builder(stateManager, REv2TransactionAndProofStore::getTransactionAtStateVersion)
@@ -110,12 +106,12 @@ public final class REv2TransactionAndProofStore {
     return this.getTransactionAtStateVersionFunc.call(UInt64.fromNonNegativeLong(stateVersion));
   }
 
-  public Option<Tuple.Tuple2<List<byte[]>, LedgerProof>> getTxnsAndProof(
+  public Option<TxnsAndProof> getTxnsAndProof(
       long startStateVersionInclusive,
       int maxNumberOfTxnsIfMoreThanOneProof,
       int maxPayloadSizeInBytes) {
     return this.getTxnsAndProof.call(
-        Tuple.Tuple3.of(
+        new TxnsAndProofRequest(
             UInt64.fromNonNegativeLong(startStateVersionInclusive),
             UInt32.fromNonNegativeInt(maxNumberOfTxnsIfMoreThanOneProof),
             UInt32.fromNonNegativeInt(maxPayloadSizeInBytes)));
@@ -134,9 +130,7 @@ public final class REv2TransactionAndProofStore {
   private static native byte[] getTransactionAtStateVersion(
       StateManager stateManager, byte[] payload);
 
-  private final Natives.Call1<
-          Tuple.Tuple3<UInt64, UInt32, UInt32>, Option<Tuple.Tuple2<List<byte[]>, LedgerProof>>>
-      getTxnsAndProof;
+  private final Natives.Call1<TxnsAndProofRequest, Option<TxnsAndProof>> getTxnsAndProof;
 
   private static native byte[] getTxnsAndProof(StateManager stateManager, byte[] payload);
 

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/TxnsAndProofRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/TxnsAndProofRequest.java
@@ -62,44 +62,21 @@
  * permissions under this License.
  */
 
-package com.radixdlt.recovery;
+package com.radixdlt.transaction;
 
-import com.google.common.reflect.TypeToken;
-import com.radixdlt.lang.Option;
-import com.radixdlt.lang.Tuple;
-import com.radixdlt.monitoring.LabelledTimer;
-import com.radixdlt.monitoring.Metrics;
-import com.radixdlt.sbor.Natives;
-import com.radixdlt.statemanager.StateManager;
-import java.util.Optional;
+import com.radixdlt.sbor.codec.CodecMap;
+import com.radixdlt.sbor.codec.StructCodec;
+import com.radixdlt.utils.UInt32;
+import com.radixdlt.utils.UInt64;
 
-public final class VertexStoreRecovery {
-  public VertexStoreRecovery(Metrics metrics, StateManager stateManager) {
-    LabelledTimer<Metrics.MethodId> timer = metrics.stateManager().nativeCall();
-    this.getVertexStore =
-        Natives.builder(stateManager, VertexStoreRecovery::getVertexStore)
-            .measure(timer.label(new Metrics.MethodId(VertexStoreRecovery.class, "getVertexStore")))
-            .build(new TypeToken<>() {});
-    this.saveVertexStoreFunc =
-        Natives.builder(stateManager, VertexStoreRecovery::saveVertexStore)
-            .measure(
-                timer.label(new Metrics.MethodId(VertexStoreRecovery.class, "saveVertexStore")))
-            .build(new TypeToken<>() {});
+/** A request for listing a batch of transactions together with their proof. */
+public record TxnsAndProofRequest(
+    UInt64 startStateVersionInclusive,
+    UInt32 maxNumberOfTxnsIfMoreThanOneProof,
+    UInt32 maxPayloadSizeInBytes) {
+  public static void registerCodec(CodecMap codecMap) {
+    codecMap.register(
+        TxnsAndProofRequest.class,
+        codecs -> StructCodec.fromRecordComponents(TxnsAndProofRequest.class, codecs));
   }
-
-  public Optional<byte[]> recoverVertexStore() {
-    return this.getVertexStore.call(Tuple.tuple()).toOptional();
-  }
-
-  private static native byte[] getVertexStore(StateManager stateManager, byte[] payload);
-
-  private final Natives.Call1<Tuple.Tuple0, Option<byte[]>> getVertexStore;
-
-  public void saveVertexStore(byte[] vertexStoreBytes) {
-    this.saveVertexStoreFunc.call(vertexStoreBytes);
-  }
-
-  private static native byte[] saveVertexStore(StateManager stateManager, byte[] payload);
-
-  private final Natives.Call1<byte[], Tuple.Tuple0> saveVertexStoreFunc;
 }

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
@@ -5,6 +5,7 @@ use state_manager::{
     jni::state_manager::ActualStateManager,
     query::{dump_component_state, VaultData},
 };
+use std::ops::Deref;
 
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_lts_state_account_all_fungible_resource_balances(
@@ -37,7 +38,8 @@ fn handle_lts_state_account_all_fungible_resource_balances_internal(
         extract_component_address(&extraction_context, &request.account_address)
             .map_err(|err| err.into_response_error("account_address"))?;
 
-    let component_dump = match dump_component_state(state_manager.store(), component_address) {
+    let read_store = state_manager.store();
+    let component_dump = match dump_component_state(read_store.deref(), component_address) {
         Ok(component_dump) => component_dump,
         Err(err) => match component_address {
             ComponentAddress::Account(_) => return Err(not_found_error("Account not found")),

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
@@ -5,6 +5,7 @@ use state_manager::{
     query::{dump_component_state, VaultData},
     store::traits::QueryableProofStore,
 };
+use std::ops::Deref;
 
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_lts_state_account_fungible_resource_balance(
@@ -48,7 +49,8 @@ fn handle_lts_state_account_fungible_resource_balance_internal(
             .map_err(|err| err.into_response_error("account_address"))?;
 
     // TODO: super-inefficient implementation - change before mainnet
-    let component_dump = match dump_component_state(state_manager.store(), component_address) {
+    let read_store = state_manager.store();
+    let component_dump = match dump_component_state(read_store.deref(), component_address) {
         Ok(component_dump) => component_dump,
         Err(err) => match component_address {
             ComponentAddress::Account(_) => return Err(not_found_error("Account not found")),

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
@@ -19,6 +19,7 @@ pub(crate) async fn handle_lts_transaction_status(
 
 use models::lts_transaction_payload_status::Status as LtsPayloadStatus;
 use models::LtsTransactionIntentStatus as LtsIntentStatus;
+use state_manager::query::StateManagerSubstateQueries;
 
 fn handle_lts_transaction_status_internal(
     state_manager: &ActualStateManager,
@@ -39,7 +40,7 @@ fn handle_lts_transaction_status_internal(
         .pending_transaction_result_cache
         .peek_all_known_payloads_for_intent(&intent_hash);
 
-    let current_epoch = state_manager.get_epoch();
+    let current_epoch = state_manager.store().get_epoch();
 
     let invalid_from_epoch = known_pending_payloads
         .iter()

--- a/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
@@ -4,6 +4,7 @@ use radix_engine::types::{AccessControllerOffset, NodeModuleId, SubstateOffset};
 use radix_engine_interface::api::types::{AccessRulesOffset, RENodeId};
 use state_manager::jni::state_manager::ActualStateManager;
 use state_manager::query::{dump_component_state, VaultData};
+use std::ops::Deref;
 
 use super::map_to_descendent_id;
 
@@ -61,7 +62,8 @@ fn handle_state_access_controller_internal(
         substate
     };
 
-    let component_dump = dump_component_state(state_manager.store(), controller_address)
+    let read_store = state_manager.store();
+    let component_dump = dump_component_state(read_store.deref(), controller_address)
         .map_err(|err| server_error(format!("Error traversing component state: {err:?}")))?;
 
     let state_owned_vaults = component_dump

--- a/core-rust/core-api-server/src/core_api/handlers/state_component.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_component.rs
@@ -6,6 +6,7 @@ use radix_engine_interface::api::types::{
 };
 use state_manager::jni::state_manager::ActualStateManager;
 use state_manager::query::{dump_component_state, VaultData};
+use std::ops::Deref;
 
 pub(crate) async fn handle_state_component(
     state: State<CoreApiState>,
@@ -118,7 +119,8 @@ fn handle_state_component_internal(
         substate
     };
 
-    let component_dump = dump_component_state(state_manager.store(), component_address)
+    let read_store = state_manager.store();
+    let component_dump = dump_component_state(read_store.deref(), component_address)
         .map_err(|err| server_error(format!("Error traversing component state: {err:?}")))?;
 
     let state_owned_vaults = component_dump

--- a/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
@@ -4,6 +4,7 @@ use radix_engine::types::{NodeModuleId, SubstateOffset, ValidatorOffset};
 use radix_engine_interface::api::types::{AccessRulesOffset, RENodeId};
 use state_manager::jni::state_manager::ActualStateManager;
 use state_manager::query::{dump_component_state, VaultData};
+use std::ops::Deref;
 
 use super::map_to_descendent_id;
 
@@ -60,7 +61,8 @@ fn handle_state_validator_internal(
         substate
     };
 
-    let component_dump = dump_component_state(state_manager.store(), validator_address)
+    let read_store = state_manager.store();
+    let component_dump = dump_component_state(read_store.deref(), validator_address)
         .map_err(|err| server_error(format!("Error traversing component state: {err:?}")))?;
 
     let state_owned_vaults = component_dump

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -13,6 +13,7 @@ use radix_engine_interface::manifest_args;
 use radix_engine_interface::{
     blueprints::transaction_processor::InstructionOutput, data::scrypto::scrypto_encode,
 };
+use state_manager::query::StateManagerSubstateQueries;
 use state_manager::PreviewRequest;
 use transaction::model::{Instruction, PreviewFlags, TransactionManifest};
 
@@ -80,7 +81,7 @@ pub(crate) async fn handle_transaction_callpreview(
         }
     };
 
-    let epoch = state_manager.get_epoch();
+    let epoch = state_manager.store().get_epoch();
 
     let result = state_manager
         .preview(PreviewRequest {

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -19,6 +19,7 @@ pub(crate) async fn handle_transaction_status(
 
 use models::transaction_payload_status::Status as PayloadStatus;
 use models::TransactionIntentStatus as IntentStatus;
+use state_manager::query::StateManagerSubstateQueries;
 
 fn handle_transaction_status_internal(
     state_manager: &ActualStateManager,
@@ -39,7 +40,7 @@ fn handle_transaction_status_internal(
         .pending_transaction_result_cache
         .peek_all_known_payloads_for_intent(&intent_hash);
 
-    let current_epoch = state_manager.get_epoch();
+    let current_epoch = state_manager.store().get_epoch();
 
     let invalid_from_epoch = known_pending_payloads
         .iter()

--- a/core-rust/state-manager/src/jni/state_manager.rs
+++ b/core-rust/state-manager/src/jni/state_manager.rs
@@ -131,6 +131,7 @@ pub type ActualStateManager = StateManager<StateManagerDatabase>;
 
 pub struct JNIStateManager {
     pub state_manager: Arc<RwLock<ActualStateManager>>,
+    pub database: Arc<RwLock<StateManagerDatabase>>,
 }
 
 impl JNIStateManager {
@@ -149,18 +150,22 @@ impl JNIStateManager {
             }
         };
 
-        let store = StateManagerDatabase::from_config(config.db_config);
-        let mempool = SimpleMempool::new(mempool_config);
+        let database = Arc::new(parking_lot::const_rwlock(
+            StateManagerDatabase::from_config(config.db_config),
+        ));
 
         // Build the state manager.
         let state_manager = Arc::new(parking_lot::const_rwlock(StateManager::new(
             config.network_definition,
-            mempool,
-            store,
+            SimpleMempool::new(mempool_config),
+            database.clone(),
             config.logging_config,
         )));
 
-        let jni_state_manager = JNIStateManager { state_manager };
+        let jni_state_manager = JNIStateManager {
+            state_manager,
+            database,
+        };
 
         env.set_rust_field(j_state_manager, POINTER_JNI_FIELD_NAME, jni_state_manager)
             .unwrap();
@@ -182,6 +187,16 @@ impl JNIStateManager {
             .get_rust_field(j_state_manager, POINTER_JNI_FIELD_NAME)
             .unwrap();
         jni_state_manager.state_manager.clone()
+    }
+
+    pub fn get_database(
+        env: &JNIEnv,
+        j_state_manager: JObject,
+    ) -> Arc<RwLock<StateManagerDatabase>> {
+        let jni_state_manager: MutexGuard<JNIStateManager> = env
+            .get_rust_field(j_state_manager, POINTER_JNI_FIELD_NAME)
+            .unwrap();
+        jni_state_manager.database.clone()
     }
 }
 

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -890,15 +890,6 @@ impl StateTracker {
 
 impl<'db, S> StateManager<S>
 where
-    S: WriteableVertexStore,
-{
-    pub fn save_vertex_store(&'db mut self, vertex_store: Vec<u8>) {
-        self.store.write().save_vertex_store(vertex_store);
-    }
-}
-
-impl<'db, S> StateManager<S>
-where
     S: CommitStore,
     S: ReadableStore,
     S: QueryableProofStore + TransactionIdentifierLoader,

--- a/core/src/main/java/com/radixdlt/rev2/REv2TransactionsAndProofReader.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2TransactionsAndProofReader.java
@@ -108,8 +108,10 @@ public final class REv2TransactionsAndProofReader implements TransactionsAndProo
         .map(
             rawTxnsAndProof ->
                 CommittedTransactionsWithProof.create(
-                    rawTxnsAndProof.first().stream().map(RawLedgerTransaction::create).toList(),
-                    REv2ToConsensus.ledgerProof(rawTxnsAndProof.last())))
+                    rawTxnsAndProof.transactions().stream()
+                        .map(RawLedgerTransaction::create)
+                        .toList(),
+                    REv2ToConsensus.ledgerProof(rawTxnsAndProof.proof())))
         .or(() -> null);
   }
 

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
@@ -216,13 +216,14 @@ public final class REv2StateManagerModule extends AbstractModule {
           }
 
           @Provides
-          REv2TransactionAndProofStore transactionAndProofStore(RustStateComputer stateComputer) {
-            return stateComputer.getTransactionAndProofStore();
+          REv2TransactionAndProofStore transactionAndProofStore(
+              Metrics metrics, StateManager stateManager) {
+            return new REv2TransactionAndProofStore(metrics, stateManager);
           }
 
           @Provides
-          VertexStoreRecovery rEv2VertexStoreRecovery(RustStateComputer stateComputer) {
-            return stateComputer.getVertexStoreRecovery();
+          VertexStoreRecovery rEv2VertexStoreRecovery(Metrics metrics, StateManager stateManager) {
+            return new VertexStoreRecovery(metrics, stateManager);
           }
 
           @Provides
@@ -250,11 +251,11 @@ public final class REv2StateManagerModule extends AbstractModule {
 
           @Provides
           PersistentVertexStore vertexStore(
-              RustStateComputer stateComputer, Metrics metrics, Serialization serialization) {
+              VertexStoreRecovery recovery, Metrics metrics, Serialization serialization) {
             return s -> {
               metrics.misc().vertexStoreSaved().inc();
               var vertexStoreBytes = serialization.toDson(s.toSerialized(), DsonOutput.Output.ALL);
-              stateComputer.saveVertexStore(vertexStoreBytes);
+              recovery.saveVertexStore(vertexStoreBytes);
             };
           }
 


### PR DESCRIPTION
⚠️ this is an ALTERNATIVE to https://github.com/radixdlt/babylon-node/pull/405

This PR achieves the same separation of concerns (and - in future - of locks!) on Rust's side, while not touching the Java side. (it means literally 50% less code changes)

The motivation stays exactly the same as in https://github.com/radixdlt/babylon-node/pull/405#issue-1658765012 
The implementation is also very similar, with just one difference: instead of splitting the ownership at Java side, we still have just one Java `StateManager` and one Rust `JNIStateManager`. The split here happens at `JNIStateManager`, which separately owns an `ActualStateManager` and a `StateManagerDatabase`. This way, some operations may e.g. lock only the `StateManagerDatabase`, without locking `ActualStateManager.