### PR TITLE
Refactor: Splitting the immutable part out from StateManager

### DIFF
--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
@@ -1,23 +1,12 @@
 use crate::core_api::*;
-use state_manager::{jni::state_manager::ActualStateManager, store::traits::QueryableProofStore};
+use state_manager::store::traits::QueryableProofStore;
 
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_lts_stream_account_transaction_outcomes(
     state: State<CoreApiState>,
-    request: Json<models::LtsStreamAccountTransactionOutcomesRequest>,
+    Json(request): Json<models::LtsStreamAccountTransactionOutcomesRequest>,
 ) -> Result<Json<models::LtsStreamAccountTransactionOutcomesResponse>, ResponseError<()>> {
-    core_api_read_handler(
-        state,
-        request,
-        handle_lts_stream_account_transaction_outcomes_internal,
-    )
-}
-
-fn handle_lts_stream_account_transaction_outcomes_internal(
-    state_manager: &ActualStateManager,
-    request: models::LtsStreamAccountTransactionOutcomesRequest,
-) -> Result<models::LtsStreamAccountTransactionOutcomesResponse, ResponseError<()>> {
-    assert_matching_network(&request.network, &state_manager.network)?;
+    assert_matching_network(&request.network, &state.network)?;
 
     let _from_state_version: u64 = extract_api_state_version(request.from_state_version)
         .map_err(|err| err.into_response_error("from_state_version"))?;
@@ -37,7 +26,10 @@ fn handle_lts_stream_account_transaction_outcomes_internal(
         )));
     }
 
