### PR TITLE
Splitting the Rust metrics into logical parts + Moving Registry ownership out of StateManager

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/prometheus/RustPrometheus.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/prometheus/RustPrometheus.java
@@ -70,12 +70,12 @@ import com.radixdlt.lang.Tuple;
 import com.radixdlt.sbor.Natives;
 import com.radixdlt.statemanager.StateManager;
 
-public class StateManagerPrometheus {
+public class RustPrometheus {
 
   @Inject
-  public StateManagerPrometheus(StateManager stateManager) {
+  public RustPrometheus(StateManager stateManager) {
     this.prometheusMetricsFunc =
-        Natives.builder(stateManager, StateManagerPrometheus::prometheusMetrics)
+        Natives.builder(stateManager, RustPrometheus::prometheusMetrics)
             .build(new TypeToken<>() {});
   }
 

--- a/core/src/main/java/com/radixdlt/api/prometheus/PrometheusService.java
+++ b/core/src/main/java/com/radixdlt/api/prometheus/PrometheusService.java
@@ -66,27 +66,27 @@ package com.radixdlt.api.prometheus;
 
 import com.google.inject.Inject;
 import com.radixdlt.api.system.health.HealthInfoService;
-import com.radixdlt.prometheus.StateManagerPrometheus;
+import com.radixdlt.prometheus.RustPrometheus;
 
 public class PrometheusService {
 
   private final JavaPrometheus javaPrometheus;
-  private final StateManagerPrometheus stateManagerPrometheus;
+  private final RustPrometheus rustPrometheus;
   private final HealthInfoService healthInfoService;
 
   @Inject
   public PrometheusService(
       HealthInfoService healthInfoService,
-      StateManagerPrometheus stateManagerPrometheus,
+      RustPrometheus rustPrometheus,
       JavaPrometheus javaPrometheus) {
     this.healthInfoService = healthInfoService;
-    this.stateManagerPrometheus = stateManagerPrometheus;
+    this.rustPrometheus = rustPrometheus;
     this.javaPrometheus = javaPrometheus;
   }
 
   public String getMetrics() {
     var builder = new StringBuilder();
-    builder.append(this.stateManagerPrometheus.prometheusMetrics());
+    builder.append(this.rustPrometheus.prometheusMetrics());
     builder.append(this.javaPrometheus.prometheusMetrics());
     exportHealth(builder);
     return builder.append('\n').toString();


### PR DESCRIPTION
This is the next PR towards the end-state described at https://github.com/radixdlt/babylon-node/pull/407#issuecomment-1511005042.

Here I move the Prometheus' `Registry` up (to `JNIStateManager`), and this way, the `do_prometheus_metrics()` native call does not have to acquire StateManager's lock (or any lock at all, since the `Registry` is thread-safe already, **according to my quick glance through its sources, which I encourage to verify during the review**).

Apart from that, I refactor the Rust metrics a bit (since maintaining nice metric infra is my hobby) and split it into logical parts (in preparation for the "split mempool out" PR which should come soon).