### PR TITLE
Accessing the database directly from CoreApi (avoiding StateManager lock)

### DIFF
--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
@@ -24,16 +24,15 @@ pub(crate) async fn handle_lts_state_account_all_fungible_resource_balances(
         extract_component_address(&extraction_context, &request.account_address)
             .map_err(|err| err.into_response_error("account_address"))?;
 
-    let state_manager = state.state_manager.read();
-    let read_store = state_manager.store();
-    let component_dump = match dump_component_state(read_store.deref(), component_address) {
+    let database = state.database.read();
+    let component_dump = match dump_component_state(database.deref(), component_address) {
         Ok(component_dump) => component_dump,
         Err(err) => match component_address {
             ComponentAddress::Account(_) => return Err(not_found_error("Account not found")),
             ComponentAddress::EcdsaSecp256k1VirtualAccount(_)
             | ComponentAddress::EddsaEd25519VirtualAccount(_) => {
                 return Ok(models::LtsStateAccountAllFungibleResourceBalancesResponse {
-                    state_version: to_api_state_version(read_store.max_state_version())?,
+                    state_version: to_api_state_version(database.max_state_version())?,
                     account_address: to_api_component_address(&mapping_context, &component_address),
                     fungible_resource_balances: Vec::new(),
                 })
@@ -81,7 +80,7 @@ pub(crate) async fn handle_lts_state_account_all_fungible_resource_balances(
         .collect();
 
     Ok(models::LtsStateAccountAllFungibleResourceBalancesResponse {
-        state_version: to_api_state_version(read_store.max_state_version())?,
+        state_version: to_api_state_version(database.max_state_version())?,
         account_address: to_api_component_address(&mapping_context, &component_address),
         fungible_resource_balances,
     })

--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
@@ -26,10 +26,9 @@ pub(crate) async fn handle_lts_stream_account_transaction_outcomes(
         )));
     }
 
-    let state_manager = state.state_manager.read();
-    let read_store = state_manager.store();
+    let database = state.database.read();
 
-    let _max_state_version = read_store.max_state_version();
+    let _max_state_version = database.max_state_version();
 
     Err(not_implemented("Endpoint not implemented yet"))
 }

--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_transaction_outcomes.rs
@@ -27,12 +27,11 @@ pub(crate) async fn handle_lts_stream_transaction_outcomes(
         )));
     }
 
-    let state_manager = state.state_manager.read();
-    let read_store = state_manager.store();
+    let database = state.database.read();
 
-    let max_state_version = read_store.max_state_version();
+    let max_state_version = database.max_state_version();
 
