### PR TITLE
DO-1336 / fix join images on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,6 +74,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=sha
       - name: Join multiarch images
         run: |
           docker buildx imagetools create -t eu.gcr.io/dev-container-repo/babylon-node:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }} \


### PR DESCRIPTION
add sha tag to metadata action
in case where there is no branch or pr (like on releases) the sha will be used as the 'org.opencontainers.image.version'
This solves the error seen here: https://github.com/radixdlt/babylon-node/actions/runs/4737002863/jobs/8409830237#step:9:2

Only relevant for GCR Docker Images on releases.