### PR TITLE
Limit core api stream response size

### DIFF
--- a/core-rust/core-api-server/src/core_api/constants.rs
+++ b/core-rust/core-api-server/src/core_api/constants.rs
@@ -1,4 +1,5 @@
 pub(crate) const MAX_STREAM_COUNT_PER_REQUEST: u16 = 10000;
+pub(crate) const MAX_STREAM_TOTAL_SIZE_PER_RESPONSE: usize = 40 * 1024 * 1024;
 
 // TODO - Change this to be slightly larger than the double the max transaction payload size.
 // (We double due to the hex encoding of the payload)

--- a/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
@@ -47,22 +47,30 @@ pub(crate) async fn handle_stream_transactions(
 
     let max_state_version = database.max_state_version();
 
-    let txns = database.get_committed_transaction_bundles(
+    let transactions = database.get_committed_transaction_bundles(
         from_state_version,
         limit.try_into().expect("limit out of usize bounds"),
     );
 
-    let api_txns = txns
-        .into_iter()
-        .map(|(ledger_transaction, receipt, identifiers)| {
-            Ok(to_api_committed_transaction(
-                &mapping_context,
-                ledger_transaction,
-                receipt,
-                identifiers,
-            )?)
-        })
-        .collect::<Result<Vec<models::CommittedTransaction>, ResponseError<()>>>()?;
+    // Reserve enough for the "header" fields
+    let mut current_total_size = 2048;
+    let mut api_txns = Vec::new();
+    for (ledger_transaction, receipt, identifiers) in transactions {
+        let committed_transaction = to_api_committed_transaction(
+            &mapping_context,
+            ledger_transaction,
+            receipt,
+            identifiers,
+        )?;
+
+        let committed_transaction_size = committed_transaction.get_json_size();
+        if current_total_size + committed_transaction_size > MAX_STREAM_TOTAL_SIZE_PER_RESPONSE {
+            break;
+        }
+        current_total_size += committed_transaction_size;
+
+        api_txns.push(committed_transaction);
+    }
 
     let count: i32 = {
         let transaction_count = api_txns.len();


### PR DESCRIPTION
In this PR I: 
1. add `ByteCountWriter` which implements `std::io::Write` in order to "hijack" `serde_json::to_writer` for size calculation instead of rendering `Json`s.
2. add `GetJsonSize` which uses `ByteCountWriter`
3. add a response total size limit for all `/*/stream/*` endpoints