### PR TITLE
Replace database boilerplate code with enum_dispatch proc_macro

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -583,6 +583,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2067,7 @@ version = "0.1.0"
 dependencies = [
  "bech32",
  "blake2",
+ "enum_dispatch",
  "hex",
  "im",
  "jni",

--- a/core-rust/state-manager/Cargo.toml
+++ b/core-rust/state-manager/Cargo.toml
@@ -52,3 +52,4 @@ opentelemetry = { version = "0.18", default-features = false, features = [
   "trace",
 ] }
 opentelemetry-jaeger = { version = "0.17", features = ["rt-tokio"] }
+enum_dispatch = "0.3.11"

--- a/core-rust/state-manager/src/accumulator_tree/storage.rs
+++ b/core-rust/state-manager/src/accumulator_tree/storage.rs
@@ -62,10 +62,12 @@
  * permissions under this License.
  */
 
+use enum_dispatch::enum_dispatch;
 use radix_engine::types::{ScryptoCategorize, ScryptoDecode, ScryptoEncode};
 
 /// The "read" part of an accumulator tree storage SPI.
 /// Both the key type and node type are implementation-dependent.
+#[enum_dispatch]
 pub trait ReadableAccuTreeStore<K, N> {
     /// Gets a vertical `TreeSlice` by the given key.
     fn get_tree_slice(&self, key: &K) -> Option<TreeSlice<N>>;

--- a/core-rust/state-manager/src/query/transaction_identifiers.rs
+++ b/core-rust/state-manager/src/query/transaction_identifiers.rs
@@ -1,5 +1,8 @@
+use enum_dispatch::enum_dispatch;
+
 use crate::CommittedTransactionIdentifiers;
 
+#[enum_dispatch]
 pub trait TransactionIdentifierLoader {
     fn get_top_transaction_identifiers(&self) -> CommittedTransactionIdentifiers;
 }

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -62,31 +62,23 @@
  * permissions under this License.
  */
 
-use crate::store::traits::extensions::*;
-use crate::store::traits::CommitBundle;
 use crate::store::traits::*;
 use crate::store::{InMemoryStore, RocksDBStore};
-use crate::LedgerTransactionReceipt;
-use crate::LocalTransactionExecution;
-
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::types::UserPayloadHash;
 
+use enum_dispatch::enum_dispatch;
 use radix_engine::ledger::{OutputValue, QueryableSubstateStore, ReadableSubstateStore};
 use radix_engine::system::node_substates::PersistedSubstate;
 
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice};
 use crate::query::TransactionIdentifierLoader;
-use crate::store::traits::RecoverableVertexStore;
-use crate::transaction::LedgerTransaction;
-use crate::{
-    CommittedTransactionIdentifiers, IntentHash, LedgerPayloadHash, LedgerProof,
-    LocalTransactionReceipt, ReceiptTreeHash, TransactionTreeHash,
-};
+use crate::CommittedTransactionIdentifiers;
+use crate::{IntentHash, LedgerPayloadHash, ReceiptTreeHash, TransactionTreeHash};
 use radix_engine::types::*;
-use radix_engine::types::{Address, KeyValueStoreId, SubstateId};
+use radix_engine::types::{KeyValueStoreId, SubstateId};
 use radix_engine_stores::hash_tree::tree_store::{NodeKey, Payload, ReadableTreeStore, TreeNode};
 
 #[derive(Debug, Categorize, Encode, Decode, Clone)]
@@ -95,6 +87,20 @@ pub enum DatabaseTypeConfig {
     RocksDB(String, DatabaseConfig),
 }
 
+// As of May 2023, enum_dispatch does not work with generic traits (or other libraries that do the same).
+// We can also extend code generation for remaining local (declared in this crate) traits once
+// trait aliases/specialization makes it into stable Rust.
+// Unfortunately this doesn't work across crates since it's a proc_macro (i.e. for ReadableSubstateStore).
+#[enum_dispatch(
+    ConfigurableDatabase,
+    QueryableProofStore,
+    TransactionIdentifierLoader,
+    WriteableVertexStore,
+    RecoverableVertexStore,
+    AccountChangeIndexExtension,
+    QueryableTransactionStore,
+    CommitStore
+)]
 pub enum StateManagerDatabase {
     InMemory(InMemoryStore),
     RocksDB(RocksDBStore),
@@ -130,58 +136,6 @@ impl StateManagerDatabase {
     }
 }
 
