### PR TITLE
Update docker-compose & README

### DIFF
--- a/testnet-node/README.md
+++ b/testnet-node/README.md
@@ -20,6 +20,8 @@ curl \
   -d '{ "network": "kisharnet" }'
 ```
 
+Note: we recommend updating the docker limits to at least 4 CPUs, 4GB RAM and 100GB disk size.
+
 ## Node volumes
 
 The node makes use of some persistent data, which is set up to be stored as docker volumes.

--- a/testnet-node/README.md
+++ b/testnet-node/README.md
@@ -49,3 +49,12 @@ with
 ```
 
 And then `./run.sh` in this folder.
+
+## Debugging
+
+It might happen that you stumble across: 
+```
+com.sleepycat.je.DiskLimitException: (JE 18.3.12) Disk usage is not within je.maxDisk or je.freeDisk limits and write operations are prohibited: maxDiskLimit=0 freeDiskLimit=5,368,709,120 adjustedMaxDiskLimit=0 maxDiskOverage=0 freeDiskShortage=28,782,592 diskFreeSpace=5,339,926,528 availableLogSize=-28,782,592 totalLogSize=1,915,298 activeLogSize=1,915,298 reservedLogSize=0 protectedLogSize=0 protectedLogSizeMap={}
+```
+
+This means you have (almost) reached the virtual disk memory limit of docker. You simply need to increase the limit. 

--- a/testnet-node/docker-compose.yml
+++ b/testnet-node/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - "127.0.0.1:30000:30000" # Gossip port - binds to localhost:30000
     environment:
       JAVA_OPTS: --enable-preview -server -Xms8g -Xmx8g  -XX:MaxDirectMemorySize=2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCompressedOops -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStoreType=jks -Djava.security.egd=file:/dev/urandom -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+      RADIXDLT_HOST_IP_ADDRESS: 127.0.0.1
       RADIXDLT_LOG_LEVEL: info
       RADIXDLT_VALIDATOR_KEY_LOCATION: /home/radixdlt/key/node.ks
       RADIXDLT_NODE_KEY_CREATE_IF_MISSING: true


### PR DESCRIPTION
Adds forgotten `RADIXDLT_HOST_IP_ADDRESS` env to docker-compose and update README debugging section.