### PR TITLE
Extracting a shared "execute next txn in the series" logic

### DIFF
--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -63,6 +63,7 @@
  */
 
 use crate::accumulator_tree::slice_merger::AccuTreeSliceMerger;
+use std::fmt::Formatter;
 
 use crate::query::*;
 use crate::staging::{ExecutionCache, ReadableStore};
@@ -98,6 +99,8 @@ use radix_engine_interface::blueprints::consensus_manager::LeaderProposalHistory
 use radix_engine_interface::constants::GENESIS_HELPER;
 use radix_engine_interface::network::NetworkDefinition;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use radix_engine::transaction::RejectResult;
 use tracing::{error, info};
 use utils::rust::collections::NonIterMap;
 
@@ -220,7 +223,6 @@ where
             .expect("Could not encode genesis transaction");
         let prepared = PreparedLedgerTransaction::prepare_from_raw(&raw)
             .expect("Could not prepare genesis transaction");
-        let payload_hash = prepared.ledger_transaction_hash();
         let legacy_hash = prepared.legacy_ledger_payload_hash();
 
         let system_transaction = prepared
@@ -237,13 +239,10 @@ where
             &legacy_hash,
             self.execution_configurator
                 .wrap(executable, ConfigType::Genesis)
-                .warn_after(
-                    TRANSACTION_RUNTIME_WARN_THRESHOLD,
-                    format!("prepare genesis {}", payload_hash),
-                ),
+                .warn_after(TRANSACTION_RUNTIME_WARN_THRESHOLD, "genesis"),
         );
 
-        let commit = processed.expect_commit(format!("prepare genesis {}", payload_hash));
+        let commit = processed.expect_commit("genesis");
 
         GenesisTransactionResult {
             raw,
@@ -268,6 +267,15 @@ where
             .ledger_header;
         let epoch_identifiers = EpochTransactionIdentifiers::from(&epoch_header);
 
+        let mut series_executor = TransactionSeriesExecutor::new(
+            read_store.deref(),
+            &self.execution_cache,
+            self.execution_configurator.deref(),
+            epoch_identifiers,
+            base_state_version,
+            base_ledger_hashes,
+        );
+
         if prepare_request.committed_ledger_hashes != base_ledger_hashes {
             panic!(
                 "state {:?} from request does not match the current ledger state {:?}",
@@ -285,7 +293,6 @@ where
             base_committed_state_version: base_state_version,
         };
 
-        let mut state_tracker = StateTracker::initial(base_state_version, base_ledger_hashes);
         let mut duplicate_intent_hash_detector =
             DuplicateIntentHashDetector::new(read_store.deref());
 
@@ -301,37 +308,17 @@ where
                 duplicate_intent_hash_detector.record_prepared_uncommitted(intent_hash);
             }
 
-            let legacy_hash = validated.legacy_ledger_payload_hash();
-            let payload_hash = validated.ledger_transaction_hash();
-            let executable = validated.get_executable();
-            {
-                let mut execution_cache = self.execution_cache.lock();
-                let processed = execution_cache.execute_transaction(
-                    read_store.deref(),
-                    &epoch_identifiers,
-                    state_tracker.latest_state_version(),
-                    &state_tracker.latest_ledger_hashes().transaction_root,
-                    &legacy_hash,
-                    self.execution_configurator
-                        .wrap(executable, ConfigType::Regular)
-                        .warn_after(
-                            TRANSACTION_RUNTIME_WARN_THRESHOLD,
-                            format!("already prepared {}", payload_hash),
-                        ),
-                );
-
-                let commit = processed.expect_commit(format!("already prepared {}", payload_hash));
-
-                state_tracker.update(commit);
-            }
+            series_executor
+                .execute(ConfigType::Regular, &validated, "prepared uncommitted")
+                .expect("prepared uncommited transaction rejected");
         }
 
         if &prepare_request.prepared_uncommitted_ledger_hashes
-            != state_tracker.latest_ledger_hashes()
+            != series_executor.latest_ledger_hashes()
         {
             panic!(
                 "State {:?} after prepared transactions does not match the state {:?} from request",
-                state_tracker.latest_ledger_hashes(),
+                series_executor.latest_ledger_hashes(),
                 prepare_request.prepared_uncommitted_ledger_hashes,
             );
         }
@@ -368,35 +355,22 @@ where
                 },
             };
             let ledger_round_update = LedgerTransaction::RoundUpdateV1(Box::new(round_update));
-            let prepared = self
+            let validated = self
                 .ledger_transaction_validator
                 .validate_user_or_round_update_from_model(&ledger_round_update)
                 .expect("expected to be able to prepare the round update transaction");