-    let txns = read_store.get_committed_transaction_bundles(
+    let txns = database.get_committed_transaction_bundles(
         from_state_version,
         limit.try_into().expect("limit out of usize bounds"),
     );

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
@@ -12,12 +12,12 @@ pub(crate) async fn handle_lts_transaction_construction(
     assert_matching_network(&request.network, &state.network)?;
     let mapping_context = MappingContext::new(&state.network);
 
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
 
     let epoch_manager_substate = {
         let substate_offset = SubstateOffset::EpochManager(EpochManagerOffset::EpochManager);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(EPOCH_MANAGER.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -31,7 +31,7 @@ pub(crate) async fn handle_lts_transaction_construction(
     let clock_substate = {
         let substate_offset = SubstateOffset::Clock(ClockOffset::CurrentTimeRoundedToMinutes);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(CLOCK.into()),
             NodeModuleId::SELF,
             &substate_offset,

--- a/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
@@ -27,12 +27,12 @@ pub(crate) async fn handle_state_access_controller(
         return Err(client_error("Only access controller addresses work for this endpoint. Try another endpoint instead."));
     }
 
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
     let component_state = {
         let substate_offset =
             SubstateOffset::AccessController(AccessControllerOffset::AccessController);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(controller_address.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -45,7 +45,7 @@ pub(crate) async fn handle_state_access_controller(
     let component_access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(controller_address.into()),
             NodeModuleId::AccessRules,
             &substate_offset,
@@ -56,8 +56,7 @@ pub(crate) async fn handle_state_access_controller(
         substate
     };
 
-    let read_store = state_manager.store();
-    let component_dump = dump_component_state(read_store.deref(), controller_address)
+    let component_dump = dump_component_state(database.deref(), controller_address)
         .map_err(|err| server_error(format!("Error traversing component state: {err:?}")))?;
 
     let state_owned_vaults = component_dump

--- a/core-rust/core-api-server/src/core_api/handlers/state_clock.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_clock.rs
@@ -11,11 +11,11 @@ pub(crate) async fn handle_state_clock(
 ) -> Result<Json<models::StateClockResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
 
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
     let rounded_to_minutes_substate = {
         let substate_offset = SubstateOffset::Clock(ClockOffset::CurrentTimeRoundedToMinutes);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(CLOCK.into()),
             NodeModuleId::SELF,
             &substate_offset,

--- a/core-rust/core-api-server/src/core_api/handlers/state_component.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_component.rs
@@ -28,11 +28,11 @@ pub(crate) async fn handle_state_component(
         return Err(client_error("Only component addresses starting component_ or account_ currently work with this endpoint. Try another endpoint instead."));
     }
 
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
     let type_info = {
         let substate_offset = SubstateOffset::TypeInfo(TypeInfoOffset::TypeInfo);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(component_address.into()),
             NodeModuleId::TypeInfo,
             &substate_offset,
@@ -45,7 +45,7 @@ pub(crate) async fn handle_state_component(
     let component_state = {
         let substate_offset = SubstateOffset::Component(ComponentOffset::State0);
         let loaded_substate_opt = read_optional_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(component_address.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -59,7 +59,7 @@ pub(crate) async fn handle_state_component(
     let account_state = {
         let substate_offset = SubstateOffset::Account(AccountOffset::Account);
         let loaded_substate_opt = read_optional_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(component_address.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -74,7 +74,7 @@ pub(crate) async fn handle_state_component(
     let component_royalty_config = {
         let substate_offset = SubstateOffset::Royalty(RoyaltyOffset::RoyaltyConfig);
         let loaded_substate_opt = read_optional_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(component_address.into()),
             NodeModuleId::ComponentRoyalty,
             &substate_offset,
@@ -88,7 +88,7 @@ pub(crate) async fn handle_state_component(
     let component_royalty_accumulator = {
         let substate_offset = SubstateOffset::Royalty(RoyaltyOffset::RoyaltyAccumulator);
         let loaded_substate_opt = read_optional_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(component_address.into()),
             NodeModuleId::ComponentRoyalty,
             &substate_offset,
@@ -102,7 +102,7 @@ pub(crate) async fn handle_state_component(
     let component_access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(component_address.into()),
             NodeModuleId::AccessRules,
             &substate_offset,
@@ -113,8 +113,7 @@ pub(crate) async fn handle_state_component(
         substate
     };
 
-    let read_store = state_manager.store();
-    let component_dump = dump_component_state(read_store.deref(), component_address)
+    let component_dump = dump_component_state(database.deref(), component_address)
         .map_err(|err| server_error(format!("Error traversing component state: {err:?}")))?;
 
     let state_owned_vaults = component_dump

--- a/core-rust/core-api-server/src/core_api/handlers/state_epoch.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_epoch.rs
@@ -11,11 +11,11 @@ pub(crate) async fn handle_state_epoch(
 ) -> Result<Json<models::StateEpochResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
     let mapping_context = MappingContext::new(&state.network);
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
     let epoch_manager_substate = {
         let substate_offset = SubstateOffset::EpochManager(EpochManagerOffset::EpochManager);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(EPOCH_MANAGER.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -29,7 +29,7 @@ pub(crate) async fn handle_state_epoch(
     let validator_set_substate = {
         let substate_offset = SubstateOffset::EpochManager(EpochManagerOffset::CurrentValidatorSet);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(EPOCH_MANAGER.into()),
             NodeModuleId::SELF,
             &substate_offset,

--- a/core-rust/core-api-server/src/core_api/handlers/state_package.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_package.rs
@@ -15,12 +15,12 @@ pub(crate) async fn handle_state_package(
     let package_address = extract_package_address(&extraction_context, &request.package_address)
         .map_err(|err| err.into_response_error("package_address"))?;
 
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
 
     let package_info = {
         let substate_offset = SubstateOffset::Package(PackageOffset::Info);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(package_address.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -33,7 +33,7 @@ pub(crate) async fn handle_state_package(
     let package_royalty = {
         let substate_offset = SubstateOffset::Package(PackageOffset::Royalty);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(package_address.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -46,7 +46,7 @@ pub(crate) async fn handle_state_package(
     let package_access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(package_address.into()),
             NodeModuleId::AccessRules,
             &substate_offset,

--- a/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
@@ -23,14 +23,14 @@ pub(crate) async fn handle_state_resource(
     let resource_address = extract_resource_address(&extraction_context, &request.resource_address)
         .map_err(|err| err.into_response_error("resource_address"))?;
 
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
 
     let manager = match &resource_address {
         ResourceAddress::Fungible(_) => {
             let substate_offset =
                 SubstateOffset::ResourceManager(ResourceManagerOffset::ResourceManager);
             let loaded_substate = read_mandatory_substate(
-                state_manager.deref(),
+                database.deref(),
                 RENodeId::GlobalObject(resource_address.into()),
                 NodeModuleId::SELF,
                 &substate_offset,
@@ -44,7 +44,7 @@ pub(crate) async fn handle_state_resource(
             let substate_offset =
                 SubstateOffset::ResourceManager(ResourceManagerOffset::ResourceManager);
             let loaded_substate = read_mandatory_substate(
-                state_manager.deref(),
+                database.deref(),
                 RENodeId::GlobalObject(resource_address.into()),
                 NodeModuleId::SELF,
                 &substate_offset,
@@ -58,7 +58,7 @@ pub(crate) async fn handle_state_resource(
     let access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(resource_address.into()),
             NodeModuleId::AccessRules,
             &substate_offset,
@@ -72,7 +72,7 @@ pub(crate) async fn handle_state_resource(
     let vault_access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(resource_address.into()),
             NodeModuleId::AccessRules1,
             &substate_offset,

--- a/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
@@ -27,12 +27,12 @@ pub(crate) async fn handle_state_validator(
         ));
     }
 
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
 
     let component_state = {
         let substate_offset = SubstateOffset::Validator(ValidatorOffset::Validator);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(validator_address.into()),
             NodeModuleId::SELF,
             &substate_offset,
@@ -45,7 +45,7 @@ pub(crate) async fn handle_state_validator(
     let component_access_rules = {
         let substate_offset = SubstateOffset::AccessRules(AccessRulesOffset::AccessRules);
         let loaded_substate = read_mandatory_substate(
-            state_manager.deref(),
+            database.deref(),
             RENodeId::GlobalObject(validator_address.into()),
             NodeModuleId::AccessRules,
             &substate_offset,
@@ -56,8 +56,7 @@ pub(crate) async fn handle_state_validator(
         substate
     };
 
-    let read_store = state_manager.store();
-    let component_dump = dump_component_state(read_store.deref(), validator_address)
+    let component_dump = dump_component_state(database.deref(), validator_address)
         .map_err(|err| server_error(format!("Error traversing component state: {err:?}")))?;
 
     let state_owned_vaults = component_dump

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -10,17 +10,16 @@ pub(crate) async fn handle_status_network_status(
     Json(request): Json<models::NetworkStatusRequest>,
 ) -> Result<Json<models::NetworkStatusResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
-    let state_manager = state.state_manager.read();
-    let read_store = state_manager.store();
+    let database = state.database.read();
     Ok(models::NetworkStatusResponse {
-        post_genesis_state_identifier: read_store
+        post_genesis_state_identifier: database
             .get_committed_transaction_identifiers(1)
             .map(|identifiers| -> Result<_, MappingError> {
                 Ok(Box::new(to_api_committed_state_identifier(identifiers)?))
             })
             .transpose()?,
         current_state_identifier: Box::new(to_api_committed_state_identifier(
-            read_store.get_top_transaction_identifiers(),
+            database.get_top_transaction_identifiers(),
         )?),
         pre_genesis_state_identifier: Box::new(to_api_committed_state_identifier(
             CommittedTransactionIdentifiers::pre_genesis(),

--- a/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
@@ -43,12 +43,11 @@ pub(crate) async fn handle_stream_transactions(
         )));
     }
 
-    let state_manager = state.state_manager.read();
-    let read_store = state_manager.store();
+    let database = state.database.read();
 
-    let max_state_version = read_store.max_state_version();
+    let max_state_version = database.max_state_version();
 
-    let txns = read_store.get_committed_transaction_bundles(
+    let txns = database.get_committed_transaction_bundles(
         from_state_version,
         limit.try_into().expect("limit out of usize bounds"),
     );

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -81,7 +81,8 @@ pub(crate) async fn handle_transaction_callpreview(
 
     let state_manager = state.state_manager.read();
 
-    let epoch = state_manager.store().get_epoch();
+    let database = state.database.read();
+    let epoch = database.get_epoch();
 
     let result = state_manager
         .preview(PreviewRequest {

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
@@ -15,25 +15,20 @@ pub(crate) async fn handle_transaction_receipt(
     let intent_hash = extract_intent_hash(request.intent_hash)
         .map_err(|err| err.into_response_error("intent_hash"))?;
 
-    let state_manager = state.state_manager.read();
+    let database = state.database.read();
 
-    let txn_state_version_opt = state_manager
-        .store()
-        .get_txn_state_version_by_identifier(&intent_hash);
+    let txn_state_version_opt = database.get_txn_state_version_by_identifier(&intent_hash);
 
     if let Some(txn_state_version) = txn_state_version_opt {
-        let ledger_transaction = state_manager
-            .store()
+        let ledger_transaction = database
             .get_committed_transaction(txn_state_version)
             .expect("Txn is missing");
 
-        let receipt = state_manager
-            .store()
+        let receipt = database
             .get_committed_transaction_receipt(txn_state_version)
             .expect("Txn receipt is missing");
 
-        let identifiers = state_manager
-            .store()
+        let identifiers = database
             .get_committed_transaction_identifiers(txn_state_version)
             .expect("Txn identifiers are missing");
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -25,16 +25,15 @@ pub(crate) async fn handle_transaction_status(
         .map_err(|err| err.into_response_error("intent_hash"))?;
 
     let state_manager = state.state_manager.read();
+    let database = state.database.read();
 
-    let txn_state_version_opt = state_manager
-        .store()
-        .get_txn_state_version_by_identifier(&intent_hash);
+    let txn_state_version_opt = database.get_txn_state_version_by_identifier(&intent_hash);
 
     let mut known_pending_payloads = state_manager
         .pending_transaction_result_cache
         .peek_all_known_payloads_for_intent(&intent_hash);
 
-    let current_epoch = state_manager.store().get_epoch();
+    let current_epoch = database.get_epoch();
 
     let invalid_from_epoch = known_pending_payloads
         .iter()
@@ -50,13 +49,11 @@ pub(crate) async fn handle_transaction_status(
     });
 
     if let Some(txn_state_version) = txn_state_version_opt {
-        let txn = state_manager
-            .store()
+        let txn = database
             .get_committed_transaction(txn_state_version)
             .expect("Txn is missing");
 
-        let local_detailed_outcome = state_manager
-            .store()
+        let local_detailed_outcome = database
             .get_committed_transaction_receipt(txn_state_version)
             .expect("Txn receipt is missing")
             .local_execution

--- a/core-rust/core-api-server/src/core_api/helpers.rs
+++ b/core-rust/core-api-server/src/core_api/helpers.rs
@@ -2,35 +2,28 @@ use radix_engine::ledger::ReadableSubstateStore;
 use radix_engine::system::node_substates::PersistedSubstate;
 use radix_engine::types::{RENodeId, SubstateId, SubstateOffset};
 use radix_engine_interface::api::types::NodeModuleId;
-use state_manager::jni::state_manager::ActualStateManager;
+
+use state_manager::store::StateManagerDatabase;
 
 use super::{MappingError, ResponseError};
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn read_mandatory_substate(
-    state_manager: &ActualStateManager,
+    database: &StateManagerDatabase,
     renode_id: RENodeId,
     node_module_id: NodeModuleId,
     substate_offset: &SubstateOffset,
 ) -> Result<PersistedSubstate, ResponseError<()>> {
-    read_optional_substate(state_manager, renode_id, node_module_id, substate_offset).ok_or_else(
-        || {
-            MappingError::MismatchedSubstateId {
-                message: format!(
-                    "Substate {substate_offset:?} not found under RE node {renode_id:?} and module {node_module_id:?}"
-                ),
-            }
-            .into()
-        },
-    )
+    let substate_id = SubstateId(renode_id, node_module_id, substate_offset.clone());
+    read_mandatory_substate_from_id(database, &substate_id)
 }
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn read_mandatory_substate_from_id(
-    state_manager: &ActualStateManager,
+    database: &StateManagerDatabase,
     substate_id: &SubstateId,
 ) -> Result<PersistedSubstate, ResponseError<()>> {
-    read_optional_substate_from_id(state_manager, substate_id).ok_or_else(
+    read_optional_substate_from_id(database, substate_id).ok_or_else(
         || {
             let SubstateId(renode_id, node_module_id, substate_offset) = substate_id;
             MappingError::MismatchedSubstateId {
@@ -45,27 +38,21 @@ pub(crate) fn read_mandatory_substate_from_id(
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn read_optional_substate(
-    state_manager: &ActualStateManager,
+    database: &StateManagerDatabase,
     renode_id: RENodeId,
     node_module_id: NodeModuleId,
     substate_offset: &SubstateOffset,
 ) -> Option<PersistedSubstate> {
     let substate_id = SubstateId(renode_id, node_module_id, substate_offset.clone());
-    state_manager
-        .store()
-        .get_substate(&substate_id)
-        .map(|o| o.substate)
+    read_optional_substate_from_id(database, &substate_id)
 }
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn read_optional_substate_from_id(
-    state_manager: &ActualStateManager,
+    database: &StateManagerDatabase,
     substate_id: &SubstateId,
 ) -> Option<PersistedSubstate> {
-    state_manager
-        .store()
-        .get_substate(substate_id)
-        .map(|o| o.substate)
+    database.get_substate(substate_id).map(|o| o.substate)
 }
 
 #[tracing::instrument(skip_all)]

--- a/core-rust/core-api-server/src/core_api/server.rs
+++ b/core-rust/core-api-server/src/core_api/server.rs
@@ -78,11 +78,13 @@ use state_manager::jni::state_manager::ActualStateManager;
 use super::{constants::LARGE_REQUEST_MAX_BYTES, handlers::*, not_found_error, ResponseError};
 
 use handle_status_network_configuration as handle_provide_info_at_root_path;
+use state_manager::store::StateManagerDatabase;
 
 #[derive(Clone)]
 pub(crate) struct CoreApiState {
     pub network: NetworkDefinition,
     pub state_manager: Arc<RwLock<ActualStateManager>>,
+    pub database: Arc<RwLock<StateManagerDatabase>>,
 }
 
 pub async fn create_server<F>(
@@ -90,12 +92,14 @@ pub async fn create_server<F>(
     shutdown_signal: F,
     network: NetworkDefinition,
     state_manager: Arc<RwLock<ActualStateManager>>,
+    database: Arc<RwLock<StateManagerDatabase>>,
 ) where
     F: Future<Output = ()>,
 {
     let core_api_state = CoreApiState {
         network,
         state_manager,
+        database,
     };
 
     let router = Router::new()

--- a/core-rust/core-api-server/src/jni/mod.rs
+++ b/core-rust/core-api-server/src/jni/mod.rs
@@ -79,6 +79,7 @@ use std::str;
 use std::sync::{Arc, MutexGuard};
 use tokio::runtime::Runtime as TokioRuntime;
 
+use state_manager::store::StateManagerDatabase;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -93,6 +94,7 @@ pub struct JNICoreApiServer {
     pub config: CoreApiServerConfig,
     pub network: NetworkDefinition,
     pub state_manager: Arc<RwLock<ActualStateManager>>,
+    pub database: Arc<RwLock<StateManagerDatabase>>,
     pub running_server: Option<RunningServer>,
 }
 
@@ -107,12 +109,14 @@ extern "system" fn Java_com_radixdlt_api_CoreApiServer_init(
     let state = JNIStateManager::get_state(&env, j_state_manager);
     let network = state.network.clone();
     let state_manager = state.state_manager.clone();
+    let database = state.database.clone();
     let config_bytes: Vec<u8> = jni_jbytearray_to_vector(&env, j_config).unwrap();
     let config = CoreApiServerConfig::from_java(&config_bytes).unwrap();
     let jni_core_api_server = JNICoreApiServer {
         config,
         network,
         state_manager,
+        database,
         running_server: None,
     };
 
@@ -142,6 +146,7 @@ extern "system" fn Java_com_radixdlt_api_CoreApiServer_start(
 
     let network = jni_core_api_server.network.clone();
     let state_manager = jni_core_api_server.state_manager.clone();
+    let database = jni_core_api_server.database.clone();
 
     let bind_addr = format!("{}:{}", config.bind_interface, config.port);
     tokio_runtime.spawn(async move {
@@ -176,6 +181,7 @@ extern "system" fn Java_com_radixdlt_api_CoreApiServer_start(
             shutdown_signal_receiver.map(|_| ()),
             network,
             state_manager,
+            database,
         )
         .await;
     });

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -83,7 +83,7 @@ use ::transaction::model::{
     TransactionIntent,
 };
 use ::transaction::validation::{TestIntentHashManager, ValidationConfig};
-use parking_lot::{RawRwLock, RwLock};
+use parking_lot::RwLock;
 use prometheus::Registry;
 use radix_engine::transaction::{
     execute_preview, execute_transaction, AbortReason, ExecutionConfig, FeeReserveConfig,
@@ -97,7 +97,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::staging::epoch_handling::AccuTreeEpochHandler;
-use parking_lot::lock_api::RwLockReadGuard;
+
 use radix_engine::blueprints::epoch_manager::Validator;
 use radix_engine::kernel::interpreters::ScryptoInterpreter;
 use radix_engine_interface::data::manifest::manifest_encode;
@@ -206,10 +206,6 @@ impl<S> StateManager<S>
 where
     S: ReadableSubstateStore,
 {
-    pub fn store(&self) -> RwLockReadGuard<'_, RawRwLock, S> {
-        self.store.read()
-    }
-
     pub fn preview(&self, preview_request: PreviewRequest) -> Result<PreviewResult, PreviewError> {
         let notary = preview_request.notary_public_key.unwrap_or_else(|| {
             PublicKey::EcdsaSecp256k1(EcdsaSecp256k1PrivateKey::from_u64(2).unwrap().public_key())


### PR DESCRIPTION
This is the next PR towards the end-state described at https://github.com/radixdlt/babylon-node/pull/407#issuecomment-1511005042, building on top of https://github.com/radixdlt/babylon-node/pull/410 (though not strictly required - just wanna avoid some conflicts).

In this PR, I access the `database` directly from CoreApi, in many cases avoiding a lock on `StateManager` (in fact, a `StateManager.store()` accessor vanished!).

Note: here we see that a certain pattern forms - the `network + state_manager + database` fields travel together. If anyone suggests a good, _not-yet-taken_ name for this group (remember it may grow!), I promise to refactor that into a struct 🤞.