### PR TITLE
Providing the mempool relay dispatcher in a way available to pre-genesis injector

### DIFF
--- a/core/src/main/java/com/radixdlt/genesis/PreGenesisNodeModule.java
+++ b/core/src/main/java/com/radixdlt/genesis/PreGenesisNodeModule.java
@@ -66,12 +66,10 @@ package com.radixdlt.genesis;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.radixdlt.consensus.ConsensusByzantineEvent;
-import com.radixdlt.environment.Dispatchers;
 import com.radixdlt.environment.Environment;
 import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.environment.EventProcessorOnDispatch;
@@ -79,12 +77,14 @@ import com.radixdlt.environment.NoOpEnvironment;
 import com.radixdlt.lang.Option;
 import com.radixdlt.ledger.LedgerUpdate;
 import com.radixdlt.mempool.MempoolAddSuccess;
+import com.radixdlt.mempool.MempoolRelayDispatcher;
 import com.radixdlt.modules.CryptoModule;
 import com.radixdlt.modules.MetricsModule;
 import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.modules.REv2StateManagerModule;
 import com.radixdlt.rev2.modules.REv2StateManagerModule.DatabaseType;
 import com.radixdlt.store.NodeStorageLocationFromPropertiesModule;
+import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.properties.RuntimeProperties;
 
 public final class PreGenesisNodeModule extends AbstractModule {
@@ -111,15 +111,11 @@ public final class PreGenesisNodeModule extends AbstractModule {
     we're just using a no-op dispatchers/environment here. */
     bind(Environment.class).toInstance(new NoOpEnvironment());
     Multibinder.newSetBinder(binder(), new TypeLiteral<EventProcessorOnDispatch<?>>() {});
-    bind(new TypeLiteral<EventDispatcher<ConsensusByzantineEvent>>() {})
-        .toProvider(Dispatchers.dispatcherProvider(ConsensusByzantineEvent.class))
-        .in(Scopes.SINGLETON);
-    bind(new TypeLiteral<EventDispatcher<MempoolAddSuccess>>() {})
-        .toProvider(Dispatchers.dispatcherProvider(MempoolAddSuccess.class))
-        .in(Scopes.SINGLETON);
-    bind(new TypeLiteral<EventDispatcher<LedgerUpdate>>() {})
-        .toProvider(Dispatchers.dispatcherProvider(LedgerUpdate.class))
-        .in(Scopes.SINGLETON);
+    bind(new TypeLiteral<EventDispatcher<ConsensusByzantineEvent>>() {}).toInstance(event -> {});
+    bind(new TypeLiteral<EventDispatcher<MempoolAddSuccess>>() {}).toInstance(event -> {});
+    bind(new TypeLiteral<EventDispatcher<LedgerUpdate>>() {}).toInstance(event -> {});
+    bind(new TypeLiteral<MempoolRelayDispatcher<RawNotarizedTransaction>>() {})
+        .toInstance(transaction -> {});
     install(REv2StateManagerModule.create(0, 0, 0, DatabaseType.ROCKS_DB, Option.empty()));
   }
 

--- a/core/src/main/java/com/radixdlt/keys/InMemoryBFTKeyModule.java
+++ b/core/src/main/java/com/radixdlt/keys/InMemoryBFTKeyModule.java
@@ -70,6 +70,7 @@ import com.radixdlt.consensus.HashSigner;
 import com.radixdlt.consensus.bft.Self;
 import com.radixdlt.crypto.ECDSASecp256k1PublicKey;
 import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.p2p.NodeId;
 import java.util.Objects;
 
 /** In memory Hash signing and identity handling */
@@ -94,5 +95,11 @@ public final class InMemoryBFTKeyModule extends AbstractModule {
   @Self
   ECDSASecp256k1PublicKey publicKey() {
     return keyPair.getPublicKey();
+  }
+
+  @Provides
+  @Self
+  NodeId nodeId(@Self ECDSASecp256k1PublicKey key) {
+    return NodeId.fromPublicKey(key);
   }
 }

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
@@ -80,7 +80,6 @@ import com.radixdlt.ledger.StateComputerLedger;
 import com.radixdlt.mempool.*;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.networks.Network;
-import com.radixdlt.p2p.NodeId;
 import com.radixdlt.recovery.VertexStoreRecovery;
 import com.radixdlt.rev2.*;
 import com.radixdlt.serialization.DsonOutput;
@@ -215,16 +214,6 @@ public final class REv2StateManagerModule extends AbstractModule {
                 byzantineEventEventDispatcher,
                 serialization,
                 metrics);
-          }
-
-          @Provides
-          MempoolRelayDispatcher<RawNotarizedTransaction> mempoolRelayDispatcher(
-              EventDispatcher<MempoolAddSuccess> mempoolAddSuccessEventDispatcher,
-              @Self NodeId selfNodeId) {
-            return transaction ->
-                mempoolAddSuccessEventDispatcher.dispatch(
-                    MempoolAddSuccess.create(
-                        RawNotarizedTransaction.create(transaction.getPayload()), selfNodeId));
           }
 
           @Provides

--- a/core/src/test/java/com/radixdlt/api/SystemApiTestBase.java
+++ b/core/src/test/java/com/radixdlt/api/SystemApiTestBase.java
@@ -85,7 +85,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.SingleNodeAndPeersDeterministicNetworkModule;
 import com.radixdlt.modules.StateComputerConfig;
 import com.radixdlt.networks.Network;
-import com.radixdlt.p2p.NodeId;
 import com.radixdlt.p2p.P2PConfig;
 import com.radixdlt.p2p.RadixNodeUri;
 import com.radixdlt.p2p.TestP2PModule;
@@ -153,9 +152,6 @@ public abstract class SystemApiTestBase {
                         "localhost",
                         23456);
                 bind(RadixNodeUri.class).annotatedWith(Self.class).toInstance(selfUri);
-                bind(NodeId.class)
-                    .annotatedWith(Self.class)
-                    .toInstance(NodeId.fromPublicKey(TEST_KEY.getPublicKey()));
                 var runtimeProperties = mock(RuntimeProperties.class);
                 bind(RuntimeProperties.class).toInstance(runtimeProperties);
                 bind(HealthInfoService.class).to(HealthInfoServiceImpl.class);

--- a/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
@@ -77,6 +77,7 @@ import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.lang.Option;
 import com.radixdlt.ledger.*;
 import com.radixdlt.mempool.MempoolAddSuccess;
+import com.radixdlt.mempool.MempoolRelayDispatcher;
 import com.radixdlt.modules.CryptoModule;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.monitoring.MetricsInitializer;
@@ -108,6 +109,8 @@ public class REv2StateComputerTest {
             bind(LedgerAccumulator.class).to(SimpleLedgerAccumulatorAndVerifier.class);
             bind(new TypeLiteral<EventDispatcher<LedgerUpdate>>() {}).toInstance(e -> {});
             bind(new TypeLiteral<EventDispatcher<MempoolAddSuccess>>() {}).toInstance(e -> {});
+            bind(new TypeLiteral<MempoolRelayDispatcher<RawNotarizedTransaction>>() {})
+                .toInstance(e -> {});
             bind(new TypeLiteral<EventDispatcher<ConsensusByzantineEvent>>() {})
                 .toInstance(e -> {});
             bind(Metrics.class).toInstance(new MetricsInitializer().initialize());


### PR DESCRIPTION
A small bugfix for a "node cannot boot-up" problem introduced by https://github.com/radixdlt/babylon-node/pull/404 (reported at https://rdxworks.slack.com/archives/C01M90Y2448/p1681725787060909)