-impl ConfigurableDatabase for StateManagerDatabase {
-    fn read_config_state(&self) -> DatabaseConfigState {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.read_config_state(),
-            StateManagerDatabase::RocksDB(store) => store.read_config_state(),
-        }
-    }
-
-    fn write_config(&mut self, database_config: &DatabaseConfig) {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.write_config(database_config),
-            StateManagerDatabase::RocksDB(store) => store.write_config(database_config),
-        }
-    }
-
-    fn is_local_transaction_execution_index_enabled(&self) -> bool {
-        match self {
-            StateManagerDatabase::InMemory(store) => {
-                store.is_local_transaction_execution_index_enabled()
-            }
-            StateManagerDatabase::RocksDB(store) => {
-                store.is_local_transaction_execution_index_enabled()
-            }
-        }
-    }
-
-    fn is_account_change_index_enabled(&self) -> bool {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.is_account_change_index_enabled(),
-            StateManagerDatabase::RocksDB(store) => store.is_account_change_index_enabled(),
-        }
-    }
-}
-
-impl ReadableSubstateStore for StateManagerDatabase {
-    fn get_substate(&self, substate_id: &SubstateId) -> Option<OutputValue> {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.get_substate(substate_id),
-            StateManagerDatabase::RocksDB(store) => store.get_substate(substate_id),
-        }
-    }
-}
-
-impl<P: Payload> ReadableTreeStore<P> for StateManagerDatabase {
-    fn get_node(&self, key: &NodeKey) -> Option<TreeNode<P>> {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.get_node(key),
-            StateManagerDatabase::RocksDB(store) => store.get_node(key),
-        }
-    }
-}
-
 impl ReadableAccuTreeStore<u64, TransactionTreeHash> for StateManagerDatabase {
     fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionTreeHash>> {
         match self {
@@ -196,101 +150,6 @@ impl ReadableAccuTreeStore<u64, ReceiptTreeHash> for StateManagerDatabase {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_tree_slice(state_version),
             StateManagerDatabase::RocksDB(store) => store.get_tree_slice(state_version),
-        }
-    }
-}
-
-impl CommitStore for StateManagerDatabase {
-    fn commit(&mut self, commit_bundle: CommitBundle) {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.commit(commit_bundle),
-            StateManagerDatabase::RocksDB(store) => store.commit(commit_bundle),
-        }
-    }
-}
-
-impl QueryableTransactionStore for StateManagerDatabase {
-    #[tracing::instrument(skip_all)]
-    fn get_committed_transaction_bundles(
-        &self,
-        start_state_version_inclusive: u64,
-        limit: usize,
-    ) -> Vec<CommittedTransactionBundle> {
-        match self {
-            StateManagerDatabase::InMemory(store) => {
-                store.get_committed_transaction_bundles(start_state_version_inclusive, limit)
-            }
-            StateManagerDatabase::RocksDB(store) => {
-                store.get_committed_transaction_bundles(start_state_version_inclusive, limit)
-            }
-        }
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn get_committed_transaction(&self, state_version: u64) -> Option<LedgerTransaction> {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.get_committed_transaction(state_version),
-            StateManagerDatabase::RocksDB(store) => store.get_committed_transaction(state_version),
-        }
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn get_committed_transaction_identifiers(
-        &self,
-        state_version: u64,
-    ) -> Option<CommittedTransactionIdentifiers> {
-        match self {
-            StateManagerDatabase::InMemory(store) => {
-                store.get_committed_transaction_identifiers(state_version)
-            }
-            StateManagerDatabase::RocksDB(store) => {
-                store.get_committed_transaction_identifiers(state_version)
-            }
-        }
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn get_committed_ledger_transaction_receipt(
-        &self,
-        state_version: u64,
-    ) -> Option<LedgerTransactionReceipt> {
-        match self {
-            StateManagerDatabase::InMemory(store) => {
-                store.get_committed_ledger_transaction_receipt(state_version)
-            }
-            StateManagerDatabase::RocksDB(store) => {
-                store.get_committed_ledger_transaction_receipt(state_version)
-            }
-        }
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn get_committed_local_transaction_execution(
-        &self,
-        state_version: u64,
-    ) -> Option<LocalTransactionExecution> {
-        match self {
-            StateManagerDatabase::InMemory(store) => {
-                store.get_committed_local_transaction_execution(state_version)
-            }
-            StateManagerDatabase::RocksDB(store) => {
-                store.get_committed_local_transaction_execution(state_version)
-            }
-        }
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn get_committed_local_transaction_receipt(
-        &self,
-        state_version: u64,
-    ) -> Option<LocalTransactionReceipt> {
-        match self {
-            StateManagerDatabase::InMemory(store) => {
-                store.get_committed_local_transaction_receipt(state_version)
-            }
-            StateManagerDatabase::RocksDB(store) => {
-                store.get_committed_local_transaction_receipt(state_version)
-            }
         }
     }
 }
@@ -334,61 +193,20 @@ impl TransactionIndex<&LedgerPayloadHash> for StateManagerDatabase {
     }
 }
 
-impl TransactionIdentifierLoader for StateManagerDatabase {
-    fn get_top_transaction_identifiers(&self) -> CommittedTransactionIdentifiers {
+impl<P: Payload> ReadableTreeStore<P> for StateManagerDatabase {
+    fn get_node(&self, key: &NodeKey) -> Option<TreeNode<P>> {
         match self {
-            StateManagerDatabase::InMemory(store) => store.get_top_transaction_identifiers(),
-            StateManagerDatabase::RocksDB(store) => store.get_top_transaction_identifiers(),
+            StateManagerDatabase::InMemory(store) => store.get_node(key),
+            StateManagerDatabase::RocksDB(store) => store.get_node(key),
         }
     }
 }
 
-impl QueryableProofStore for StateManagerDatabase {
-    fn max_state_version(&self) -> u64 {
+impl ReadableSubstateStore for StateManagerDatabase {
+    fn get_substate(&self, substate_id: &SubstateId) -> Option<OutputValue> {
         match self {
-            StateManagerDatabase::InMemory(store) => store.max_state_version(),
-            StateManagerDatabase::RocksDB(store) => store.max_state_version(),
-        }
-    }
-
-    fn get_txns_and_proof(
-        &self,
-        start_state_version_inclusive: u64,
-        max_number_of_txns_if_more_than_one_proof: u32,
-        max_payload_size_in_bytes: u32,
-    ) -> Option<(Vec<Vec<u8>>, LedgerProof)> {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.get_txns_and_proof(
-                start_state_version_inclusive,
-                max_number_of_txns_if_more_than_one_proof,
-                max_payload_size_in_bytes,
-            ),
-            StateManagerDatabase::RocksDB(store) => store.get_txns_and_proof(
-                start_state_version_inclusive,
-                max_number_of_txns_if_more_than_one_proof,
-                max_payload_size_in_bytes,
-            ),
-        }
-    }
-
-    fn get_epoch_proof(&self, epoch: u64) -> Option<LedgerProof> {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.get_epoch_proof(epoch),
-            StateManagerDatabase::RocksDB(store) => store.get_epoch_proof(epoch),
-        }
-    }
-
-    fn get_last_proof(&self) -> Option<LedgerProof> {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.get_last_proof(),
-            StateManagerDatabase::RocksDB(store) => store.get_last_proof(),
-        }
-    }
-
-    fn get_last_epoch_proof(&self) -> Option<LedgerProof> {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.get_last_epoch_proof(),
-            StateManagerDatabase::RocksDB(store) => store.get_last_epoch_proof(),
+            StateManagerDatabase::InMemory(store) => store.get_substate(substate_id),
+            StateManagerDatabase::RocksDB(store) => store.get_substate(substate_id),
         }
     }
 }
@@ -401,60 +219,6 @@ impl QueryableSubstateStore for StateManagerDatabase {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_kv_store_entries(kv_store_id),
             StateManagerDatabase::RocksDB(store) => store.get_kv_store_entries(kv_store_id),
-        }
-    }
-}
-
-impl WriteableVertexStore for StateManagerDatabase {
-    fn save_vertex_store(&mut self, vertex_store_bytes: Vec<u8>) {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.save_vertex_store(vertex_store_bytes),
-            StateManagerDatabase::RocksDB(store) => store.save_vertex_store(vertex_store_bytes),
-        }
-    }
-}
-
-impl RecoverableVertexStore for StateManagerDatabase {
-    fn get_vertex_store(&self) -> Option<Vec<u8>> {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.get_vertex_store(),
-            StateManagerDatabase::RocksDB(store) => store.get_vertex_store(),
-        }
-    }
-}
-
-impl AccountChangeIndexExtension for StateManagerDatabase {
-    fn account_change_index_last_processed_state_version(&self) -> u64 {
-        match self {
-            StateManagerDatabase::InMemory(store) => {
-                store.account_change_index_last_processed_state_version()
-            }
-            StateManagerDatabase::RocksDB(store) => {
-                store.account_change_index_last_processed_state_version()
-            }
-        }
-    }
-
-    fn catchup_account_change_index(&mut self) {
-        match self {
-            StateManagerDatabase::InMemory(store) => store.catchup_account_change_index(),
-            StateManagerDatabase::RocksDB(store) => store.catchup_account_change_index(),
-        }
-    }
-
-    fn get_state_versions_for_account(
-        &self,
-        address: Address,
-        start_state_version_inclusive: u64,
-        limit: usize,
-    ) -> Vec<u64> {
-        match self {
-            StateManagerDatabase::InMemory(store) => {
-                store.get_state_versions_for_account(address, start_state_version_inclusive, limit)
-            }
-            StateManagerDatabase::RocksDB(store) => {
-                store.get_state_versions_for_account(address, start_state_version_inclusive, limit)
-            }
         }
     }
 }

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -63,9 +63,11 @@
  */
 
 use crate::staging::StateHashTreeDiff;