-            let ledger_hash = prepared.ledger_transaction_hash();
-            let legacy_hash = prepared.legacy_ledger_payload_hash();
-            let executable = prepared.get_executable();
 
+            let execute_result =
+                series_executor.execute(ConfigType::Regular, &validated, "round update");
+            let commit = execute_result.expect("round update rejected");
+            if let DetailedTransactionOutcome::Failure(error) =
+                commit.local_receipt.local_execution.outcome
             {
-                let mut execution_cache = self.execution_cache.lock();
-                let processed_round_update = execution_cache.execute_transaction(
-                    read_store.deref(),
-                    &epoch_identifiers,
-                    state_tracker.latest_state_version(),
-                    &state_tracker.latest_ledger_hashes().transaction_root,
-                    &legacy_hash,
-                    self.execution_configurator
-                        .wrap(executable, ConfigType::Regular)
-                        .warn_after(
-                            TRANSACTION_RUNTIME_WARN_THRESHOLD,
-                            format!("round update {}", prepare_request.round.number()),
-                        ),
+                panic!(
+                    "update to round {} failed: {:?}",
+                    prepare_request.round.number(),
+                    error
                 );
-
-                let round_update_commit = processed_round_update
-                    .expect_commit(format!("round update {}", prepare_request.round.number()));
-                round_update_commit
-                    .check_success(format!("round update {}", prepare_request.round.number()));
-                state_tracker.update(round_update_commit);
             }
 
             committable_transactions.push(CommittableTransaction {
@@ -406,8 +380,8 @@ where
                     .expect("Expected round update to be encodable"),
                 intent_hash: None,
                 notarized_transaction_hash: None,
-                ledger_hash,
-                legacy_hash,
+                ledger_hash: validated.ledger_transaction_hash(),
+                legacy_hash: validated.legacy_ledger_payload_hash(),
             });
         }
 
@@ -426,7 +400,7 @@ where
             .enumerate()
         {
             // Don't process any additional transactions if next epoch has occurred
-            if state_tracker.next_epoch().is_some() {
+            if series_executor.next_epoch().is_some() {
                 break;
             }
 
@@ -466,7 +440,6 @@ where
             let intent_hash = prepared_user_transaction.intent_hash();
             let notarized_transaction_hash = prepared_user_transaction.notarized_transaction_hash();
             let ledger_hash = prepared_transaction.ledger_transaction_hash();
-            let legacy_hash = prepared_transaction.legacy_ledger_payload_hash();
             let invalid_at_epoch = prepared_user_transaction
                 .signed_intent
                 .intent
@@ -521,62 +494,40 @@ where
                 }
             };
 
