### PR TITLE
Custom HttpStatus-aware replacement for `err(Debug)` in instrumentation

### DIFF
--- a/core-rust/core-api-server/src/core_api/errors.rs
+++ b/core-rust/core-api-server/src/core_api/errors.rs
@@ -2,6 +2,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+
 use hyper::StatusCode;
 use radix_engine_interface::network::NetworkDefinition;
 
@@ -88,7 +89,9 @@ impl<E: ErrorDetails> IntoResponse for ResponseError<E> {
             self.trace.map(|x| x.0),
         );
 
-        (self.status_code, Json(body)).into_response()
+        let mut response = (self.status_code, Json(body.clone())).into_response();
+        response.extensions_mut().insert(body);
+        response
     }
 }
 

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
@@ -4,7 +4,7 @@ use state_manager::query::{dump_component_state, VaultData};
 use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_state_account_all_fungible_resource_balances(
     state: State<CoreApiState>,
     Json(request): Json<models::LtsStateAccountAllFungibleResourceBalancesRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
@@ -6,7 +6,7 @@ use state_manager::{
 };
 use std::ops::Deref;
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_state_account_fungible_resource_balance(
     state: State<CoreApiState>,
     Json(request): Json<models::LtsStateAccountFungibleResourceBalanceRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
@@ -1,7 +1,7 @@
 use crate::core_api::*;
 use state_manager::store::traits::QueryableProofStore;
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_stream_account_transaction_outcomes(
     state: State<CoreApiState>,
     Json(request): Json<models::LtsStreamAccountTransactionOutcomesRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_transaction_outcomes.rs
@@ -1,7 +1,7 @@
 use crate::core_api::*;
 use state_manager::store::traits::{QueryableProofStore, QueryableTransactionStore};
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_stream_transaction_outcomes(
     state: State<CoreApiState>,
     Json(request): Json<models::LtsStreamTransactionOutcomesRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
@@ -4,7 +4,7 @@ use radix_engine::types::{ClockOffset, EpochManagerOffset, SubstateOffset, CLOCK
 use radix_engine_interface::api::types::{NodeModuleId, RENodeId};
 use std::ops::Deref;
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_transaction_construction(
     state: State<CoreApiState>,
     Json(request): Json<models::LtsTransactionConstructionRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
@@ -12,7 +12,7 @@ use state_manager::mempool::pending_transaction_result_cache::PendingTransaction
 use state_manager::query::StateManagerSubstateQueries;
 use state_manager::store::traits::*;
 
-#[tracing::instrument(err(Debug), skip(state))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_transaction_status(
     state: State<CoreApiState>,
     Json(request): Json<models::LtsTransactionStatusRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
@@ -4,7 +4,7 @@ use hyper::StatusCode;
 use models::lts_transaction_submit_error_details::LtsTransactionSubmitErrorDetails;
 use state_manager::{MempoolAddError, MempoolAddSource};
 
-#[tracing::instrument(level = "debug", skip(state), err(Debug))]
+#[tracing::instrument(level = "debug", skip(state))]
 pub(crate) async fn handle_lts_transaction_submit(
     State(state): State<CoreApiState>,
     Json(request): Json<models::LtsTransactionSubmitRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
@@ -1,6 +1,6 @@
 use crate::core_api::*;
 
-#[tracing::instrument(level = "debug", skip(state), err(Debug))]
+#[tracing::instrument(level = "debug", skip(state))]
 pub(crate) async fn handle_mempool_list(
     State(state): State<CoreApiState>,
     Json(request): Json<models::MempoolListRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/state_clock.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_clock.rs
@@ -4,7 +4,7 @@ use radix_engine::types::{ClockOffset, SubstateOffset, CLOCK};
 use radix_engine_interface::api::types::{NodeModuleId, RENodeId};
 use std::ops::Deref;
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_state_clock(
     state: State<CoreApiState>,
     Json(request): Json<models::StateClockRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/state_epoch.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_epoch.rs
@@ -4,7 +4,7 @@ use radix_engine::types::{EpochManagerOffset, SubstateOffset, EPOCH_MANAGER};
 use radix_engine_interface::api::types::{NodeModuleId, RENodeId};
 use std::ops::Deref;
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_state_epoch(
     state: State<CoreApiState>,
     Json(request): Json<models::StateEpochRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
@@ -2,7 +2,7 @@ use crate::core_api::*;
 use radix_engine::types::*;
 use radix_engine_interface::address::{EntityType, HrpSet};
 
-#[tracing::instrument(err(Debug), skip(state))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_status_network_configuration(
     state: State<CoreApiState>,
 ) -> Result<Json<models::NetworkConfigurationResponse>, ResponseError<()>> {

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -4,7 +4,7 @@ use state_manager::query::TransactionIdentifierLoader;
 use state_manager::store::traits::QueryableTransactionStore;
 use state_manager::CommittedTransactionIdentifiers;
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_status_network_status(
     state: State<CoreApiState>,
     Json(request): Json<models::NetworkStatusRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -27,7 +27,7 @@ macro_rules! args_from_bytes_vec {
     }};
 }
 
-#[tracing::instrument(level = "debug", skip_all, err(Debug))]
+#[tracing::instrument(level = "debug", skip_all)]
 pub(crate) async fn handle_transaction_callpreview(
     State(state): State<CoreApiState>,
     Json(request): Json<models::TransactionCallPreviewRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
@@ -3,7 +3,7 @@ use crate::core_api::*;
 
 use state_manager::store::traits::*;
 
-#[tracing::instrument(skip(state), err(Debug))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_transaction_receipt(
     state: State<CoreApiState>,
     Json(request): Json<models::TransactionReceiptRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -12,7 +12,7 @@ use state_manager::mempool::pending_transaction_result_cache::PendingTransaction
 use state_manager::query::StateManagerSubstateQueries;
 use state_manager::store::traits::*;
 
-#[tracing::instrument(err(Debug), skip(state))]
+#[tracing::instrument(skip(state))]
 pub(crate) async fn handle_transaction_status(
     state: State<CoreApiState>,
     Json(request): Json<models::TransactionStatusRequest>,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
@@ -4,7 +4,7 @@ use hyper::StatusCode;
 use models::transaction_submit_error_details::TransactionSubmitErrorDetails;
 use state_manager::{MempoolAddError, MempoolAddSource};
 
-#[tracing::instrument(level = "debug", skip(state), err(Debug))]
+#[tracing::instrument(level = "debug", skip(state))]
 pub(crate) async fn handle_transaction_submit(
     State(state): State<CoreApiState>,
     Json(request): Json<models::TransactionSubmitRequest>,

--- a/core-rust/core-api-server/src/core_api/server.rs
+++ b/core-rust/core-api-server/src/core_api/server.rs
@@ -65,6 +65,9 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use axum::http::{StatusCode, Uri};
+use axum::middleware::map_response;
+use axum::response::Response;
 use axum::{
     extract::DefaultBodyLimit,
     routing::{get, post},
@@ -73,10 +76,13 @@ use axum::{
 use parking_lot::RwLock;
 use radix_engine::types::{Categorize, Decode, Encode};
 use radix_engine_common::network::NetworkDefinition;
+use tracing::{debug, error, info, trace, warn, Level};
+
 use state_manager::jni::state_manager::ActualStateManager;
 
 use super::{constants::LARGE_REQUEST_MAX_BYTES, handlers::*, not_found_error, ResponseError};
 
+use crate::core_api::models::ErrorResponse;
 use handle_status_network_configuration as handle_provide_info_at_root_path;
 use state_manager::mempool_manager::MempoolManager;
 use state_manager::simple_mempool::SimpleMempool;
@@ -178,7 +184,8 @@ where
 
     let prefixed_router = Router::new()
         .nest("/core", router)
-        .route("/", get(handle_no_core_path));
+        .route("/", get(handle_no_core_path))
+        .layer(map_response(emit_error_response_event));
 
     let bind_addr = bind_addr.parse().expect("Failed to parse bind address");
 
@@ -189,9 +196,39 @@ where
         .unwrap();
 }
 
-#[tracing::instrument(err(Debug))]
+#[tracing::instrument]
 pub(crate) async fn handle_no_core_path() -> Result<(), ResponseError<()>> {
     Err(not_found_error("Try /core"))
+}
+
+/// A function (to be used within a `map_response` layer) in order to emit more customized events
+/// when top-level `ErrorResponse` is returned.
+/// In short, it is supposed to replace an `err(Debug)` within `#[tracing::instrument(...)]` of
+/// every handler function which returns `Result<_, ResponseError<_>>`. It emits almost the same
+/// information (except for emitting the path instead of the handler function name), but is
+/// capable of choosing the `Level` based on the HTTP status code (see `resolve_level()`).
+async fn emit_error_response_event(uri: Uri, response: Response) -> Response {
+    let error_response = response.extensions().get::<ErrorResponse>();
+    if let Some(error_response) = error_response {
+        let level = resolve_level(response.status());
+        // the `event!(level, ...)` macro does not accept non-costant levels, hence we unroll:
+        match level {
+            Level::TRACE => trace!(path = uri.path(), error = debug(error_response)),
+            Level::DEBUG => debug!(path = uri.path(), error = debug(error_response)),
+            Level::INFO => info!(path = uri.path(), error = debug(error_response)),
+            Level::WARN => warn!(path = uri.path(), error = debug(error_response)),
+            Level::ERROR => error!(path = uri.path(), error = debug(error_response)),
+        }
+    }
+    response
+}
+
+fn resolve_level(status_code: StatusCode) -> Level {
+    if status_code.is_server_error() {
+        Level::WARN
+    } else {
+        Level::DEBUG
+    }
 }
 
 #[derive(Debug, Categorize, Encode, Decode, Clone)]


### PR DESCRIPTION
A follow-up to https://github.com/radixdlt/babylon-node/pull/434.

Here we take care of the `"Mempool is full"` log, which was an open question back then.

I removed all `err(Debug)`, and now its job is done by a single `emit_error_response_event` custom axum Layer.
Here is how it looks before (line 1) and after (line 2):
![image](https://user-images.githubusercontent.com/119413677/234527408-70acd684-5d82-4aa0-993e-0473aa86fac3.png)
_(in short: the same info, but `path=` instead of handler function name)_

Currently I configured the levels as: `WARN` for HTTP 5xx, `DEBUG` for every other HTTP code (according to David's wish at https://rdxworks.slack.com/archives/C01M90Y2448/p1682440513064859?thread_ts=1682436148.845669&cid=C01M90Y2448).