+use crate::store::StateManagerDatabase;
 use crate::transaction::LedgerTransaction;
 use crate::{CommittedTransactionIdentifiers, LedgerProof, LocalTransactionReceipt};
 pub use commit::*;
+use enum_dispatch::enum_dispatch;
 pub use proofs::*;
 use radix_engine_common::{Categorize, Decode, Encode};
 pub use substate::*;
@@ -125,6 +127,7 @@ impl DatabaseConfig {
     }
 }
 
+#[enum_dispatch]
 pub trait ConfigurableDatabase {
     fn read_config_state(&self) -> DatabaseConfigState;
 
@@ -142,10 +145,14 @@ pub type CommittedTransactionBundle = (
 );
 
 pub mod vertex {
+    use super::*;
+
+    #[enum_dispatch]
     pub trait RecoverableVertexStore {
         fn get_vertex_store(&self) -> Option<Vec<u8>>;
     }
 
+    #[enum_dispatch]
     pub trait WriteableVertexStore {
         fn save_vertex_store(&mut self, vertex_store_bytes: Vec<u8>);
     }
@@ -158,6 +165,8 @@ pub mod substate {
 }
 
 pub mod transactions {
+    use super::*;
+
     use crate::store::traits::CommittedTransactionBundle;
     use crate::transaction::LedgerTransaction;
     use crate::{
@@ -165,6 +174,7 @@ pub mod transactions {
         LocalTransactionReceipt,
     };
 
+    #[enum_dispatch]
     pub trait QueryableTransactionStore {
         fn get_committed_transaction_bundles(
             &self,
@@ -195,6 +205,7 @@ pub mod transactions {
         ) -> Option<LocalTransactionReceipt>;
     }
 
+    #[enum_dispatch]
     pub trait TransactionIndex<T>: QueryableTransactionStore {
         fn get_txn_state_version_by_identifier(&self, identifier: T) -> Option<u64>;
     }
@@ -203,6 +214,7 @@ pub mod transactions {
 pub mod proofs {
     use super::*;
 
+    #[enum_dispatch]
     pub trait QueryableProofStore {
         fn max_state_version(&self) -> u64;
         fn get_txns_and_proof(
@@ -308,14 +320,17 @@ pub mod commit {
         }
     }
 
+    #[enum_dispatch]
     pub trait CommitStore {
         fn commit(&mut self, commit_bundle: CommitBundle);
     }
 }
 
 pub mod extensions {
+    use super::*;
     use radix_engine::types::Address;
 
+    #[enum_dispatch]
     pub trait AccountChangeIndexExtension {
         fn account_change_index_last_processed_state_version(&self) -> u64;
 


### PR DESCRIPTION
This PR is built on top of [PR 444](https://github.com/radixdlt/babylon-node/pull/444).

The `StateManagerDatabase` uses static dispatch (using enum/match) in order to support multiple implementations. Obviously this code is very repetitive and hence easy to generate. 

In this PR I use `enum_dispatch` to replace most of the boilerplate trait implementations for it.

Note 1: `proc_macro`s don't work across crates, so little to no chance for generating traits from `radixdlt-scrypto` this easily.
Note 2: Generic traits are not yet supported.
