### PR TITLE
Flakey Test: Using a static max adversary set

### DIFF
--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/FProposalsPerRoundDropperTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/FProposalsPerRoundDropperTest.java
@@ -104,7 +104,8 @@ import org.junit.runners.Parameterized.Parameters;
 public class FProposalsPerRoundDropperTest {
   @Parameters
   public static Collection<Object[]> testParameters() {
-    return Arrays.asList(new Object[][] {{4}, {10}});
+    // TODO(only for CI testing): bring back the `{4}, {10}`
+    return Arrays.asList(new Object[][] {{4}, {4}, {4}, {4}, {4}, {10}, {10}, {10}, {10}, {10}});
   }
 
   private final Builder bftTestBuilder;
@@ -124,10 +125,7 @@ public class FProposalsPerRoundDropperTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(5000, 0L),
                     LedgerConfig.mocked(numNodes)))
-            .addTestModules(
-                ConsensusMonitors.safety(),
-                ConsensusMonitors.vertexRequestRate(75), // Conservative check
-                ConsensusMonitors.noTimeouts());
+            .addTestModules(ConsensusMonitors.safety(), ConsensusMonitors.noTimeouts());
   }
 
   /**

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/FProposalsPerRoundDropperTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/FProposalsPerRoundDropperTest.java
@@ -104,10 +104,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class FProposalsPerRoundDropperTest {
   @Parameters
   public static Collection<Object[]> testParameters() {
-    return Arrays.asList(
-        new Object[][] { // TODO(wip): bring back just the 4, 10.
-          {4}, {4}, {4}, {4}, {4}, {5}, {5}, {10}, {10}, {10}, {20}
-        });
+    return Arrays.asList(new Object[][] {{4}, {10}});
   }
 
   private final Builder bftTestBuilder;

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/FProposalsPerRoundDropperTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/FProposalsPerRoundDropperTest.java
@@ -104,8 +104,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class FProposalsPerRoundDropperTest {
   @Parameters
   public static Collection<Object[]> testParameters() {
-    // TODO(only for CI testing): bring back the `{4}, {10}`
-    return Arrays.asList(new Object[][] {{4}, {4}, {4}, {4}, {4}, {10}, {10}, {10}, {10}, {10}});
+    return Arrays.asList(new Object[][] {{4}, {10}});
   }
 
   private final Builder bftTestBuilder;

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/FProposalsPerRoundDropperTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus/FProposalsPerRoundDropperTest.java
@@ -98,17 +98,13 @@ import org.junit.runners.Parameterized.Parameters;
  * Simulation with a communication adversary which drops a random proposal message in every round.
  *
  * <p>Dropped proposals implies that validators will need to retrieve the information originally in
- * this proposals via syncing with other nodes.
+ * these proposals via syncing with other nodes.
  */
 @RunWith(Parameterized.class)
 public class FProposalsPerRoundDropperTest {
   @Parameters
   public static Collection<Object[]> testParameters() {
-    return Arrays.asList(
-        new Object[][] {
-          {4},
-          {5} // TODO: Investigate why 5 still failing on Travis and 20 still failing on Jenkins
-        });
+    return Arrays.asList(new Object[][] {{4}, {10}});
   }
 
   private final Builder bftTestBuilder;
@@ -120,7 +116,7 @@ public class FProposalsPerRoundDropperTest {
             .networkModules(
                 NetworkOrdering.inOrder(),
                 NetworkLatencies.fixed(10),
-                NetworkDroppers.fRandomProposalsPerRoundDropped())
+                NetworkDroppers.fNodesAllReceivedProposalsDropped())
             .functionalNodeModule(
                 new FunctionalRadixNodeModule(
                     NodeStorageConfig.none(),

--- a/core/src/test-core/java/com/radixdlt/harness/simulation/network/FRandomProposalDroppersEachRound.java
+++ b/core/src/test-core/java/com/radixdlt/harness/simulation/network/FRandomProposalDroppersEachRound.java
@@ -79,22 +79,18 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /** Drops one proposal per round */
-public class FProposalsPerRoundDropper implements Predicate<SimulationNetwork.MessageInTransit> {
+public class FRandomProposalDroppersEachRound
+    implements Predicate<SimulationNetwork.MessageInTransit> {
   private final ConcurrentHashMap<Round, Set<NodeId>> proposalToDrop = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<Round, Integer> proposalCount = new ConcurrentHashMap<>();
   private final ImmutableList<BFTValidatorId> validatorSet;
   private final Random random;
   private final int faultySize;
 
-  public FProposalsPerRoundDropper(ImmutableList<BFTValidatorId> validatorSet, Random random) {
+  public FRandomProposalDroppersEachRound(
+      ImmutableList<BFTValidatorId> validatorSet, Random random) {
     this.validatorSet = validatorSet;
     this.random = random;
-    this.faultySize = (validatorSet.size() - 1) / 3;
-  }
-
-  public FProposalsPerRoundDropper(ImmutableList<BFTValidatorId> validatorSet) {
-    this.validatorSet = validatorSet;
-    this.random = null;
     this.faultySize = (validatorSet.size() - 1) / 3;
   }
 
@@ -107,9 +103,7 @@ public class FProposalsPerRoundDropper implements Predicate<SimulationNetwork.Me
               round,
               v -> {
                 final List<BFTValidatorId> nodes = Lists.newArrayList(validatorSet);
-                if (random != null) {
-                  Collections.shuffle(nodes, random);
-                }
+                Collections.shuffle(nodes, random);
                 return nodes.subList(0, faultySize).stream()
                     .map(n -> NodeId.fromPublicKey(n.getKey()))
                     .collect(Collectors.toSet());


### PR DESCRIPTION
A subset of `F=(N-1)/3` adversaries is assumed to be static across hotstuff execution (i.e. across 3 rounds).

This assumption is not met by our `NetworkDroppers.fRandomProposalsPerRoundDropped()` util (which changes the set every round). With sufficiently large network (`N>=5` on CI worker, `N>=10` on a laptop), this easily leads to unfortunate subset selections / timings (further complicated by pipelined nature of hotstuff), which cause timeouts (which are asserted in these tests).

The easiest way to fix is to have the subset `F` static across the entire test execution - and this PR applies it.
Locally, I was also able to handcraft some awkward code which changed the `F'=(N-1)/3 - 2` only by 1 node each round (i.e. there were still `N - (N-1)/3` of the same non-adversary validators in every consecutive 3 rounds) - and this also made the test stable (although I am almost sure I was able to catch a failure once, with `N=20`; possibly due to other reasons?).

Anyways: we still have another test, `OutOfOrderTest`, which uses the too-random `NetworkDroppers.fRandomProposalsPerRoundDropped()` and asserts liveness and safety. (i.e. it passes because it does not assert on timeouts)
So I think we are fine with testing using the static adversary set here.