### PR TITLE
feat: add wrappers for each subapi in TS SDK

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -2,9 +2,15 @@
 
 This SDK is a thin wrapper around the [Babylon Core API](https://docs-babylon.radixdlt.com/main/apis/api-specification.html).
 
-The `CoreApiClient` is the main exported object. It currently includes high-level wrappers around two sub-APIs: `LTS` and `Status`.
+The **`CoreApiClient`** is the main exported object. It includes high-level wrappers around every sub-API: 
+- **`LTS`** / **`lts`** - For long term support/backward compatible endpoints aimed at integrators such as exchanges.
+- **`Status`** - For status and configuration details for the node / engine.
+- **`Mempool`** - For information on the contents of the node's mempool.
+- **`State`** - For reading the state of entities. 
+- **`Stream`** -  For reading the committed transactions.
+- **`Transaction`** - For transaction construction, preview, submission, and monitoring the status of an individual transaction.
 
-For querying other sub-APIs, for now, use methods on `coreApiClient.LowLevel.X` where `X` is each of the different sub-APIs.
+All high level wrappers internally instantiate classes generated from OpenAPI specification. In order to query automatically generated code, you can either use `innerClient` property on each of high level APIs or access them through `coreApiClient.lowLevel.X` where `X` is each of the different sub-APIs.
 
 ## End-to-end examples
 

--- a/sdk/typescript/lib/index.ts
+++ b/sdk/typescript/lib/index.ts
@@ -4,11 +4,12 @@ import {
   LTSApi,
   MempoolApi,
   RequestContext,
+  StateApi,
   StatusApi,
   StreamApi,
   TransactionApi,
 } from "./generated";
-import { LTS, Status } from "./subapis";
+import { LTS, Mempool, State, Status, Stream, Transaction } from "./subapis";
 export * from "./subapis";
 export * from "./generated";
 
@@ -25,15 +26,20 @@ interface CoreApiClientSettings {
 }
 
 export class CoreApiClient {
-  public status: Status;
   public LTS: LTS;
   public lts: LTS;
+  public mempool: Mempool;
+  public state: State;
+  public status: Status;
+  public stream: Stream;
+  public transaction: Transaction;
   public lowLevel: {
-    status: StatusApi;
     lts: LTSApi;
-    transaction: TransactionApi;
     mempool: MempoolApi;
+    state: StateApi;
+    status: StatusApi;
     stream: StreamApi;
+    transaction: TransactionApi;
   };
 
   private constructor(
@@ -41,15 +47,20 @@ export class CoreApiClient {
     public logicalNetworkName: string
   ) {
     this.lowLevel = {
-      status: new StatusApi(configuration),
       lts: new LTSApi(configuration),
-      transaction: new TransactionApi(configuration),
       mempool: new MempoolApi(configuration),
+      state: new StateApi(configuration),
+      status: new StatusApi(configuration),
       stream: new StreamApi(configuration),
+      transaction: new TransactionApi(configuration),      
     };
-    this.status = new Status(this.lowLevel.status, logicalNetworkName);
     this.lts = new LTS(this.lowLevel.lts, logicalNetworkName);
     this.LTS = this.lts; // NOTE: this is to keep backwards compatibility
+    this.mempool = new Mempool(this.lowLevel.mempool)
+    this.state = new State(this.lowLevel.state)
+    this.status = new Status(this.lowLevel.status, logicalNetworkName);
+    this.stream = new Stream(this.lowLevel.stream);
+    this.transaction = new Transaction(this.lowLevel.transaction);
   }
 
   private static constructConfiguration(

--- a/sdk/typescript/lib/subapis/index.ts
+++ b/sdk/typescript/lib/subapis/index.ts
@@ -1,3 +1,7 @@
 // This folder captures high-level subapis that wrap the generated low level client.
 export * from "./lts";
+export * from "./mempool";
+export * from "./state";
 export * from "./status";
+export * from "./stream";
+export * from "./transaction";

--- a/sdk/typescript/lib/subapis/mempool.ts
+++ b/sdk/typescript/lib/subapis/mempool.ts
@@ -1,0 +1,8 @@
+import { MempoolApi } from "../generated";
+
+/**
+ * Wraps the lower-level `MempoolApi` - which can be accessed with `innerClient` for advanced use cases.
+ */
+export class Mempool {
+    constructor(public innerClient: MempoolApi) {}
+}

--- a/sdk/typescript/lib/subapis/state.ts
+++ b/sdk/typescript/lib/subapis/state.ts
@@ -1,0 +1,8 @@
+import { StateApi } from "../generated";
+
+/**
+ * Wraps the lower-level `StateApi` - which can be accessed with `innerClient` for advanced use cases.
+ */
+export class State {
+    constructor(public innerClient: StateApi) {}
+}

--- a/sdk/typescript/lib/subapis/status.ts
+++ b/sdk/typescript/lib/subapis/status.ts
@@ -1,6 +1,5 @@
 import {
   StatusApi,
-  LtsStateAccountAllFungibleResourceBalancesResponse,
   NetworkConfigurationResponse,
   NetworkStatusResponse,
 } from "../generated";

--- a/sdk/typescript/lib/subapis/stream.ts
+++ b/sdk/typescript/lib/subapis/stream.ts
@@ -1,0 +1,8 @@
+import { StreamApi } from "../generated";
+
+/**
+ * Wraps the lower-level `StreamApi` - which can be accessed with `innerClient` for advanced use cases.
+ */
+export class Stream {
+    constructor(public innerClient: StreamApi) {}
+}

--- a/sdk/typescript/lib/subapis/transaction.ts
+++ b/sdk/typescript/lib/subapis/transaction.ts
@@ -1,0 +1,8 @@
+import { TransactionApi } from "../generated";
+
+/**
+ * Wraps the lower-level `TransactionApi` - which can be accessed with `innerClient` for advanced use cases.
+ */
+export class Transaction {
+    constructor(public innerClient: TransactionApi) {}
+}


### PR DESCRIPTION
## Add TS SDK Sub-Api Wrappers 

## Description

Each Sub-API from now on has high-level wrapper (some of them are empty) which includes `innerClient` property.
