### PR TITLE
Removing no-longer-used metric definitions

### DIFF
--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -151,7 +151,6 @@ public record Metrics(
     Ledger ledger,
     LedgerSync sync,
     Mempool mempool,
-    V1RadixEngine v1RadixEngine,
     Messages messages,
     Networking networking,
     Crypto crypto,
@@ -211,22 +210,7 @@ public record Metrics(
         Gauge size, Counter forks, Counter rebuilds, Counter indirectParents) {}
   }
 
-  public record BerkeleyDb(V1Ledger v1Ledger, AddressBook addressBook, SafetyState safetyState) {
-
-    public record V1Ledger(
-        Counter commits,
-        Timer transactionCreate,
-        Timer read,
-        Timer store,
-        Timer lastCommittedRead,
-        Timer lastVertexRead,
-        Timer save,
-        Timer interact,
-        Counter bytesRead,
-        Counter bytesWritten,
-        Counter proofsAdded,
-        Counter proofsRemoved,
-        Counter headerBytesWritten) {}
+  public record BerkeleyDb(AddressBook addressBook, SafetyState safetyState) {
 
     public record AddressBook(
         Timer interact, Counter bytesRead, Counter bytesWritten, Counter entriesDeleted) {}
@@ -249,9 +233,6 @@ public record Metrics(
       Gauge targetStateVersion) {}
 
   public record Mempool(Counter relaysSent) {}
-
-  public record V1RadixEngine(
-      Counter invalidProposedTransactions, Counter userTransactions, Counter systemTransactions) {}
 
   public record Messages(Inbound inbound, Outbound outbound) {
 

--- a/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolFillAndEmptyTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolFillAndEmptyTest.java
@@ -66,7 +66,6 @@ package com.radixdlt.integration.targeted.rev2.mempool;
 
 import static com.radixdlt.environment.deterministic.network.MessageSelector.firstSelector;
 import static com.radixdlt.harness.predicates.EventPredicate.onlyLocalMempoolAddEvents;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.*;
@@ -81,7 +80,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.NetworkDefinition;
@@ -93,6 +91,7 @@ import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt64;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -152,9 +151,11 @@ public final class REv2MempoolFillAndEmptyTest {
       }
       test.runForCount(10);
       if (mempoolReader.getCount() == 0) {
-        break;
+        return;
       }
     }
+
+    Assertions.fail("expected the mempool to empty itself: {}", mempoolReader.getCount());
   }
 
   @Test
@@ -165,9 +166,6 @@ public final class REv2MempoolFillAndEmptyTest {
       for (int i = 0; i < 10; i++) {
         fillAndEmptyMempool(test);
       }
-
-      var metrics = test.getInstance(0, Metrics.class);
-      assertThat(metrics.v1RadixEngine().invalidProposedTransactions().get()).isZero();
     }
   }
 }


### PR DESCRIPTION
I only did this because I noticed "remove old metrics" in the scope of https://radixdlt.atlassian.net/browse/NODE-545 (but apparently the mempool metrics were already cleaned up).