### PR TITLE
Fix gradle error introduced in Dx/testnet and fix incompatibilty between debian/ubuntu rust artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN apt-get update; apt-get upgrade -y && \
   apt install -y \
   build-essential=12.9 \
   curl=7.74.0-1.3+deb11u7 \
-  g++-aarch64-linux-gnu=4:10.2.1-1 \
-  g++-x86-64-linux-gnu=4:10.2.1-1 \
+  g++-aarch64-linux-gnu \
+  g++-x86-64-linux-gnu \
   libc6-dev-arm64-cross=2.31-9cross4 \
   libclang-dev=1:11.0-51+nmu5 \
   libssl-dev=1.1.1n-0+deb11u4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,19 +45,19 @@ USER nobody
 FROM scratch AS binary-container
 COPY --from=binary-build-stage /radixdlt/core/build/distributions /
 
-FROM ubuntu:22.04 as base
+FROM debian:11-slim as base
 WORKDIR /app
 
 RUN apt-get update; apt-get upgrade -y && \
   apt install -y \
-  build-essential=12.9ubuntu3 \
-  curl=7.81.0-1ubuntu1.10 \
-  g++-aarch64-linux-gnu=4:11.2.0-1ubuntu1 \
-  g++-x86-64-linux-gnu=4:11.2.0-1ubuntu1 \
-  libc6-dev-arm64-cross=2.35-0ubuntu1cross3 \
-  libclang-dev=1:14.0-55~exp2 \
-  libssl-dev=3.0.2-0ubuntu1.8 \
-  pkg-config=0.29.2-1ubuntu3
+  build-essential=12.9 \
+  curl=7.74.0-1.3+deb11u7 \
+  g++-aarch64-linux-gnu=4:10.2.1-1 \
+  g++-x86-64-linux-gnu=4:10.2.1-1 \
+  libc6-dev-arm64-cross=2.31-9cross4 \
+  libclang-dev=1:11.0-51+nmu5 \
+  libssl-dev=1.1.1n-0+deb11u4 \
+  pkg-config=0.29.2-1
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh; sh rustup.sh -y --target aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
 RUN $HOME/.cargo/bin/cargo install sccache

--- a/core/src/main/java/com/radixdlt/keys/PersistedBFTKeyManager.java
+++ b/core/src/main/java/com/radixdlt/keys/PersistedBFTKeyManager.java
@@ -79,7 +79,6 @@ public final class PersistedBFTKeyManager {
 
   public PersistedBFTKeyManager(String nodeKeyPath, boolean createNodeKeyIfMissing) {
     this.ecKeyPair = loadNodeKey(nodeKeyPath, createNodeKeyIfMissing);
-    ;
   }
 
   private static ECKeyPair loadNodeKey(String nodeKeyPath, boolean createNodeKeyIfMissing) {

--- a/core/src/main/java/com/radixdlt/keys/PersistedBFTKeyManager.java
+++ b/core/src/main/java/com/radixdlt/keys/PersistedBFTKeyManager.java
@@ -78,7 +78,8 @@ public final class PersistedBFTKeyManager {
   private final ECKeyPair ecKeyPair;
 
   public PersistedBFTKeyManager(String nodeKeyPath, boolean createNodeKeyIfMissing) {
-    this.ecKeyPair = loadNodeKey(nodeKeyPath, createNodeKeyIfMissing);;
+    this.ecKeyPair = loadNodeKey(nodeKeyPath, createNodeKeyIfMissing);
+    ;
   }
 
   private static ECKeyPair loadNodeKey(String nodeKeyPath, boolean createNodeKeyIfMissing) {


### PR DESCRIPTION
I think there was a typo here. Gradle complains about it for me:

```
#23 106.7 FAILURE: Build failed with an exception.
#23 106.7 
#23 106.7 * What went wrong:
#23 106.7 Execution failed for task ':core:spotlessJavaCheck'.
#23 106.7 > The following files had format violations:
#23 106.7       src/main/java/com/radixdlt/keys/PersistedBFTKeyManager.java
#23 106.7           @@ -78,7 +78,8 @@
#23 106.7            ··private·final·ECKeyPair·ecKeyPair;
#23 106.7            
#23 106.7            ··public·PersistedBFTKeyManager(String·nodeKeyPath,·boolean·createNodeKeyIfMissing)·{
#23 106.7           -····this.ecKeyPair·=·loadNodeKey(nodeKeyPath,·createNodeKeyIfMissing);;
#23 106.7           +····this.ecKeyPair·=·loadNodeKey(nodeKeyPath,·createNodeKeyIfMissing);
#23 106.7           +····;
#23 106.7            ··}
#23 106.7            
#23 106.7            ··private·static·ECKeyPair·loadNodeKey(String·nodeKeyPath,·boolean·createNodeKeyIfMissing)·{
#23 106.7   Run './gradlew :core:spotlessApply' to fix these violations.
#23 106.7 
#23 106.7 * Try:
#23 106.7 Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

```

Pipeline:
https://github.com/radixdlt/babylon-node/actions/runs/4738219925/jobs/8411924968#step:19:2759

Code Comment:
https://github.com/radixdlt/babylon-node/commit/8b13378a60bd435842f5aedda0ce958877f73b2c#r109577680

