### PR TITLE
Moving the mempool re-evaluation to its own scheduled event

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/mempool/MempoolReader.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/mempool/MempoolReader.java
@@ -67,7 +67,11 @@ package com.radixdlt.mempool;
 import java.util.List;
 
 public interface MempoolReader<RawTx> {
+
   List<RawTx> getTransactionsToRelay(int maxNumTxns, int maxTotalTxnsPayloadSize);
+
+  List<RawTx> getTransactionsForProposal(
+      int maxCount, int maxPayloadSizeBytes, List<RawTx> transactionsToExclude);
 
   int getCount();
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/mempool/MempoolReevaluator.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/mempool/MempoolReevaluator.java
@@ -64,16 +64,7 @@
 
 package com.radixdlt.mempool;
 
-import java.util.List;
+public interface MempoolReevaluator {
 
-/**
- * Basic mempool functionality.
- *
- * <p>Note that conceptually, a mempool can be thought of as a list indexable by hash.
- */
-public interface Mempool<RawTx, ProcessedTx> extends MempoolReader<RawTx>, MempoolInserter<RawTx> {
-
-  void handleTransactionsCommitted(List<ProcessedTx> transactions);
-
-  int getCount();
+  void reevaluateTransactionCommitability(int maxReevaluatedCount);
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
@@ -67,9 +67,6 @@ package com.radixdlt.statecomputer;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.lang.Result;
 import com.radixdlt.lang.Tuple;
-import com.radixdlt.mempool.MempoolInserter;
-import com.radixdlt.mempool.MempoolReader;
-import com.radixdlt.mempool.RustMempool;
 import com.radixdlt.monitoring.LabelledTimer;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.monitoring.Metrics.MethodId;
@@ -79,19 +76,13 @@ import com.radixdlt.rev2.ValidatorInfo;
 import com.radixdlt.sbor.Natives;
 import com.radixdlt.statecomputer.commit.*;
 import com.radixdlt.statemanager.StateManager;
-import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt64;
-import java.util.List;
 import java.util.Objects;
 
 public class RustStateComputer {
-  private final RustMempool mempool;
 
   public RustStateComputer(Metrics metrics, StateManager stateManager) {
     Objects.requireNonNull(stateManager);
-
-    this.mempool = new RustMempool(metrics, stateManager);
-
     LabelledTimer<MethodId> timer = metrics.stateManager().nativeCall();
     this.prepareGenesisFunc =
         Natives.builder(stateManager, RustStateComputer::prepareGenesis)
@@ -117,20 +108,6 @@ public class RustStateComputer {
         Natives.builder(stateManager, RustStateComputer::epoch)
             .measure(timer.label(new MethodId(RustStateComputer.class, "epoch")))
             .build(new TypeToken<>() {});
-  }
-
-  public MempoolReader<RawNotarizedTransaction> getMempoolReader() {
-    return this.mempool;
-  }
-
-  public MempoolInserter<RawNotarizedTransaction> getMempoolInserter() {
-    return this.mempool::addTransaction;
-  }
-
-  public List<RawNotarizedTransaction> getTransactionsForProposal(
-      int maxCount, int maxPayloadSizeBytes, List<RawNotarizedTransaction> transactionToExclude) {
-    return this.mempool.getTransactionsForProposal(
-        maxCount, maxPayloadSizeBytes, transactionToExclude);
   }
 
   public PrepareGenesisResult prepareGenesis(PrepareGenesisRequest prepareGenesisRequest) {

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -110,50 +110,60 @@ impl MempoolManager {
     /// Obeys the given count/size limits and explicit exclusions.
     pub fn get_proposal_transactions(
         &self,
-        max_count: u64,
+        max_count: usize,
         max_payload_size_bytes: u64,
         user_payload_hashes_to_exclude: &HashSet<UserPayloadHash>,
     ) -> Vec<PendingTransaction> {
         let read_mempool = self.mempool.read();
-        let candidate_pending_transactions = read_mempool.get_all_transactions();
+        let all_transactions = read_mempool.get_all_transactions();
         drop(read_mempool);
-        let mut payload_size_so_far = 0u64;
-        candidate_pending_transactions
+
+        let candidate_transactions = all_transactions
             .into_iter()
-            .filter(|candidate_transaction| {
-                !user_payload_hashes_to_exclude.contains(&candidate_transaction.payload_hash)
-            })
-            .filter(|transaction| {
-                let increased_payload_size = payload_size_so_far + transaction.payload_size as u64;
-                let fits = increased_payload_size <= max_payload_size_bytes;
-                if fits {
-                    payload_size_so_far = increased_payload_size;
-                }
-                fits
-            })
-            .take(max_count as usize)
-            .collect()
+            .filter(|candidate| !user_payload_hashes_to_exclude.contains(&candidate.payload_hash))
+            .collect();
+        Self::pick_subset_with_limits(candidate_transactions, max_count, max_payload_size_bytes)
     }
 
     /// Picks a random subset of transactions to be relayed via a mempool sync.
     /// Obeys the given count/size limits.
-    /// Checks the commitability of each transaction considered for relay (using
-    /// `CachedCommitabilityValidator`) - in case of rejection, the transaction will not be
-    /// returned, but removed from the mempool instead.
     pub fn get_relay_transactions(
         &self,
-        max_num_txns: u32,
-        max_payload_size_bytes: u32,
+        max_count: usize,
+        max_payload_size_bytes: u64,
     ) -> Vec<PendingTransaction> {
         let read_mempool = self.mempool.read();
         let candidate_transactions = read_mempool.get_all_transactions();
         drop(read_mempool);
 
-        let (transactions_to_relay, transactions_to_remove) = self.check_transactions_to_relay(
-            candidate_transactions,
-            max_num_txns.try_into().unwrap(),
-            max_payload_size_bytes.try_into().unwrap(),
-        );
+        Self::pick_subset_with_limits(candidate_transactions, max_count, max_payload_size_bytes)
+    }
+
+    /// Checks the commitability of a random subset of transactions and removes the rejected ones
+    /// from the mempool.
+    /// Obeys the given limit on the number of actually executed (i.e. not cached) transactions.
+    pub fn reevaluate_transaction_commitability(&self, max_reevaluated_count: u32) {
+        let read_mempool = self.mempool.read();
+        let mut candidate_transactions = read_mempool.get_all_transactions();
+        drop(read_mempool);
+
+        let mut transactions_to_remove = Vec::new();
+        let mut reevaluated_count = 0;
+        candidate_transactions.shuffle(&mut thread_rng());
+        for candidate_transaction in candidate_transactions {
+            let (record, was_cached) = self
+                .cached_commitability_validator
+                .check_for_rejection_cached(&candidate_transaction.payload);
+            if record.latest_attempt.rejection.is_some() {
+                transactions_to_remove.push(candidate_transaction);
+            }
+            if !was_cached {
+                reevaluated_count += 1;
+                if reevaluated_count >= max_reevaluated_count {
+                    break;
+                }
+            }
+        }
 
         if !transactions_to_remove.is_empty() {
             let mut write_mempool = self.mempool.write();
@@ -169,8 +179,6 @@ impl MempoolManager {
             drop(write_mempool);
             self.metrics.current_transactions.sub(removed_count as i64);
         }
-
-        transactions_to_relay
     }
 
     /// Adds the given transaction to the mempool (applying all the commitability checks, see
@@ -275,45 +283,24 @@ impl MempoolManager {
         self.metrics.current_transactions.sub(removed_count as i64);
     }
 
-    /// Checks the given candidate transactions for rejection and decides which ones should be
-    /// relayed via mempool sync, and which ones should be removed from mempool.
-    fn check_transactions_to_relay(
-        &self,
+    fn pick_subset_with_limits(
         mut candidate_transactions: Vec<PendingTransaction>,
-        max_num_txns: usize,
-        max_payload_size_bytes: usize,
-    ) -> (Vec<PendingTransaction>, Vec<PendingTransaction>) {
-        let mut to_relay = Vec::new();
-        let mut payload_size_so_far = 0usize;
-
-        // We (partially) cleanup the mempool on the occasion of getting the relay txns
-        // TODO: move this to a separate job
-        let mut to_remove = Vec::new();
-
+        max_count: usize,
+        max_payload_size_bytes: u64,
+    ) -> Vec<PendingTransaction> {
         candidate_transactions.shuffle(&mut thread_rng());
-        for candidate_transaction in candidate_transactions.into_iter() {
-            let (record, _) = self
-                .cached_commitability_validator
-                .check_for_rejection_cached(&candidate_transaction.payload);
-            if record.latest_attempt.rejection.is_some() {
-                // Mark the transaction to be removed from the mempool
-                // (see the comment above about moving this to a separate job)
-                to_remove.push(candidate_transaction);
-            } else {
-                // Check the payload size limit
-                payload_size_so_far += candidate_transaction.payload_size;
-                if payload_size_so_far > max_payload_size_bytes {
-                    break;
+        let mut payload_size_so_far = 0;
+        candidate_transactions
+            .into_iter()
+            .filter(|transaction| {
+                let increased_payload_size = payload_size_so_far + transaction.payload_size as u64;
+                let fits = increased_payload_size <= max_payload_size_bytes;
+                if fits {
+                    payload_size_so_far = increased_payload_size;
                 }
-
-                // Add the transaction to response
-                to_relay.push(candidate_transaction);
-                if to_relay.len() >= max_num_txns {
-                    break;
-                }
-            }
-        }
-
-        (to_relay, to_remove)
+                fits
+            })
+            .take(max_count)
+            .collect()
     }
 }

--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -84,10 +84,7 @@ import com.radixdlt.lang.Option;
 import com.radixdlt.ledger.AccumulatorState;
 import com.radixdlt.logger.EventLoggerConfig;
 import com.radixdlt.logger.EventLoggerModule;
-import com.radixdlt.mempool.MempoolReceiverModule;
-import com.radixdlt.mempool.MempoolRelayConfig;
-import com.radixdlt.mempool.MempoolRelayerModule;
-import com.radixdlt.mempool.RustMempoolConfig;
+import com.radixdlt.mempool.*;
 import com.radixdlt.messaging.MessagingModule;
 import com.radixdlt.modules.*;
 import com.radixdlt.networks.Network;
@@ -104,6 +101,7 @@ import com.radixdlt.sync.SyncRelayConfig;
 import com.radixdlt.transactions.RawLedgerTransaction;
 import com.radixdlt.utils.BooleanUtils;
 import com.radixdlt.utils.properties.RuntimeProperties;
+import java.time.Duration;
 
 /** Module which manages everything in a single node */
 public final class RadixNodeModule extends AbstractModule {
@@ -199,6 +197,7 @@ public final class RadixNodeModule extends AbstractModule {
     // Mempool Relay
     install(new MempoolRelayConfig(5, 100).asModule());
     install(new MempoolRelayerModule(20000));
+    install(new MempoolReevaluationModule(Duration.ofSeconds(10), 5));
 
     // Ledger Sync
     final long syncPatience = properties.get("sync.patience", 5000L);

--- a/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
+++ b/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
@@ -133,9 +133,9 @@ public final class StateComputerLedger implements Ledger, ProposalGenerator {
   }
 
   public interface StateComputer {
-    void addToMempool(MempoolAdd mempoolAdd, NodeId origin);
+    void addToMempool(MempoolAdd mempoolAdd, NodeId origin); // TODO(wip)
 
-    List<RawNotarizedTransaction> getTransactionsForProposal(
+    List<RawNotarizedTransaction> getTransactionsForProposal( // TODO(wip)
         List<ExecutedTransaction> executedTransactions);
 
     StateComputerResult prepare(

--- a/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
+++ b/core/src/main/java/com/radixdlt/ledger/StateComputerLedger.java
@@ -133,9 +133,9 @@ public final class StateComputerLedger implements Ledger, ProposalGenerator {
   }
 
   public interface StateComputer {
-    void addToMempool(MempoolAdd mempoolAdd, NodeId origin); // TODO(wip)
+    void addToMempool(MempoolAdd mempoolAdd, NodeId origin);
 
-    List<RawNotarizedTransaction> getTransactionsForProposal( // TODO(wip)
+    List<RawNotarizedTransaction> getTransactionsForProposal(
         List<ExecutedTransaction> executedTransactions);
 
     StateComputerResult prepare(

--- a/core/src/main/java/com/radixdlt/mempool/MempoolReevaluationModule.java
+++ b/core/src/main/java/com/radixdlt/mempool/MempoolReevaluationModule.java
@@ -104,7 +104,7 @@ public final class MempoolReevaluationModule extends AbstractModule {
   }
 
   @ProvidesIntoSet
-  private EventProcessorOnRunner<?> processor(
+  private EventProcessorOnRunner<?> mempoolReevaluationTriggerProducerProcessor(
       EventProducer<MempoolReevaluationTrigger> eventProducer) {
     return new EventProcessorOnRunner<>(
         Runners.MEMPOOL, MempoolReevaluationTrigger.class, eventProducer);

--- a/core/src/main/java/com/radixdlt/mempool/MempoolReevaluationTrigger.java
+++ b/core/src/main/java/com/radixdlt/mempool/MempoolReevaluationTrigger.java
@@ -64,16 +64,29 @@
 
 package com.radixdlt.mempool;
 
-import java.util.List;
+public final class MempoolReevaluationTrigger {
 
-/**
- * Basic mempool functionality.
- *
- * <p>Note that conceptually, a mempool can be thought of as a list indexable by hash.
- */
-public interface Mempool<RawTx, ProcessedTx> extends MempoolReader<RawTx>, MempoolInserter<RawTx> {
+  private MempoolReevaluationTrigger() {}
 
-  void handleTransactionsCommitted(List<ProcessedTx> transactions);
+  public static MempoolReevaluationTrigger create() {
+    return new MempoolReevaluationTrigger();
+  }
 
-  int getCount();
+  @Override
+  public String toString() {
+    return String.format("%s{}", this.getClass().getSimpleName());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    return o != null && getClass() == o.getClass();
+  }
+
+  @Override
+  public int hashCode() {
+    return 1;
+  }
 }

--- a/core/src/main/java/com/radixdlt/mempool/Mempools.java
+++ b/core/src/main/java/com/radixdlt/mempool/Mempools.java
@@ -89,7 +89,7 @@ public class Mempools {
 
       @Override
       public List<RawTx> getTransactionsForProposal(
-          int count, List<ProcessedTx> preparedTransactions) {
+          int maxCount, int maxPayloadSizeBytes, List<RawTx> transactionsToExclude) {
         return List.of();
       }
 

--- a/core/src/main/java/com/radixdlt/modules/DispatcherModule.java
+++ b/core/src/main/java/com/radixdlt/modules/DispatcherModule.java
@@ -85,10 +85,7 @@ import com.radixdlt.consensus.sync.VertexRequestTimeout;
 import com.radixdlt.environment.*;
 import com.radixdlt.ledger.CommittedTransactionsWithProof;
 import com.radixdlt.ledger.LedgerUpdate;
-import com.radixdlt.mempool.MempoolAdd;
-import com.radixdlt.mempool.MempoolAddSuccess;
-import com.radixdlt.mempool.MempoolRelayDispatcher;
-import com.radixdlt.mempool.MempoolRelayTrigger;
+import com.radixdlt.mempool.*;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.p2p.NodeId;
 import com.radixdlt.p2p.PeerEvent;
@@ -265,6 +262,9 @@ public class DispatcherModule extends AbstractModule {
         .in(Scopes.SINGLETON);
     bind(new TypeLiteral<ScheduledEventDispatcher<MempoolRelayTrigger>>() {})
         .toProvider(Dispatchers.scheduledDispatcherProvider(MempoolRelayTrigger.class))
+        .in(Scopes.SINGLETON);
+    bind(new TypeLiteral<ScheduledEventDispatcher<MempoolReevaluationTrigger>>() {})
+        .toProvider(Dispatchers.scheduledDispatcherProvider(MempoolReevaluationTrigger.class))
         .in(Scopes.SINGLETON);
     // The below is just another flavor of MempoolAddSuccess dispatcher, which must use a callback
     // interface (instead of an `EventDispatcher`) for dependency reasons.

--- a/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
@@ -105,6 +105,8 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
 
   private final RustStateComputer stateComputer;
 
+  private final RustMempool mempool;
+
   // Maximum number of transactions to include in a proposal
   private final int maxNumTransactionsPerProposal;
   // Maximum number of transaction payload bytes to include in a proposal
@@ -124,6 +126,7 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
 
   public REv2StateComputer(
       RustStateComputer stateComputer,
+      RustMempool mempool,
       int maxNumTransactionsPerProposal,
       int maxProposalTotalTxnsPayloadSize,
       int maxUncommittedUserTransactionsTotalPayloadSize,
@@ -134,6 +137,7 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
       Serialization serialization,
       Metrics metrics) {
     this.stateComputer = stateComputer;
+    this.mempool = mempool;
     this.maxNumTransactionsPerProposal = maxNumTransactionsPerProposal;
     this.maxProposalTotalTxnsPayloadSize = maxProposalTotalTxnsPayloadSize;
     this.maxUncommittedUserTransactionsTotalPayloadSize =
@@ -153,7 +157,7 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
         .forEach(
             transaction -> {
               try {
-                stateComputer.getMempoolInserter().addTransaction(transaction);
+                mempool.addTransaction(transaction);
                 // Please note that a `MempoolAddSuccess` event is only dispatched when the above
                 // call does not throw. This is deliberate: we do not want to propagate the
                 // transaction to other nodes if it is invalid or a duplicate (to prevent an
@@ -199,7 +203,7 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
     // TODO: This will require Proposer to simulate a NextRound update before proposing
     final var result =
         maxPayloadSize > 0 && maxNumTransactionsPerProposal > 0
-            ? stateComputer.getTransactionsForProposal(
+            ? mempool.getTransactionsForProposal(
                 maxNumTransactionsPerProposal, maxPayloadSize, rawPreviousExecutedTransactions)
             : List.<RawNotarizedTransaction>of();
 

--- a/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
@@ -81,6 +81,7 @@ import com.radixdlt.ledger.AccumulatorState;
 import com.radixdlt.ledger.MockedLedgerModule;
 import com.radixdlt.ledger.MockedLedgerRecoveryModule;
 import com.radixdlt.mempool.MempoolReceiverModule;
+import com.radixdlt.mempool.MempoolReevaluationModule;
 import com.radixdlt.mempool.MempoolRelayerModule;
 import com.radixdlt.modules.StateComputerConfig.*;
 import com.radixdlt.rev2.modules.*;
@@ -91,6 +92,7 @@ import com.radixdlt.statecomputer.RandomTransactionGenerator;
 import com.radixdlt.store.InMemoryCommittedReaderModule;
 import com.radixdlt.store.berkeley.BerkeleyDatabaseModule;
 import com.radixdlt.sync.SyncRelayConfig;
+import java.time.Duration;
 import org.junit.rules.TemporaryFolder;
 
 /** Manages the functional components of a node */
@@ -378,6 +380,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
               case MockedMempoolConfig.Relayed relayed -> {
                 install(new MempoolReceiverModule());
                 install(new MempoolRelayerModule(10000));
+                install(new MempoolReevaluationModule(Duration.ofSeconds(1), 1));
                 install(new MockedMempoolStateComputerModule(relayed.mempoolSize()));
               }
             }
@@ -416,6 +419,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
               }
               case REV2ProposerConfig.Mempool mempool -> {
                 install(new MempoolRelayerModule(10000));
+                install(new MempoolReevaluationModule(Duration.ofSeconds(1), 1));
                 install(new MempoolReceiverModule());
                 install(mempool.relayConfig().asModule());
                 install(

--- a/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/MockedMempoolStateComputerModule.java
@@ -139,7 +139,7 @@ public class MockedMempoolStateComputerModule extends AbstractModule {
       @Override
       public List<RawNotarizedTransaction> getTransactionsForProposal(
           List<StateComputerLedger.ExecutedTransaction> executedTransactions) {
-        return mempool.getTransactionsForProposal(1, List.of());
+        return mempool.getTransactionsForProposal(1, Integer.MAX_VALUE, List.of());
       }
 
       @Override

--- a/core/src/test-core/java/com/radixdlt/targeted/mempool/SimpleMempool.java
+++ b/core/src/test-core/java/com/radixdlt/targeted/mempool/SimpleMempool.java
@@ -110,24 +110,26 @@ public final class SimpleMempool
 
   @Override
   public List<RawNotarizedTransaction> getTransactionsForProposal(
-      int count, List<RawNotarizedTransaction> preparedTransactions) {
-    int size = Math.min(count, this.data.size());
-    if (size > 0) {
-      List<RawNotarizedTransaction> transactions = Lists.newArrayList();
-      var values = new ArrayList<>(this.data);
-      Collections.shuffle(values, random);
-
-      Iterator<RawNotarizedTransaction> i = values.iterator();
-      while (transactions.size() < size && i.hasNext()) {
-        var a = i.next();
-        if (!preparedTransactions.contains(a)) {
-          transactions.add(a);
-        }
+      int maxCount, int maxPayloadSizeBytes, List<RawNotarizedTransaction> preparedTransactions) {
+    List<RawNotarizedTransaction> transactions = Lists.newArrayList();
+    var candidates = new ArrayList<>(this.data);
+    Collections.shuffle(candidates, random);
+    int payloadSize = 0;
+    for (var candidate : candidates) {
+      if (preparedTransactions.contains(candidate)) {
+        continue;
       }
-      return transactions;
-    } else {
-      return Collections.emptyList();
+      int newPayloadSize = payloadSize + candidate.getPayload().length;
+      if (newPayloadSize > maxPayloadSizeBytes) {
+        continue;
+      }
+      payloadSize = newPayloadSize;
+      transactions.add(candidate);
+      if (transactions.size() >= maxCount) {
+        break;
+      }
     }
+    return transactions;
   }
 
   @Override


### PR DESCRIPTION
This simply addresses a TODO that has been there since always.
(the re-evaluation [a.k.a. "GC"] will no longer be done on mempool relay, but in its own intervals)