-            let executable = validated.get_executable();
-
-            {
-                // Take out lock for the context
-                let mut execution_cache = self.execution_cache.lock();
-
-                let processed = execution_cache.execute_transaction(
-                    read_store.deref(),
-                    &epoch_identifiers,
-                    state_tracker.latest_state_version(),
-                    &state_tracker.latest_ledger_hashes().transaction_root,
-                    &legacy_hash,
-                    self.execution_configurator
-                        .wrap(executable, ConfigType::Regular)
-                        .warn_after(
-                            TRANSACTION_RUNTIME_WARN_THRESHOLD,
-                            format!("newly proposed {}", ledger_hash),
-                        ),
-                );
-
-                match processed.expect_commit_or_reject(format!("newly proposed {}", ledger_hash)) {
-                    Ok(commit) => {
-                        state_tracker.update(commit);
-
-                        duplicate_intent_hash_detector.record_committable_proposed(intent_hash);
-                        committable_transactions.push(CommittableTransaction {
-                            index: Some(index as u32),
-                            raw: raw_ledger_transaction,
-                            intent_hash: Some(intent_hash),
-                            notarized_transaction_hash: Some(notarized_transaction_hash),
-                            ledger_hash,
-                            legacy_hash,
-                        });
-                        pending_transaction_results.push(PendingTransactionResult {
-                            intent_hash,
-                            notarized_transaction_hash,
-                            invalid_at_epoch,
-                            rejection_reason: None,
-                        });
-                    }
-                    Err(reject) => {
-                        let error = reject.error.clone();
-                        rejected_transactions.push(RejectedTransaction {
-                            index: index as u32,
-                            intent_hash: Some(intent_hash),
-                            notarized_transaction_hash: Some(notarized_transaction_hash),
-                            ledger_hash: Some(ledger_hash),
-                            error: format!("{:?}", &error),
-                        });
-                        pending_transaction_results.push(PendingTransactionResult {
-                            intent_hash,
-                            notarized_transaction_hash,
-                            invalid_at_epoch,
-                            rejection_reason: Some(RejectionReason::FromExecution(Box::new(error))),
-                        });
-                    }
+            let execute_result =
+                series_executor.execute(ConfigType::Regular, &validated, "newly proposed");
+            match execute_result {
+                Ok(_) => {
+                    duplicate_intent_hash_detector.record_committable_proposed(intent_hash);
+                    committable_transactions.push(CommittableTransaction {
+                        index: Some(index as u32),
+                        raw: raw_ledger_transaction,
+                        intent_hash: Some(intent_hash),
+                        notarized_transaction_hash: Some(notarized_transaction_hash),
+                        ledger_hash: validated.ledger_transaction_hash(),
+                        legacy_hash: validated.legacy_ledger_payload_hash(),
+                    });
+                    pending_transaction_results.push(PendingTransactionResult {
+                        intent_hash,
+                        notarized_transaction_hash,
+                        invalid_at_epoch,
+                        rejection_reason: None,
+                    });
+                }
+                Err(RejectResult { error }) => {
+                    rejected_transactions.push(RejectedTransaction {
+                        index: index as u32,
+                        intent_hash: Some(intent_hash),
+                        notarized_transaction_hash: Some(notarized_transaction_hash),
+                        ledger_hash: Some(ledger_hash),
+                        error: format!("{:?}", &error),
+                    });
+                    pending_transaction_results.push(PendingTransactionResult {
+                        intent_hash,
+                        notarized_transaction_hash,
+                        invalid_at_epoch,
+                        rejection_reason: Some(RejectionReason::FromExecution(Box::new(error))),
+                    });
                 }
             }
         }
@@ -620,8 +571,8 @@ where
         PrepareResult {
             committed: committable_transactions,
             rejected: rejected_transactions,
-            next_epoch: state_tracker.next_epoch().cloned(),
-            ledger_hashes: *state_tracker.latest_ledger_hashes(),
+            next_epoch: series_executor.next_epoch().cloned(),
+            ledger_hashes: *series_executor.latest_ledger_hashes(),
         }
     }
 
@@ -671,18 +622,6 @@ impl StateTracker {
         self.state_version += 1;
         self.ledger_hashes = result.hash_structures_diff.ledger_hashes;
         self.next_epoch = result.next_epoch();
-    }
-
-    pub fn latest_ledger_hashes(&self) -> &LedgerHashes {
-        &self.ledger_hashes
-    }
-
-    pub fn latest_state_version(&self) -> u64 {
-        self.state_version
-    }
-
-    pub fn next_epoch(&self) -> Option<&NextEpoch> {
-        self.next_epoch.as_ref()
     }
 }
 
@@ -859,7 +798,6 @@ where
             );
         }
 
-        let mut state_tracker = StateTracker::initial(base_state_version, base_ledger_hashes);
         let mut committed_transaction_bundles = Vec::new();
         let mut substate_store_update = SubstateStoreUpdate::new();
         let mut state_tree_update = HashTreeUpdate::new();
@@ -870,9 +808,18 @@ where
         let mut receipt_tree_slice_merger = AccuTreeSliceMerger::new(transaction_tree_len);
         let mut intent_hashes = Vec::new();
 