-    let _max_state_version = state_manager.store().max_state_version();
+    let state_manager = state.state_manager.read();
+    let read_store = state_manager.store();
+
+    let _max_state_version = read_store.max_state_version();
 
     Err(not_implemented("Endpoint not implemented yet"))
 }

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
@@ -12,14 +12,13 @@ pub(crate) async fn handle_lts_transaction_submit(
     Json<models::LtsTransactionSubmitResponse>,
     ResponseError<LtsTransactionSubmitErrorDetails>,
 > {
-    let mut state_manager = state.state_manager.write();
-
-    let mapping_context = MappingContext::new_for_uncommitted_data(&state_manager.network);
-
-    assert_matching_network(&request.network, &state_manager.network)?;
+    assert_matching_network(&request.network, &state.network)?;
+    let mapping_context = MappingContext::new_for_uncommitted_data(&state.network);
 
     let notarized_transaction = extract_unvalidated_transaction(&request.notarized_transaction_hex)
         .map_err(|err| err.into_response_error("notarized_transaction"))?;
+
+    let mut state_manager = state.state_manager.write();
 
     let result = state_manager
         .add_to_mempool_and_trigger_relay(MempoolAddSource::CoreApi, notarized_transaction);

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
@@ -5,8 +5,8 @@ pub(crate) async fn handle_mempool_list(
     State(state): State<CoreApiState>,
     Json(request): Json<models::MempoolListRequest>,
 ) -> Result<Json<models::MempoolListResponse>, ResponseError<()>> {
+    assert_matching_network(&request.network, &state.network)?;
     let state_manager = state.state_manager.read();
-    assert_matching_network(&request.network, &state_manager.network)?;
 
     let mempool = state_manager.mempool.read();
     Ok(models::MempoolListResponse {

--- a/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
@@ -5,37 +5,32 @@ use radix_engine::blueprints::resource::{
 use radix_engine::system::node_substates::PersistedSubstate;
 use radix_engine::types::{ResourceAddress, ResourceManagerOffset, SubstateOffset};
 use radix_engine_interface::api::types::{AccessRulesOffset, NodeModuleId, RENodeId};
-
-use state_manager::jni::state_manager::ActualStateManager;
-
-pub(crate) async fn handle_state_resource(
-    state: State<CoreApiState>,
-    request: Json<models::StateResourceRequest>,
-) -> Result<Json<models::StateResourceResponse>, ResponseError<()>> {
-    core_api_read_handler(state, request, handle_state_resource_internal)
-}
+use std::ops::Deref;
 
 enum ManagerByType {
     Fungible(FungibleResourceManagerSubstate),
     NonFungible(NonFungibleResourceManagerSubstate),
 }
 
-fn handle_state_resource_internal(
-    state_manager: &ActualStateManager,
-    request: models::StateResourceRequest,
-) -> Result<models::StateResourceResponse, ResponseError<()>> {
-    assert_matching_network(&request.network, &state_manager.network)?;
-    let extraction_context = ExtractionContext::new(&state_manager.network);
+pub(crate) async fn handle_state_resource(
+    state: State<CoreApiState>,
+    Json(request): Json<models::StateResourceRequest>,
+) -> Result<Json<models::StateResourceResponse>, ResponseError<()>> {
+    assert_matching_network(&request.network, &state.network)?;
+    let mapping_context = MappingContext::new(&state.network);
+    let extraction_context = ExtractionContext::new(&state.network);
 
     let resource_address = extract_resource_address(&extraction_context, &request.resource_address)
         .map_err(|err| err.into_response_error("resource_address"))?;
+
+    let state_manager = state.state_manager.read();
 
     let manager = match &resource_address {
         ResourceAddress::Fungible(_) => {
             let substate_offset =
                 SubstateOffset::ResourceManager(ResourceManagerOffset::ResourceManager);
             let loaded_substate = read_mandatory_substate(
-                state_manager,
+                state_manager.deref(),
                 RENodeId::GlobalObject(resource_address.into()),
                 NodeModuleId::SELF,
                 &substate_offset,
@@ -49,7 +44,7 @@ fn handle_state_resource_internal(
             let substate_offset =
                 SubstateOffset::ResourceManager(ResourceManagerOffset::ResourceManager);
             let loaded_substate = read_mandatory_substate(
-                state_manager,
+                state_manager.deref(),
                 RENodeId::GlobalObject(resource_address.into()),
                 NodeModuleId::SELF,
                 &substate_offset,
@@ -63,7 +58,7 @@ fn handle_state_resource_internal(
     let access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager,
+            state_manager.deref(),
             RENodeId::GlobalObject(resource_address.into()),
             NodeModuleId::AccessRules,
             &substate_offset,
@@ -77,7 +72,7 @@ fn handle_state_resource_internal(
     let vault_access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager,
+            state_manager.deref(),
             RENodeId::GlobalObject(resource_address.into()),
             NodeModuleId::AccessRules1,
             &substate_offset,
@@ -87,8 +82,6 @@ fn handle_state_resource_internal(
         };
         substate
     };
-
-    let mapping_context = MappingContext::new(&state_manager.network);
 
     Ok(models::StateResourceResponse {
         manager: Some(match &manager {
@@ -108,4 +101,5 @@ fn handle_state_resource_internal(
             &vault_access_rules,
         )?),
     })
+    .map(Json)
 }

--- a/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
@@ -2,7 +2,7 @@ use crate::core_api::*;
 use radix_engine::system::node_substates::PersistedSubstate;
 use radix_engine::types::{NodeModuleId, SubstateOffset, ValidatorOffset};
 use radix_engine_interface::api::types::{AccessRulesOffset, RENodeId};
-use state_manager::jni::state_manager::ActualStateManager;
+
 use state_manager::query::{dump_component_state, VaultData};
 use std::ops::Deref;
 
@@ -10,19 +10,12 @@ use super::map_to_descendent_id;
 
 pub(crate) async fn handle_state_validator(
     state: State<CoreApiState>,
-    request: Json<models::StateValidatorRequest>,
+    Json(request): Json<models::StateValidatorRequest>,
 ) -> Result<Json<models::StateValidatorResponse>, ResponseError<()>> {
-    core_api_read_handler(state, request, handle_state_validator_internal)
-}
+    assert_matching_network(&request.network, &state.network)?;
 
-fn handle_state_validator_internal(
-    state_manager: &ActualStateManager,
-    request: models::StateValidatorRequest,
-) -> Result<models::StateValidatorResponse, ResponseError<()>> {
-    assert_matching_network(&request.network, &state_manager.network)?;
-
-    let mapping_context = MappingContext::new(&state_manager.network);
-    let extraction_context = ExtractionContext::new(&state_manager.network);
+    let mapping_context = MappingContext::new(&state.network);
+    let extraction_context = ExtractionContext::new(&state.network);
 
     let validator_address =
         extract_component_address(&extraction_context, &request.validator_address)
@@ -34,10 +27,12 @@ fn handle_state_validator_internal(
         ));
     }
 
+    let state_manager = state.state_manager.read();
+
     let component_state = {
         let substate_offset = SubstateOffset::Validator(ValidatorOffset::Validator);
         let loaded_substate = read_mandatory_substate(
-            state_manager,
+            state_manager.deref(),
             RENodeId::GlobalObject(validator_address.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -50,7 +45,7 @@ fn handle_state_validator_internal(
     let component_access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager,
+            state_manager.deref(),
             RENodeId::GlobalObject(validator_address.into()),
             NodeModuleId::AccessRules,
             &substate_offset,
@@ -99,4 +94,5 @@ fn handle_state_validator_internal(
         state_owned_vaults,
         descendent_ids,
     })
+    .map(Json)
 }

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
@@ -1,21 +1,14 @@
 use crate::core_api::*;
 use radix_engine::types::*;
 use radix_engine_interface::address::{EntityType, HrpSet};
-use state_manager::jni::state_manager::ActualStateManager;
 
 #[tracing::instrument(err(Debug), skip(state))]
 pub(crate) async fn handle_status_network_configuration(
     state: State<CoreApiState>,
 ) -> Result<Json<models::NetworkConfigurationResponse>, ResponseError<()>> {
-    core_api_handler_empty_request(state, handle_status_network_configuration_internal)
-}
+    let network = state.network.clone();
 
-pub(crate) fn handle_status_network_configuration_internal(
-    state_manager: &mut ActualStateManager,
-) -> Result<models::NetworkConfigurationResponse, ResponseError<()>> {
-    let network = state_manager.network.clone();
-
-    let bech32_encoder = Bech32Encoder::new(&state_manager.network);
+    let bech32_encoder = Bech32Encoder::new(&network);
     let hrp_set: HrpSet = (&network).into();
 
     let address_types = ALL_ENTITY_TYPES
@@ -42,6 +35,7 @@ pub(crate) fn handle_status_network_configuration_internal(
             xrd: bech32_encoder.encode_resource_address_to_string(&RADIX_TOKEN),
         }),
     })
+    .map(Json)
 }
 
 const ALL_ENTITY_TYPES: [EntityType; 14] = [

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use state_manager::jni::state_manager::ActualStateManager;
+
 use state_manager::query::TransactionIdentifierLoader;
 use state_manager::store::traits::QueryableTransactionStore;
 use state_manager::CommittedTransactionIdentifiers;
@@ -7,31 +7,26 @@ use state_manager::CommittedTransactionIdentifiers;
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_status_network_status(
     state: State<CoreApiState>,
-    request: Json<models::NetworkStatusRequest>,
+    Json(request): Json<models::NetworkStatusRequest>,
 ) -> Result<Json<models::NetworkStatusResponse>, ResponseError<()>> {
-    core_api_read_handler(state, request, handle_status_network_status_internal)
-}
-
-pub(crate) fn handle_status_network_status_internal(
-    state_manager: &ActualStateManager,
-    request: models::NetworkStatusRequest,
-) -> Result<models::NetworkStatusResponse, ResponseError<()>> {
-    assert_matching_network(&request.network, &state_manager.network)?;
+    assert_matching_network(&request.network, &state.network)?;
+    let state_manager = state.state_manager.read();
+    let read_store = state_manager.store();
     Ok(models::NetworkStatusResponse {
-        post_genesis_state_identifier: state_manager
-            .store()
+        post_genesis_state_identifier: read_store
             .get_committed_transaction_identifiers(1)
             .map(|identifiers| -> Result<_, MappingError> {
                 Ok(Box::new(to_api_committed_state_identifier(identifiers)?))
             })
             .transpose()?,
         current_state_identifier: Box::new(to_api_committed_state_identifier(
-            state_manager.store().get_top_transaction_identifiers(),
+            read_store.get_top_transaction_identifiers(),
         )?),
         pre_genesis_state_identifier: Box::new(to_api_committed_state_identifier(
             CommittedTransactionIdentifiers::pre_genesis(),
         )?),
     })
+    .map(Json)
 }
 
 pub fn to_api_committed_state_identifier(

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -32,10 +32,8 @@ pub(crate) async fn handle_transaction_callpreview(
     State(state): State<CoreApiState>,
     Json(request): Json<models::TransactionCallPreviewRequest>,
 ) -> Result<Json<models::TransactionCallPreviewResponse>, ResponseError<()>> {
-    let state_manager = state.state_manager.read();
-
-    let extraction_context = ExtractionContext::new(&state_manager.network);
-    let mapping_context = MappingContext::new(&state_manager.network);
+    let extraction_context = ExtractionContext::new(&state.network);
+    let mapping_context = MappingContext::new(&state.network);
 
     let args: Vec<_> = request
         .arguments
@@ -80,6 +78,8 @@ pub(crate) async fn handle_transaction_callpreview(
             }
         }
     };
+
+    let state_manager = state.state_manager.read();
 
     let epoch = state_manager.store().get_epoch();
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
@@ -1,26 +1,21 @@
 use crate::core_api::handlers::to_api_committed_transaction;
 use crate::core_api::*;
-use state_manager::jni::state_manager::ActualStateManager;
+
 use state_manager::store::traits::*;
 
 #[tracing::instrument(skip(state), err(Debug))]
 pub(crate) async fn handle_transaction_receipt(
     state: State<CoreApiState>,
-    request: Json<models::TransactionReceiptRequest>,
+    Json(request): Json<models::TransactionReceiptRequest>,
 ) -> Result<Json<models::TransactionReceiptResponse>, ResponseError<()>> {
-    core_api_read_handler(state, request, handle_transaction_receipt_internal)
-}
+    assert_matching_network(&request.network, &state.network)?;
 
-fn handle_transaction_receipt_internal(
-    state_manager: &ActualStateManager,
-    request: models::TransactionReceiptRequest,
-) -> Result<models::TransactionReceiptResponse, ResponseError<()>> {
-    assert_matching_network(&request.network, &state_manager.network)?;
-
-    let mapping_context = MappingContext::new(&state_manager.network);
+    let mapping_context = MappingContext::new(&state.network);
 
     let intent_hash = extract_intent_hash(request.intent_hash)
         .map_err(|err| err.into_response_error("intent_hash"))?;
+
+    let state_manager = state.state_manager.read();
 
     let txn_state_version_opt = state_manager
         .store()
@@ -50,6 +45,7 @@ fn handle_transaction_receipt_internal(
                 identifiers,
             )?),
         })
+        .map(Json)
     } else {
         Err(not_found_error(format!(
             "Committed transaction not found with intent hash: {intent_hash}"

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
@@ -9,14 +9,13 @@ pub(crate) async fn handle_transaction_submit(
     State(state): State<CoreApiState>,
     Json(request): Json<models::TransactionSubmitRequest>,
 ) -> Result<Json<models::TransactionSubmitResponse>, ResponseError<TransactionSubmitErrorDetails>> {
-    let mut state_manager = state.state_manager.write();
-
-    let mapping_context = MappingContext::new_for_uncommitted_data(&state_manager.network);
-
-    assert_matching_network(&request.network, &state_manager.network)?;
+    assert_matching_network(&request.network, &state.network)?;
+    let mapping_context = MappingContext::new_for_uncommitted_data(&state.network);
 
     let notarized_transaction = extract_unvalidated_transaction(&request.notarized_transaction_hex)
         .map_err(|err| err.into_response_error("notarized_transaction"))?;
+
+    let mut state_manager = state.state_manager.write();
 
     let result = state_manager
         .add_to_mempool_and_trigger_relay(MempoolAddSource::CoreApi, notarized_transaction);

--- a/core-rust/core-api-server/src/core_api/helpers.rs
+++ b/core-rust/core-api-server/src/core_api/helpers.rs
@@ -4,27 +4,7 @@ use radix_engine::types::{RENodeId, SubstateId, SubstateOffset};
 use radix_engine_interface::api::types::NodeModuleId;
 use state_manager::jni::state_manager::ActualStateManager;
 
-use super::{CoreApiState, Json, MappingError, ResponseError, State};
-
-pub(crate) fn core_api_handler_empty_request<Response>(
-    State(state): State<CoreApiState>,
-    method: impl FnOnce(&mut ActualStateManager) -> Result<Response, ResponseError<()>>,
-) -> Result<Json<Response>, ResponseError<()>> {
-    let mut state_manager = state.state_manager.write();
-
-    method(&mut state_manager).map(Json)
-}
-
-#[tracing::instrument(skip_all)]
-pub(crate) fn core_api_read_handler<Request, Response>(
-    State(state): State<CoreApiState>,
-    Json(request_body): Json<Request>,
-    method: impl FnOnce(&ActualStateManager, Request) -> Result<Response, ResponseError<()>>,
-) -> Result<Json<Response>, ResponseError<()>> {
-    let state_manager = state.state_manager.read();
-
-    method(&state_manager, request_body).map(Json)
-}
+use super::{MappingError, ResponseError};
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn read_mandatory_substate(

--- a/core-rust/core-api-server/src/core_api/server.rs
+++ b/core-rust/core-api-server/src/core_api/server.rs
@@ -72,6 +72,7 @@ use axum::{
 };
 use parking_lot::RwLock;
 use radix_engine::types::{Categorize, Decode, Encode};
+use radix_engine_common::network::NetworkDefinition;
 use state_manager::jni::state_manager::ActualStateManager;
 
 use super::{constants::LARGE_REQUEST_MAX_BYTES, handlers::*, not_found_error, ResponseError};
@@ -80,17 +81,22 @@ use handle_status_network_configuration as handle_provide_info_at_root_path;
 
 #[derive(Clone)]
 pub(crate) struct CoreApiState {
+    pub network: NetworkDefinition,
     pub state_manager: Arc<RwLock<ActualStateManager>>,
 }
 
 pub async fn create_server<F>(
     bind_addr: &str,
     shutdown_signal: F,
+    network: NetworkDefinition,
     state_manager: Arc<RwLock<ActualStateManager>>,
 ) where
     F: Future<Output = ()>,
 {
-    let core_api_state = CoreApiState { state_manager };
+    let core_api_state = CoreApiState {
+        network,
+        state_manager,
+    };
 
     let router = Router::new()
         // This only adds a route for /core, /core/ doesn't seem possible using /nest

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -127,11 +127,11 @@ const FULL_TRANSACTION_WARN_TIME_LIMIT: Duration = Duration::from_millis(500);
 pub struct StateManager<S> {
     pub mempool: RwLock<SimpleMempool>,
     mempool_relay_dispatcher: MempoolRelayDispatcher,
-    pub network: NetworkDefinition,
+    network: NetworkDefinition,
     store: Arc<RwLock<S>>,
     execution_cache: ExecutionCache,
     pub user_transaction_validator: UserTransactionValidator,
-    pub ledger_transaction_validator: LedgerTransactionValidator,
+    ledger_transaction_validator: LedgerTransactionValidator,
     pub pending_transaction_result_cache: PendingTransactionResultCache,
     pub metrics: StateManagerMetrics,
     pub prometheus_registry: Registry,


### PR DESCRIPTION
This continues the effort started at https://github.com/radixdlt/babylon-node/pull/407 (towards an end-state described at https://github.com/radixdlt/babylon-node/pull/407#issuecomment-1511005042).

In this PR, I pull an _example piece_ of an immutable state up (from `StateManager` to `JNIStateManager`). This way, the callers that only need to access the immutable state (e.g. CoreApi) no longer need to obtain the `StateManager`'s lock (in fact, they don't need any lock). 

In most controllers, this has only limited effect (because soon after reading the immutable state, the controller logic wants something more complex from `StateManager` anyway). But in some (e.g. `handle_status_network_configuration()`) we now avoid locking altogether.

More obvious performance gains will show up in a consecutive PR (enabled by this one), in which I access the `database` directly from applicable controllers (i.e. avoiding the `StateManager`'s lock, and locking only the `StateManagerDatabase`).