+        let mut series_executor = TransactionSeriesExecutor::new(
+            write_store.deref(),
+            &self.execution_cache,
+            self.execution_configurator.deref(),
+            epoch_identifiers,
+            base_state_version,
+            base_ledger_hashes,
+        );
+
         let mut result_receipts = vec![];
         for (i, (raw, prepared)) in prepared_transactions.into_iter().enumerate() {
-            let (validated, execution_type) = if genesis {
+            let (validated, config_type) = if genesis {
                 (
                     self.ledger_transaction_validator.validate_genesis(prepared),
                     ConfigType::Genesis,
@@ -891,10 +838,6 @@ where
                 )
             };
 
-            let payload_hash = validated.ledger_transaction_hash();
-            let legacy_hash = validated.legacy_ledger_payload_hash();
-            let executable = validated.get_executable();
-
             let (
                 state_hash_tree_diff,
                 transaction_tree_slice,
@@ -902,24 +845,8 @@ where
                 local_receipt,
                 database_updates,
             ) = {
-                let mut lock_execution_cache = self.execution_cache.lock();
-                let processed = lock_execution_cache.execute_transaction(
-                    write_store.deref(),
-                    &epoch_identifiers,
-                    state_tracker.latest_state_version(),
-                    &state_tracker.latest_ledger_hashes().transaction_root,
-                    &legacy_hash,
-                    self.execution_configurator
-                        .wrap(executable, execution_type)
-                        .warn_after(
-                            TRANSACTION_RUNTIME_WARN_THRESHOLD,
-                            format!("committing {}", payload_hash),
-                        ),
-                );
-                let commit = processed.expect_commit(format!("committing {}", payload_hash));
-
-                state_tracker.update(commit);
-
+                let execute_result = series_executor.execute(config_type, &validated, "prepared");
+                let commit = execute_result.expect("prepared transaction not committable");
                 let hash_structures_diff = &commit.hash_structures_diff;
                 let state_hash_tree_diff = hash_structures_diff.state_hash_tree_diff.clone();
                 let transaction_tree_slice =
@@ -938,7 +865,7 @@ where
 
             Self::check_epoch_proof_match(
                 commit_ledger_header,
-                state_tracker.next_epoch(),
+                series_executor.next_epoch(),
                 i == (commit_transactions_len - 1),
             )?;
 
@@ -947,25 +874,25 @@ where
             }
 
             substate_store_update.apply(database_updates);
-            state_tree_update.add(state_tracker.latest_state_version(), state_hash_tree_diff);
+            state_tree_update.add(series_executor.latest_state_version(), state_hash_tree_diff);
             transaction_tree_slice_merger.append(transaction_tree_slice);
             receipt_tree_slice_merger.append(receipt_tree_slice);
 
             result_receipts.push(local_receipt.clone());
 
             committed_transaction_bundles.push(CommittedTransactionBundle {
-                state_version: state_tracker.latest_state_version(),
+                state_version: series_executor.latest_state_version(),
                 raw,
                 receipt: local_receipt,
                 identifiers: CommittedTransactionIdentifiers {
                     payload: validated.create_identifiers(),
-                    resultant_ledger_hashes: *state_tracker.latest_ledger_hashes(),
+                    resultant_ledger_hashes: *series_executor.latest_ledger_hashes(),
                 },
             });
         }
 
         let commit_ledger_hashes = &commit_ledger_header.hashes;
-        let final_ledger_hashes = state_tracker.latest_ledger_hashes();
+        let final_ledger_hashes = series_executor.latest_ledger_hashes();
         if final_ledger_hashes != commit_ledger_hashes {
             error!(
                 "computed ledger hashes at version {} differ from the ones in proof ({:?} != {:?})",
@@ -1141,5 +1068,96 @@ impl<'s, S: for<'a> TransactionIndex<&'a IntentHash>> DuplicateIntentHashDetecto
     pub fn record_committable_proposed(&mut self, intent_hash: IntentHash) {
         self.recorded_intent_hashes
             .insert(intent_hash, IntentHashDuplicateWith::Proposed);
+    }
+}
+
+/// An internal delegate for executing a series of consecutive transactions while tracking their
+/// progress.
+struct TransactionSeriesExecutor<'s, S> {
+    store: &'s S,
+    execution_cache: &'s Mutex<ExecutionCache>,
+    execution_configurator: &'s ExecutionConfigurator,
+    epoch_transaction_identifiers: EpochTransactionIdentifiers,
+    state_tracker: StateTracker,
+}
+
+impl<'s, S: ReadableStore> TransactionSeriesExecutor<'s, S> {
+    /// Creates a new executor for a lifetime of entire transaction batch execution (i.e. for all
+    /// transactions in a prepared vertex, or in a commit request).
+    /// The borrowed `store` should be already locked (i.e. the epoch and base state of the ledger
+    /// passed here should have been read under the same lock; and final database writes, if any,
+    /// should also be performed under the same lock).
+    /// The locking of the borrowed `execution_cache` will be handled by this executor.
+    pub fn new(
+        store: &'s S,
+        execution_cache: &'s Mutex<ExecutionCache>,
+        execution_configurator: &'s ExecutionConfigurator,
+        epoch_transaction_identifiers: EpochTransactionIdentifiers,
+        base_state_version: u64,
+        base_ledger_hashes: LedgerHashes,
+    ) -> Self {
+        Self {
+            store,
+            execution_cache,
+            execution_configurator,
+            epoch_transaction_identifiers,
+            state_tracker: StateTracker::initial(base_state_version, base_ledger_hashes),
+        }
+    }
+
+    /// Executes the given already-validated ledger transaction (against the borrowed `store` and
+    /// `execution_cache`).
+    /// Uses an internal [`StateTracker`] to track the progression of *committable* transactions.
+    /// The passed description will only be used for logging/errors/panics (and will be augmented by
+    /// the transaction's ledger hash).
+    pub fn execute(
+        &mut self,
+        config_type: ConfigType,
+        transaction: &ValidatedLedgerTransaction,
+        description: impl Display,
+    ) -> Result<ProcessedCommitResult, RejectResult> {
+        let description = DescribedTransactionHash {
+            ledger_hash: transaction.ledger_transaction_hash(),
+            description,
+        };
+        let mut execution_cache = self.execution_cache.lock();
+        let processed = execution_cache.execute_transaction(
+            self.store,
+            &self.epoch_transaction_identifiers,
+            self.state_tracker.state_version,
+            &self.state_tracker.ledger_hashes.transaction_root,
+            &transaction.legacy_ledger_payload_hash,
+            self.execution_configurator
+                .wrap(transaction.get_executable(), config_type)
+                .warn_after(TRANSACTION_RUNTIME_WARN_THRESHOLD, &description),
+        );
+        let result = processed.expect_commit_or_reject(&description).cloned();
+        if let Ok(commit) = &result {
+            self.state_tracker.update(commit);
+        }
+        result
+    }
+
+    pub fn latest_ledger_hashes(&self) -> &LedgerHashes {
+        &self.state_tracker.ledger_hashes
+    }
+
+    pub fn latest_state_version(&self) -> u64 {
+        self.state_tracker.state_version
+    }
+
+    pub fn next_epoch(&self) -> Option<&NextEpoch> {
+        self.state_tracker.next_epoch.as_ref()
+    }
+}
+
+struct DescribedTransactionHash<D> {
+    ledger_hash: LedgerTransactionHash,
+    description: D,
+}
+
+impl<D: Display> Display for DescribedTransactionHash<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (ledger hash {})", self.description, self.ledger_hash)
     }
 }

--- a/core-rust/state-manager/src/transaction/executable_logic.rs
+++ b/core-rust/state-manager/src/transaction/executable_logic.rs
@@ -4,6 +4,7 @@ use radix_engine::transaction::{
 use radix_engine::vm::wasm::{DefaultWasmEngine, WasmInstrumenter, WasmMeteringConfig};
 use radix_engine::vm::ScryptoVm;
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::time::{Duration, Instant};
 
 use radix_engine_interface::*;
@@ -91,15 +92,15 @@ pub struct ConfiguredExecutable<'a> {
 impl<'a> ConfiguredExecutable<'a> {
     /// Wraps this instance in a time-measuring decorator (which will log a `warn!` after the given
     /// runtime threshold).
-    pub fn warn_after(
+    pub fn warn_after<D: Display>(
         self,
         threshold: Duration,
-        logged_description: impl Into<String>,
-    ) -> TimeWarningTransactionLogic<Self> {
+        description: D,
+    ) -> TimeWarningTransactionLogic<Self, D> {
         TimeWarningTransactionLogic {
             underlying: self,
             threshold,
-            logged_description: logged_description.into(),
+            description,
         }
     }
 }
@@ -117,16 +118,17 @@ impl<'a, S: SubstateDatabase> TransactionLogic<S> for ConfiguredExecutable<'a> {
 }
 
 /// A time-measuring decorator for a `TransactionLogic`.
-pub struct TimeWarningTransactionLogic<U> {
+pub struct TimeWarningTransactionLogic<U, D> {
     underlying: U,
     threshold: Duration,
-    logged_description: String, // for error-surfacing only
+    description: D,
 }
 
-impl<U, S> TransactionLogic<S> for TimeWarningTransactionLogic<U>
+impl<U, D, S> TransactionLogic<S> for TimeWarningTransactionLogic<U, D>
 where
     S: SubstateDatabase,
     U: TransactionLogic<S>,
+    D: Display,
 {
     fn execute_on(self, store: &S) -> TransactionReceipt {
         let start = Instant::now();
@@ -134,10 +136,10 @@ where
         let elapsed = start.elapsed();
         if elapsed > self.threshold {
             warn!(
-                "Transaction execution took {}ms, above warning threshold of {}ms ({})",
+                "Execution of {} took {}ms, above warning threshold of {}ms",
+                self.description,
                 elapsed.as_millis(),
                 self.threshold.as_millis(),
-                self.logged_description,
             );
         }
         result


### PR DESCRIPTION
In this PR, a `TransactionSeriesExecutor` is born, just to reduce some copy-paste (and unify processing, I guess).

I also do some cleanup of logged transaction descriptions here (so it is no longer awkward to render transaction description strings just for logging).