### PR TITLE
Refactor: Introducing a type-safe `StateVersion`

### DIFF
--- a/core-rust/core-api-server/src/core_api/conversions/errors.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/errors.rs
@@ -2,6 +2,7 @@ use radix_engine::types::NonFungibleIdType;
 use radix_engine_common::{address::EncodeBech32AddressError, types::PartitionNumber};
 use radix_engine_interface::data::scrypto::model::ParseNonFungibleLocalIdError;
 use sbor::{DecodeError, EncodeError};
+use state_manager::StateVersion;
 use tracing::warn;
 use transaction::errors::TransactionValidationError;
 
@@ -55,7 +56,7 @@ pub enum MappingError {
         message: String,
     },
     CouldNotDecodeTransaction {
-        state_version: u64,
+        state_version: StateVersion,
         error: DecodeError,
     },
 }

--- a/core-rust/core-api-server/src/core_api/conversions/lts.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/lts.rs
@@ -4,7 +4,7 @@ use radix_engine::{
 };
 use state_manager::{
     CommittedTransactionIdentifiers, LedgerTransactionOutcome, LocalTransactionReceipt,
-    SubstateChange, TransactionTreeHash,
+    StateVersion, SubstateChange, TransactionTreeHash,
 };
 use transaction::prelude::*;
 
@@ -13,7 +13,7 @@ use crate::core_api::*;
 #[tracing::instrument(skip_all)]
 pub fn to_api_lts_committed_transaction_outcome(
     context: &MappingContext,
-    state_version: u64,
+    state_version: StateVersion,
     receipt: LocalTransactionReceipt,
     identifiers: CommittedTransactionIdentifiers,
 ) -> Result<models::LtsCommittedTransactionOutcome, MappingError> {

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
@@ -2,6 +2,7 @@ use crate::core_api::*;
 use radix_engine::types::*;
 use radix_engine_queries::typed_substate_layout::*;
 use state_manager::store::traits::QueryableProofStore;
+use state_manager::StateVersion;
 use std::ops::Deref;
 
 #[tracing::instrument(skip(state))]
@@ -108,7 +109,7 @@ pub(crate) async fn handle_lts_state_account_fungible_resource_balance(
 
 fn response(
     context: &MappingContext,
-    state_version: u64,
+    state_version: StateVersion,
     account_address: &ComponentAddress,
     resource_address: &ResourceAddress,
     amount: &Decimal,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
@@ -23,7 +23,7 @@ pub(crate) async fn handle_lts_stream_account_transaction_outcomes(
     let account_address = extract_global_address(&extraction_context, &request.account_address)
         .map_err(|err| err.into_response_error("account_address"))?;
 
-    let from_state_version: u64 = extract_api_state_version(request.from_state_version)
+    let from_state_version = extract_api_state_version(request.from_state_version)
         .map_err(|err| err.into_response_error("from_state_version"))?;
 
     let limit: usize = request

--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_transaction_outcomes.rs
@@ -11,7 +11,7 @@ pub(crate) async fn handle_lts_stream_transaction_outcomes(
     assert_matching_network(&request.network, &state.network)?;
     let mapping_context = MappingContext::new(&state.network);
 
-    let from_state_version: u64 = extract_api_state_version(request.from_state_version)
+    let from_state_version = extract_api_state_version(request.from_state_version)
         .map_err(|err| err.into_response_error("from_state_version"))?;
 
     let limit: u64 = request

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -2,7 +2,7 @@ use crate::core_api::*;
 
 use state_manager::query::TransactionIdentifierLoader;
 use state_manager::store::traits::*;
-use state_manager::{LedgerHashes, LedgerProof};
+use state_manager::{LedgerHashes, LedgerProof, StateVersion};
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_status_network_status(
@@ -16,7 +16,7 @@ pub(crate) async fn handle_status_network_status(
     let (current_state_version, current_ledger_hashes) = database.get_top_ledger_hashes();
     Ok(models::NetworkStatusResponse {
         pre_genesis_state_identifier: Box::new(to_api_committed_state_identifiers(
-            0,
+            StateVersion::pre_genesis(),
             &LedgerHashes::pre_genesis(),
         )?),
         genesis_epoch_round: database
@@ -68,7 +68,7 @@ pub fn to_api_epoch_round(
 }
 
 pub fn to_api_committed_state_identifiers(
-    state_version: u64,
+    state_version: StateVersion,
     ledger_hashes: &LedgerHashes,
 ) -> Result<models::CommittedStateIdentifier, MappingError> {
     Ok(models::CommittedStateIdentifier {

--- a/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
@@ -5,7 +5,7 @@ use radix_engine::types::hash;
 use radix_engine_common::types::ValidatorIndex;
 use state_manager::store::traits::*;
 use state_manager::transaction::*;
-use state_manager::{CommittedTransactionIdentifiers, LocalTransactionReceipt};
+use state_manager::{CommittedTransactionIdentifiers, LocalTransactionReceipt, StateVersion};
 
 use std::collections::HashMap;
 use transaction::manifest;
@@ -24,7 +24,7 @@ pub(crate) async fn handle_stream_transactions(
         .with_transaction_formats(&request.transaction_format_options)
         .with_substate_formats(&request.substate_format_options);
 
-    let from_state_version: u64 = extract_api_state_version(request.from_state_version)
+    let from_state_version = extract_api_state_version(request.from_state_version)
         .map_err(|err| err.into_response_error("from_state_version"))?;
 
     let limit: u64 = request
@@ -118,7 +118,7 @@ pub(crate) async fn handle_stream_transactions(
 #[tracing::instrument(skip_all)]
 pub fn to_api_committed_transaction(
     context: &MappingContext,
-    state_version: u64,
+    state_version: StateVersion,
     raw_ledger_transaction: RawLedgerTransaction,
     ledger_transaction: LedgerTransaction,
     receipt: LocalTransactionReceipt,

--- a/core-rust/state-manager/src/jni/transaction_store.rs
+++ b/core-rust/state-manager/src/jni/transaction_store.rs
@@ -65,7 +65,7 @@
 use crate::jni::state_manager::JNIStateManager;
 use crate::store::traits::*;
 use crate::transaction::{LedgerTransactionHash, RawLedgerTransaction};
-use crate::{DetailedTransactionOutcome, LedgerProof, LedgerTransactionOutcome};
+use crate::{DetailedTransactionOutcome, LedgerProof, LedgerTransactionOutcome, StateVersion};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
@@ -116,7 +116,8 @@ extern "system" fn Java_com_radixdlt_transaction_REv2TransactionAndProofStore_ge
     jni_sbor_coded_call(
         &env,
         request_payload,
-        |state_version: u64| -> Option<ExecutedTransaction> {
+        |state_version_number: u64| -> Option<ExecutedTransaction> {
+            let state_version = StateVersion::of(state_version_number);
             let database = JNIStateManager::get_database(&env, j_state_manager);
             let read_database = database.read();
             let committed_transaction = read_database.get_committed_transaction(state_version)?;
@@ -157,7 +158,8 @@ extern "system" fn Java_com_radixdlt_transaction_REv2TransactionAndProofStore_ge
     jni_sbor_coded_call(
         &env,
         request_payload,
-        |state_version: u64| -> Option<TransactionDetails> {
+        |state_version_number: u64| -> Option<TransactionDetails> {
+            let state_version = StateVersion::of(state_version_number);
             let database = JNIStateManager::get_database(&env, j_state_manager);
             let read_database = database.read();
             let committed_local_transaction_execution =
@@ -188,7 +190,7 @@ extern "system" fn Java_com_radixdlt_transaction_REv2TransactionAndProofStore_ge
         |request: TxnsAndProofRequest| -> Option<TxnsAndProof> {
             let database = JNIStateManager::get_database(&env, j_state_manager);
             let txns_and_proof = database.read().get_txns_and_proof(
-                request.start_state_version_inclusive,
+                StateVersion::of(request.start_state_version_inclusive),
                 request.max_number_of_txns_if_more_than_one_proof,
                 request.max_payload_size_in_bytes,
             );

--- a/core-rust/state-manager/src/query/transaction_identifiers.rs
+++ b/core-rust/state-manager/src/query/transaction_identifiers.rs
@@ -1,15 +1,16 @@
 use enum_dispatch::enum_dispatch;
 
-use crate::{CommittedTransactionIdentifiers, LedgerHashes};
+use crate::{CommittedTransactionIdentifiers, LedgerHashes, StateVersion};
 
 #[enum_dispatch]
 pub trait TransactionIdentifierLoader {
-    // TODO(no-accu-hash): it's worth having `pub struct StateVersion(u64);` at this point
-    fn get_top_transaction_identifiers(&self) -> Option<(u64, CommittedTransactionIdentifiers)>;
+    fn get_top_transaction_identifiers(
+        &self,
+    ) -> Option<(StateVersion, CommittedTransactionIdentifiers)>;
 
-    fn get_top_ledger_hashes(&self) -> (u64, LedgerHashes) {
+    fn get_top_ledger_hashes(&self) -> (StateVersion, LedgerHashes) {
         self.get_top_transaction_identifiers()
             .map(|(state_version, ids)| (state_version, ids.resultant_ledger_hashes))
-            .unwrap_or_else(|| (0, LedgerHashes::pre_genesis()))
+            .unwrap_or_else(|| (StateVersion::pre_genesis(), LedgerHashes::pre_genesis()))
     }
 }

--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -71,7 +71,7 @@ use crate::staging::{
     AccuTreeDiff, HashStructuresDiff, HashUpdateContext, ProcessedTransactionReceipt,
     StateHashTreeDiff,
 };
-use crate::{EpochTransactionIdentifiers, ReceiptTreeHash, TransactionTreeHash};
+use crate::{EpochTransactionIdentifiers, ReceiptTreeHash, StateVersion, TransactionTreeHash};
 use im::hashmap::HashMap as ImmutableHashMap;
 
 use im::ordmap::OrdMap as ImmutableOrdMap;
@@ -160,7 +160,7 @@ impl ExecutionCache {
         &mut self,
         root_store: &S,
         epoch_transaction_identifiers: &EpochTransactionIdentifiers,
-        parent_state_version: u64,
+        parent_state_version: StateVersion,
         parent_transaction_root: &TransactionTreeHash,
         ledger_transaction_hash: &LedgerTransactionHash,
         executable: T,
@@ -341,10 +341,10 @@ impl<'s, S: ReadableTreeStore<()>> ReadableTreeStore<()> for StagedStore<'s, S> 
     }
 }
 
-impl<'s, S: ReadableAccuTreeStore<u64, TransactionTreeHash>>
-    ReadableAccuTreeStore<u64, TransactionTreeHash> for StagedStore<'s, S>
+impl<'s, S: ReadableAccuTreeStore<StateVersion, TransactionTreeHash>>
+    ReadableAccuTreeStore<StateVersion, TransactionTreeHash> for StagedStore<'s, S>
 {
-    fn get_tree_slice(&self, key: &u64) -> Option<TreeSlice<TransactionTreeHash>> {
+    fn get_tree_slice(&self, key: &StateVersion) -> Option<TreeSlice<TransactionTreeHash>> {
         self.overlay
             .transaction_tree_slices
             .get(key)
@@ -353,10 +353,10 @@ impl<'s, S: ReadableAccuTreeStore<u64, TransactionTreeHash>>
     }
 }
 
-impl<'s, S: ReadableAccuTreeStore<u64, ReceiptTreeHash>> ReadableAccuTreeStore<u64, ReceiptTreeHash>
-    for StagedStore<'s, S>
+impl<'s, S: ReadableAccuTreeStore<StateVersion, ReceiptTreeHash>>
+    ReadableAccuTreeStore<StateVersion, ReceiptTreeHash> for StagedStore<'s, S>
 {
-    fn get_tree_slice(&self, key: &u64) -> Option<TreeSlice<ReceiptTreeHash>> {
+    fn get_tree_slice(&self, key: &StateVersion) -> Option<TreeSlice<ReceiptTreeHash>> {
         self.overlay
             .receipt_tree_slices
             .get(key)
@@ -410,8 +410,8 @@ pub struct ImmutableStore {
     substate_updates: ImmutableOrdMap<(DbPartitionKey, DbSortKey), DatabaseUpdate>,
     re_node_layer_nodes: ImmutableHashMap<NodeKey, TreeNode<PartitionPayload>>,
     substate_layer_nodes: ImmutableHashMap<NodeKey, TreeNode<()>>,
-    transaction_tree_slices: ImmutableHashMap<u64, TreeSlice<TransactionTreeHash>>,
-    receipt_tree_slices: ImmutableHashMap<u64, TreeSlice<ReceiptTreeHash>>,
+    transaction_tree_slices: ImmutableHashMap<StateVersion, TreeSlice<TransactionTreeHash>>,
+    receipt_tree_slices: ImmutableHashMap<StateVersion, TreeSlice<ReceiptTreeHash>>,
 }
 
 impl Accumulator<ProcessedTransactionReceipt> for ImmutableStore {

--- a/core-rust/state-manager/src/staging/epoch_handling.rs
+++ b/core-rust/state-manager/src/staging/epoch_handling.rs
@@ -62,6 +62,8 @@
  * permissions under this License.
  */
 
+use crate::StateVersion;
+
 /// An extracted logic related to the "accu tree per epoch" approach (where the first leaf of the
 /// next epoch's tree is an auto-inserted root of the previous epoch's tree).
 pub struct AccuTreeEpochHandler {
@@ -72,10 +74,14 @@ impl AccuTreeEpochHandler {
     /// Creates an instance scoped at a particular epoch, based on 2 state versions: the state
     /// version of the transaction which started that epoch, and the state version of the last
     /// committed transaction.
-    pub fn new(epoch_state_version: u64, current_state_version: u64) -> Self {
+    pub fn new(epoch_state_version: StateVersion, current_state_version: StateVersion) -> Self {
         Self {
-            epoch_version_count: usize::try_from(current_state_version - epoch_state_version)
-                .unwrap(),
+            epoch_version_count: StateVersion::calculate_progress(
+                epoch_state_version,
+                current_state_version,
+            )
+            .and_then(usize::try_from)
+            .unwrap(),
         }
     }
 

--- a/core-rust/state-manager/src/staging/mod.rs
+++ b/core-rust/state-manager/src/staging/mod.rs
@@ -69,7 +69,7 @@ mod stage_tree;
 mod substate_overlay_iterator;
 
 use crate::accumulator_tree::storage::ReadableAccuTreeStore;
-use crate::{ReceiptTreeHash, TransactionTreeHash};
+use crate::{ReceiptTreeHash, StateVersion, TransactionTreeHash};
 use radix_engine_store_interface::interface::SubstateDatabase;
 use radix_engine_stores::hash_tree::tree_store::{PartitionPayload, ReadableTreeStore};
 
@@ -87,14 +87,14 @@ impl<T> ReadableStateTreeStore for T where
 
 pub trait ReadableHashStructuresStore:
     ReadableStateTreeStore
-    + ReadableAccuTreeStore<u64, TransactionTreeHash>
-    + ReadableAccuTreeStore<u64, ReceiptTreeHash>
+    + ReadableAccuTreeStore<StateVersion, TransactionTreeHash>
+    + ReadableAccuTreeStore<StateVersion, ReceiptTreeHash>
 {
 }
 impl<T> ReadableHashStructuresStore for T where
     T: ReadableStateTreeStore
-        + ReadableAccuTreeStore<u64, TransactionTreeHash>
-        + ReadableAccuTreeStore<u64, ReceiptTreeHash>
+        + ReadableAccuTreeStore<StateVersion, TransactionTreeHash>
+        + ReadableAccuTreeStore<StateVersion, ReceiptTreeHash>
 {
 }
 

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -69,7 +69,10 @@ use std::path::PathBuf;
 
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice};
 use crate::query::TransactionIdentifierLoader;
-use crate::{CommittedTransactionIdentifiers, LedgerHashes, ReceiptTreeHash, TransactionTreeHash};
+use crate::{
+    CommittedTransactionIdentifiers, LedgerHashes, ReceiptTreeHash, StateVersion,
+    TransactionTreeHash,
+};
 use enum_dispatch::enum_dispatch;
 use radix_engine_store_interface::interface::{
     DbPartitionKey, DbSortKey, DbSubstateValue, PartitionEntry, SubstateDatabase,
@@ -168,8 +171,11 @@ impl<P: Payload> ReadableTreeStore<P> for StateManagerDatabase {
     }
 }
 
-impl ReadableAccuTreeStore<u64, TransactionTreeHash> for StateManagerDatabase {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionTreeHash>> {
+impl ReadableAccuTreeStore<StateVersion, TransactionTreeHash> for StateManagerDatabase {
+    fn get_tree_slice(
+        &self,
+        state_version: &StateVersion,
+    ) -> Option<TreeSlice<TransactionTreeHash>> {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_tree_slice(state_version),
             StateManagerDatabase::RocksDB(store) => store.get_tree_slice(state_version),
@@ -177,8 +183,8 @@ impl ReadableAccuTreeStore<u64, TransactionTreeHash> for StateManagerDatabase {
     }
 }
 
-impl ReadableAccuTreeStore<u64, ReceiptTreeHash> for StateManagerDatabase {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptTreeHash>> {
+impl ReadableAccuTreeStore<StateVersion, ReceiptTreeHash> for StateManagerDatabase {
+    fn get_tree_slice(&self, state_version: &StateVersion) -> Option<TreeSlice<ReceiptTreeHash>> {
         match self {
             StateManagerDatabase::InMemory(store) => store.get_tree_slice(state_version),
             StateManagerDatabase::RocksDB(store) => store.get_tree_slice(state_version),
@@ -187,7 +193,7 @@ impl ReadableAccuTreeStore<u64, ReceiptTreeHash> for StateManagerDatabase {
 }
 
 impl TransactionIndex<&IntentHash> for StateManagerDatabase {
-    fn get_txn_state_version_by_identifier(&self, identifier: &IntentHash) -> Option<u64> {
+    fn get_txn_state_version_by_identifier(&self, identifier: &IntentHash) -> Option<StateVersion> {
         match self {
             StateManagerDatabase::InMemory(store) => {
                 store.get_txn_state_version_by_identifier(identifier)
@@ -203,7 +209,7 @@ impl TransactionIndex<&NotarizedTransactionHash> for StateManagerDatabase {
     fn get_txn_state_version_by_identifier(
         &self,
         identifier: &NotarizedTransactionHash,
-    ) -> Option<u64> {
+    ) -> Option<StateVersion> {
         match self {
             StateManagerDatabase::InMemory(store) => {
                 store.get_txn_state_version_by_identifier(identifier)
@@ -219,7 +225,7 @@ impl TransactionIndex<&LedgerTransactionHash> for StateManagerDatabase {
     fn get_txn_state_version_by_identifier(
         &self,
         identifier: &LedgerTransactionHash,
-    ) -> Option<u64> {
+    ) -> Option<StateVersion> {
         match self {
             StateManagerDatabase::InMemory(store) => {
                 store.get_txn_state_version_by_identifier(identifier)

--- a/core-rust/state-manager/src/store/in_memory.rs
+++ b/core-rust/state-manager/src/store/in_memory.rs
@@ -70,7 +70,8 @@ use crate::transaction::{
 };
 use crate::{
     CommittedTransactionIdentifiers, LedgerProof, LedgerTransactionReceipt,
-    LocalTransactionExecution, LocalTransactionReceipt, ReceiptTreeHash, TransactionTreeHash,
+    LocalTransactionExecution, LocalTransactionReceipt, ReceiptTreeHash, StateVersion,
+    TransactionTreeHash,
 };
 
 use crate::query::TransactionIdentifierLoader;
@@ -89,22 +90,22 @@ use transaction::model::*;
 #[derive(Debug)]
 pub struct InMemoryStore {
     flags: DatabaseFlags,
-    transactions: BTreeMap<u64, RawLedgerTransaction>,
-    transaction_identifiers: BTreeMap<u64, CommittedTransactionIdentifiers>,
-    ledger_receipts: BTreeMap<u64, LedgerTransactionReceipt>,
-    local_transaction_executions: BTreeMap<u64, LocalTransactionExecution>,
-    transaction_intent_lookup: HashMap<IntentHash, u64>,
-    user_payload_hash_lookup: HashMap<NotarizedTransactionHash, u64>,
-    ledger_payload_hash_lookup: HashMap<LedgerTransactionHash, u64>,
-    proofs: BTreeMap<u64, LedgerProof>,
+    transactions: BTreeMap<StateVersion, RawLedgerTransaction>,
+    transaction_identifiers: BTreeMap<StateVersion, CommittedTransactionIdentifiers>,
+    ledger_receipts: BTreeMap<StateVersion, LedgerTransactionReceipt>,
+    local_transaction_executions: BTreeMap<StateVersion, LocalTransactionExecution>,
+    transaction_intent_lookup: HashMap<IntentHash, StateVersion>,
+    user_payload_hash_lookup: HashMap<NotarizedTransactionHash, StateVersion>,
+    ledger_payload_hash_lookup: HashMap<LedgerTransactionHash, StateVersion>,
+    proofs: BTreeMap<StateVersion, LedgerProof>,
     epoch_proofs: BTreeMap<Epoch, LedgerProof>,
     vertex_store: Option<Vec<u8>>,
     substate_store: InMemorySubstateDatabase,
     tree_node_store: SerializedInMemoryTreeStore,
-    transaction_tree_slices: BTreeMap<u64, TreeSlice<TransactionTreeHash>>,
-    receipt_tree_slices: BTreeMap<u64, TreeSlice<ReceiptTreeHash>>,
-    account_change_index_last_state_version: u64,
-    account_change_index_set: HashMap<GlobalAddress, BTreeSet<u64>>,
+    transaction_tree_slices: BTreeMap<StateVersion, TreeSlice<TransactionTreeHash>>,
+    receipt_tree_slices: BTreeMap<StateVersion, TreeSlice<ReceiptTreeHash>>,
+    account_change_index_last_state_version: StateVersion,
+    account_change_index_set: HashMap<GlobalAddress, BTreeSet<StateVersion>>,
 }
 
 impl InMemoryStore {
@@ -125,14 +126,14 @@ impl InMemoryStore {
             tree_node_store: SerializedInMemoryTreeStore::new(),
             transaction_tree_slices: BTreeMap::new(),
             receipt_tree_slices: BTreeMap::new(),
-            account_change_index_last_state_version: 0,
+            account_change_index_last_state_version: StateVersion::pre_genesis(),
             account_change_index_set: HashMap::new(),
         }
     }
 
     fn insert_transaction(
         &mut self,
-        state_version: u64,
+        state_version: StateVersion,
         transaction: RawLedgerTransaction,
         receipt: LocalTransactionReceipt,
         identifiers: CommittedTransactionIdentifiers,
@@ -190,12 +191,12 @@ impl ConfigurableDatabase for InMemoryStore {
         // We don't need to do anything for in memory store
     }
 
-    fn is_local_transaction_execution_index_enabled(&self) -> bool {
-        self.flags.enable_local_transaction_execution_index
-    }
-
     fn is_account_change_index_enabled(&self) -> bool {
         self.flags.enable_account_change_index
+    }
+
+    fn is_local_transaction_execution_index_enabled(&self) -> bool {
+        self.flags.enable_local_transaction_execution_index
     }
 }
 
@@ -212,7 +213,7 @@ impl RecoverableVertexStore for InMemoryStore {
 }
 
 impl TransactionIndex<&IntentHash> for InMemoryStore {
-    fn get_txn_state_version_by_identifier(&self, identifier: &IntentHash) -> Option<u64> {
+    fn get_txn_state_version_by_identifier(&self, identifier: &IntentHash) -> Option<StateVersion> {
         self.transaction_intent_lookup.get(identifier).cloned()
     }
 }
@@ -221,7 +222,7 @@ impl TransactionIndex<&NotarizedTransactionHash> for InMemoryStore {
     fn get_txn_state_version_by_identifier(
         &self,
         identifier: &NotarizedTransactionHash,
-    ) -> Option<u64> {
+    ) -> Option<StateVersion> {
         self.user_payload_hash_lookup.get(identifier).cloned()
     }
 }
@@ -230,7 +231,7 @@ impl TransactionIndex<&LedgerTransactionHash> for InMemoryStore {
     fn get_txn_state_version_by_identifier(
         &self,
         identifier: &LedgerTransactionHash,
-    ) -> Option<u64> {
+    ) -> Option<StateVersion> {
         self.ledger_payload_hash_lookup.get(identifier).cloned()
     }
 }
@@ -258,14 +259,17 @@ impl<P: Payload> ReadableTreeStore<P> for InMemoryStore {
     }
 }
 
-impl ReadableAccuTreeStore<u64, TransactionTreeHash> for InMemoryStore {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionTreeHash>> {
+impl ReadableAccuTreeStore<StateVersion, TransactionTreeHash> for InMemoryStore {
+    fn get_tree_slice(
+        &self,
+        state_version: &StateVersion,
+    ) -> Option<TreeSlice<TransactionTreeHash>> {
         self.transaction_tree_slices.get(state_version).cloned()
     }
 }
 
-impl ReadableAccuTreeStore<u64, ReceiptTreeHash> for InMemoryStore {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptTreeHash>> {
+impl ReadableAccuTreeStore<StateVersion, ReceiptTreeHash> for InMemoryStore {
+    fn get_tree_slice(&self, state_version: &StateVersion) -> Option<TreeSlice<ReceiptTreeHash>> {
         self.receipt_tree_slices.get(state_version).cloned()
     }
 }
@@ -315,12 +319,12 @@ impl CommitStore for InMemoryStore {
 }
 
 pub struct InMemoryCommittedTransactionBundleIterator<'a> {
-    state_version: u64,
+    state_version: StateVersion,
     store: &'a InMemoryStore,
 }
 
 impl<'a> InMemoryCommittedTransactionBundleIterator<'a> {
-    fn new(from_state_version: u64, store: &'a InMemoryStore) -> Self {
+    fn new(from_state_version: StateVersion, store: &'a InMemoryStore) -> Self {
         InMemoryCommittedTransactionBundleIterator {
             state_version: from_state_version,
             store,
@@ -333,7 +337,7 @@ impl Iterator for InMemoryCommittedTransactionBundleIterator<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let state_version = self.state_version;
-        self.state_version += 1;
+        self.state_version = self.state_version.next();
         match self.store.transactions.get(&state_version) {
             None => None,
             Some(transaction) => Some(CommittedTransactionBundle {
@@ -367,7 +371,7 @@ impl Iterator for InMemoryCommittedTransactionBundleIterator<'_> {
 impl IterableTransactionStore for InMemoryStore {
     fn get_committed_transaction_bundle_iter(
         &self,
-        from_state_version: u64,
+        from_state_version: StateVersion,
     ) -> Box<dyn Iterator<Item = CommittedTransactionBundle> + '_> {
         // This is to align behaviour with the RocksDB implementation. See comment there.
         debug_assert!(self.is_local_transaction_execution_index_enabled());
@@ -380,27 +384,30 @@ impl IterableTransactionStore for InMemoryStore {
 }
 
 impl QueryableTransactionStore for InMemoryStore {
-    fn get_committed_transaction(&self, state_version: u64) -> Option<RawLedgerTransaction> {
+    fn get_committed_transaction(
+        &self,
+        state_version: StateVersion,
+    ) -> Option<RawLedgerTransaction> {
         Some(self.transactions.get(&state_version)?.clone())
     }
 
     fn get_committed_transaction_identifiers(
         &self,
-        state_version: u64,
+        state_version: StateVersion,
     ) -> Option<CommittedTransactionIdentifiers> {
         Some(self.transaction_identifiers.get(&state_version)?.clone())
     }
 
     fn get_committed_ledger_transaction_receipt(
         &self,
-        state_version: u64,
+        state_version: StateVersion,
     ) -> Option<LedgerTransactionReceipt> {
         Some(self.ledger_receipts.get(&state_version)?.clone())
     }
 
     fn get_committed_local_transaction_execution(
         &self,
-        state_version: u64,
+        state_version: StateVersion,
     ) -> Option<LocalTransactionExecution> {
         Some(
             self.local_transaction_executions
@@ -411,7 +418,7 @@ impl QueryableTransactionStore for InMemoryStore {
 
     fn get_committed_local_transaction_receipt(
         &self,
-        state_version: u64,
+        state_version: StateVersion,
     ) -> Option<LocalTransactionReceipt> {
         Some(LocalTransactionReceipt {
             on_ledger: self.ledger_receipts.get(&state_version)?.clone(),
@@ -424,7 +431,9 @@ impl QueryableTransactionStore for InMemoryStore {
 }
 
 impl TransactionIdentifierLoader for InMemoryStore {
-    fn get_top_transaction_identifiers(&self) -> Option<(u64, CommittedTransactionIdentifiers)> {
+    fn get_top_transaction_identifiers(
+        &self,
+    ) -> Option<(StateVersion, CommittedTransactionIdentifiers)> {
         self.transaction_identifiers
             .iter()
             .next_back()
@@ -433,18 +442,18 @@ impl TransactionIdentifierLoader for InMemoryStore {
 }
 
 impl QueryableProofStore for InMemoryStore {
-    fn max_state_version(&self) -> u64 {
+    fn max_state_version(&self) -> StateVersion {
         self.transactions
             .iter()
             .next_back()
             .map(|(k, _v)| *k)
-            .unwrap_or_default()
+            .unwrap_or_else(StateVersion::pre_genesis)
     }
 
     /// In memory implementation doesn't need to respect the limits
     fn get_txns_and_proof(
         &self,
-        start_state_version_inclusive: u64,
+        start_state_version_inclusive: StateVersion,
         _max_number_of_txns_if_more_than_one_proof: u32,
         _max_payload_size_in_bytes: u32,
     ) -> Option<(Vec<RawLedgerTransaction>, LedgerProof)> {
@@ -484,7 +493,7 @@ impl QueryableProofStore for InMemoryStore {
 impl InMemoryStore {
     fn update_account_change_index_from_receipt(
         &mut self,
-        state_version: u64,
+        state_version: StateVersion,
         receipt: &LocalTransactionExecution,
     ) {
         for (address, _) in receipt.state_update_summary.balance_changes.iter() {
@@ -501,7 +510,7 @@ impl InMemoryStore {
 }
 
 impl AccountChangeIndexExtension for InMemoryStore {
-    fn account_change_index_last_processed_state_version(&self) -> u64 {
+    fn account_change_index_last_processed_state_version(&self) -> StateVersion {
         self.account_change_index_last_state_version
     }
 
@@ -509,7 +518,10 @@ impl AccountChangeIndexExtension for InMemoryStore {
         let last_state_version = self.max_state_version();
         let last_processed_state_version = self.account_change_index_last_processed_state_version();
 
-        for state_version in last_processed_state_version + 1..last_state_version + 1 {
+        for state_version in last_processed_state_version
+            .next()
+            .to(last_state_version.next())
+        {
             self.update_account_change_index_from_receipt(
                 state_version,
                 &self
@@ -526,8 +538,8 @@ impl IterableAccountChangeIndex for InMemoryStore {
     fn get_state_versions_for_account_iter(
         &self,
         account: GlobalAddress,
-        from_state_version: u64,
-    ) -> Box<dyn Iterator<Item = u64> + '_> {
+        from_state_version: StateVersion,
+    ) -> Box<dyn Iterator<Item = StateVersion> + '_> {
         let Some(index) = self.account_change_index_set.get(&account) else { return Box::new(vec![].into_iter()); };
         return Box::new(
             index

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -64,12 +64,12 @@
 
 use std::collections::HashSet;
 use std::fmt;
-use std::mem::size_of;
 
 use crate::store::traits::*;
 use crate::{
     CommittedTransactionIdentifiers, LedgerProof, LedgerTransactionReceipt,
-    LocalTransactionExecution, LocalTransactionReceipt, ReceiptTreeHash, TransactionTreeHash,
+    LocalTransactionExecution, LocalTransactionReceipt, ReceiptTreeHash, StateVersion,
+    TransactionTreeHash,
 };
 use node_common::utils::IsAccountExt;
 use radix_engine::types::*;
@@ -275,20 +275,20 @@ impl RocksDBStore {
                 panic!(
                     "Attempted to save intent hash {:?} which already exists at state version {:?}",
                     intent_hash,
-                    u64::from_be_bytes(existing_state_version.try_into().unwrap())
+                    StateVersion::from_bytes(existing_state_version)
                 );
             }
 
             batch.put_cf(
                 self.cf_handle(&StateVersionByTxnIntentHash),
                 intent_hash,
-                state_version.to_be_bytes(),
+                state_version.to_bytes(),
             );
 
             batch.put_cf(
                 self.cf_handle(&StateVersionByTxnUserPayloadHash),
                 notarized_transaction_hash,
-                state_version.to_be_bytes(),
+                state_version.to_bytes(),
             );
         } else {
             let maybe_existing_state_version = self
@@ -303,7 +303,7 @@ impl RocksDBStore {
                 panic!(
                     "Attempted to save ledger payload hash {:?} which already exists at state version {:?}",
                     ledger_payload_hash,
-                    u64::from_be_bytes(existing_state_version.try_into().unwrap())
+                    StateVersion::from_bytes(existing_state_version)
                 );
             }
         }
@@ -311,31 +311,31 @@ impl RocksDBStore {
         batch.put_cf(
             self.cf_handle(&StateVersionByTxnLedgerPayloadHash),
             ledger_payload_hash,
-            state_version.to_be_bytes(),
+            state_version.to_bytes(),
         );
 
         batch.put_cf(
             self.cf_handle(&TxnByStateVersion),
-            state_version.to_be_bytes(),
+            state_version.to_bytes(),
             &raw.0,
         );
 
         batch.put_cf(
             self.cf_handle(&TxnIdentifiersByStateVersion),
-            state_version.to_be_bytes(),
+            state_version.to_bytes(),
             scrypto_encode(&identifiers).unwrap(),
         );
 
         batch.put_cf(
             self.cf_handle(&LedgerReceiptByStateVersion),
-            state_version.to_be_bytes(),
+            state_version.to_bytes(),
             scrypto_encode(&receipt.on_ledger).unwrap(),
         );
 
         if self.is_local_transaction_execution_index_enabled() {
             batch.put_cf(
                 self.cf_handle(&LocalTransactionExecutionByStateVersion),
-                state_version.to_be_bytes(),
+                state_version.to_bytes(),
                 scrypto_encode(&receipt.local_execution).unwrap(),
             );
         }
@@ -410,12 +410,12 @@ impl ConfigurableDatabase for RocksDBStore {
             .expect("DB error writing database config");
     }
 
-    fn is_local_transaction_execution_index_enabled(&self) -> bool {
-        self.config.enable_local_transaction_execution_index
-    }
-
     fn is_account_change_index_enabled(&self) -> bool {
         self.config.enable_account_change_index
+    }
+
+    fn is_local_transaction_execution_index_enabled(&self) -> bool {
+        self.config.enable_local_transaction_execution_index
     }
 }
 
@@ -455,7 +455,7 @@ impl CommitStore for RocksDBStore {
         let encoded_proof = scrypto_encode(&commit_bundle.proof).unwrap();
         batch.put_cf(
             self.cf_handle(&LedgerProofByStateVersion),
-            commit_state_version.to_be_bytes(),
+            commit_state_version.to_bytes(),
             &encoded_proof,
         );
 
@@ -504,19 +504,19 @@ impl CommitStore for RocksDBStore {
             let encoded_node_keys = stale_node_keys.1.iter().map(encode_key).collect::<Vec<_>>();
             batch.put_cf(
                 self.cf_handle(&StaleStateHashTreeNodeKeysByStateVersion),
-                stale_node_keys.0.to_be_bytes(),
+                stale_node_keys.0.to_bytes(),
                 scrypto_encode(&encoded_node_keys).unwrap(),
             )
         }
 
         batch.put_cf(
             self.cf_handle(&TransactionAccuTreeSliceByStateVersion),
-            commit_state_version.to_be_bytes(),
+            commit_state_version.to_bytes(),
             scrypto_encode(&commit_bundle.transaction_tree_slice).unwrap(),
         );
         batch.put_cf(
             self.cf_handle(&ReceiptAccuTreeSliceByStateVersion),
-            commit_state_version.to_be_bytes(),
+            commit_state_version.to_bytes(),
             scrypto_encode(&commit_bundle.receipt_tree_slice).unwrap(),
         );
 
@@ -525,7 +525,7 @@ impl CommitStore for RocksDBStore {
 }
 
 pub struct RocksDBCommittedTransactionBundleIterator<'a> {
-    state_version: u64,
+    state_version: StateVersion,
     txns_iter: DBIteratorWithThreadMode<'a, DB>,
     ledger_receipts_iter: DBIteratorWithThreadMode<'a, DB>,
     local_executions_iter: DBIteratorWithThreadMode<'a, DB>,
@@ -533,8 +533,8 @@ pub struct RocksDBCommittedTransactionBundleIterator<'a> {
 }
 
 impl<'a> RocksDBCommittedTransactionBundleIterator<'a> {
-    fn new(from_state_version: u64, store: &'a RocksDBStore) -> Self {
-        let start_state_version_bytes = from_state_version.to_be_bytes();
+    fn new(from_state_version: StateVersion, store: &'a RocksDBStore) -> Self {
+        let start_state_version_bytes = from_state_version.to_bytes();
         Self {
             state_version: from_state_version,
             txns_iter: store.db.iterator_cf(
@@ -589,8 +589,7 @@ impl Iterator for RocksDBCommittedTransactionBundleIterator<'_> {
                     ("local execution version", local_execution_kv.0),
                     ("identifiers version", identifiers_kv.0),
                 ] {
-                    let other_row_version =
-                        u64::from_be_bytes((*other_key_bytes).try_into().unwrap());
+                    let other_row_version = StateVersion::from_bytes(other_key_bytes);
                     if other_row_version != current_state_version {
                         panic!("DB inconsistency! {other_key_description} ({other_row_version}) doesn't match expected state version ({current_state_version})");
                     }
@@ -605,7 +604,7 @@ impl Iterator for RocksDBCommittedTransactionBundleIterator<'_> {
                 };
                 let identifiers = scrypto_decode(identifiers_kv.1.as_ref()).unwrap();
 
-                self.state_version += 1;
+                self.state_version = self.state_version.next();
 
                 Some(CommittedTransactionBundle {
                     state_version: current_state_version,
@@ -621,7 +620,7 @@ impl Iterator for RocksDBCommittedTransactionBundleIterator<'_> {
 impl IterableTransactionStore for RocksDBStore {
     fn get_committed_transaction_bundle_iter(
         &self,
-        from_state_version: u64,
+        from_state_version: StateVersion,
     ) -> Box<dyn Iterator<Item = CommittedTransactionBundle> + '_> {
         // This should not happen. This interface should be used after checking (e.g. `core-api-server/src/core-api/handlers/`).
         // However, with or without this debug_assert there would still be a panic if LocalTransactionExecution is missing.
@@ -635,24 +634,24 @@ impl IterableTransactionStore for RocksDBStore {
 }
 
 impl QueryableTransactionStore for RocksDBStore {
-    fn get_committed_transaction(&self, state_version: u64) -> Option<RawLedgerTransaction> {
+    fn get_committed_transaction(
+        &self,
+        state_version: StateVersion,
+    ) -> Option<RawLedgerTransaction> {
         self.db
-            .get_cf(
-                self.cf_handle(&TxnByStateVersion),
-                state_version.to_be_bytes(),
-            )
+            .get_cf(self.cf_handle(&TxnByStateVersion), state_version.to_bytes())
             .expect("DB error loading transaction")
             .map(RawLedgerTransaction)
     }
 
     fn get_committed_transaction_identifiers(
         &self,
-        state_version: u64,
+        state_version: StateVersion,
     ) -> Option<CommittedTransactionIdentifiers> {
         self.db
             .get_cf(
                 self.cf_handle(&TxnIdentifiersByStateVersion),
-                state_version.to_be_bytes(),
+                state_version.to_bytes(),
             )
             .expect("DB error loading identifiers")
             .map(|v| scrypto_decode(&v).expect("Failed to decode identifiers"))
@@ -660,24 +659,24 @@ impl QueryableTransactionStore for RocksDBStore {
 
     fn get_committed_ledger_transaction_receipt(
         &self,
-        state_version: u64,
+        state_version: StateVersion,
     ) -> Option<LedgerTransactionReceipt> {
-        self.get_by_key(&LedgerReceiptByStateVersion, &state_version.to_be_bytes())
+        self.get_by_key(&LedgerReceiptByStateVersion, &state_version.to_bytes())
     }
 
     fn get_committed_local_transaction_execution(
         &self,
-        state_version: u64,
+        state_version: StateVersion,
     ) -> Option<LocalTransactionExecution> {
         self.get_by_key(
             &LocalTransactionExecutionByStateVersion,
-            &state_version.to_be_bytes(),
+            &state_version.to_bytes(),
         )
     }
 
     fn get_committed_local_transaction_receipt(
         &self,
-        state_version: u64,
+        state_version: StateVersion,
     ) -> Option<LocalTransactionReceipt> {
         let ledger_transaction_receipt =
             self.get_committed_ledger_transaction_receipt(state_version);
@@ -701,11 +700,11 @@ impl QueryableTransactionStore for RocksDBStore {
 }
 
 impl TransactionIndex<&IntentHash> for RocksDBStore {
-    fn get_txn_state_version_by_identifier(&self, identifier: &IntentHash) -> Option<u64> {
+    fn get_txn_state_version_by_identifier(&self, identifier: &IntentHash) -> Option<StateVersion> {
         self.db
             .get_cf(self.cf_handle(&StateVersionByTxnIntentHash), identifier)
             .expect("DB error reading state version for intent hash")
-            .map(|b| u64::from_be_bytes(b.try_into().unwrap()))
+            .map(StateVersion::from_bytes)
     }
 }
 
@@ -713,14 +712,14 @@ impl TransactionIndex<&NotarizedTransactionHash> for RocksDBStore {
     fn get_txn_state_version_by_identifier(
         &self,
         identifier: &NotarizedTransactionHash,
-    ) -> Option<u64> {
+    ) -> Option<StateVersion> {
         self.db
             .get_cf(
                 self.cf_handle(&StateVersionByTxnUserPayloadHash),
                 identifier,
             )
             .expect("DB error reading state version for user payload hash")
-            .map(|b| u64::from_be_bytes(b.try_into().unwrap()))
+            .map(StateVersion::from_bytes)
     }
 }
 
@@ -728,19 +727,21 @@ impl TransactionIndex<&LedgerTransactionHash> for RocksDBStore {
     fn get_txn_state_version_by_identifier(
         &self,
         identifier: &LedgerTransactionHash,
-    ) -> Option<u64> {
+    ) -> Option<StateVersion> {
         self.db
             .get_cf(
                 self.cf_handle(&StateVersionByTxnLedgerPayloadHash),
                 identifier,
             )
             .expect("DB error reading state version for ledger payload hash")
-            .map(|b| u64::from_be_bytes(b.try_into().unwrap()))
+            .map(StateVersion::from_bytes)
     }
 }
 
 impl TransactionIdentifierLoader for RocksDBStore {
-    fn get_top_transaction_identifiers(&self) -> Option<(u64, CommittedTransactionIdentifiers)> {
+    fn get_top_transaction_identifiers(
+        &self,
+    ) -> Option<(StateVersion, CommittedTransactionIdentifiers)> {
         self.db
             .iterator_cf(
                 self.cf_handle(&TxnIdentifiersByStateVersion),
@@ -750,7 +751,7 @@ impl TransactionIdentifierLoader for RocksDBStore {
             .next()
             .map(|(key, value)| {
                 (
-                    u64::from_be_bytes((*key).try_into().unwrap()),
+                    StateVersion::from_bytes(key),
                     scrypto_decode(&value).expect("Failed to decode identifiers"),
                 )
             })
@@ -758,18 +759,18 @@ impl TransactionIdentifierLoader for RocksDBStore {
 }
 
 impl QueryableProofStore for RocksDBStore {
-    fn max_state_version(&self) -> u64 {
+    fn max_state_version(&self) -> StateVersion {
         self.db
             .iterator_cf(self.cf_handle(&TxnByStateVersion), IteratorMode::End)
             .next()
             .map(|res| res.unwrap())
-            .map(|(key, _)| u64::from_be_bytes((*key).try_into().unwrap()))
-            .unwrap_or(0)
+            .map(|(key, _)| StateVersion::from_bytes(key))
+            .unwrap_or(StateVersion::pre_genesis())
     }
 
     fn get_txns_and_proof(
         &self,
-        start_state_version_inclusive: u64,
+        start_state_version_inclusive: StateVersion,
         max_number_of_txns_if_more_than_one_proof: u32,
         max_payload_size_in_bytes: u32,
     ) -> Option<(Vec<RawLedgerTransaction>, LedgerProof)> {
@@ -780,7 +781,7 @@ impl QueryableProofStore for RocksDBStore {
         let mut proofs_iter = self.db.iterator_cf(
             self.cf_handle(&LedgerProofByStateVersion),
             IteratorMode::From(
-                &start_state_version_inclusive.to_be_bytes(),
+                &start_state_version_inclusive.to_bytes(),
                 Direction::Forward,
             ),
         );
@@ -788,7 +789,7 @@ impl QueryableProofStore for RocksDBStore {
         let mut txns_iter = self.db.iterator_cf(
             self.cf_handle(&TxnByStateVersion),
             IteratorMode::From(
-                &start_state_version_inclusive.to_be_bytes(),
+                &start_state_version_inclusive.to_bytes(),
                 Direction::Forward,
             ),
         );
@@ -803,8 +804,7 @@ impl QueryableProofStore for RocksDBStore {
             match proofs_iter.next() {
                 Some(next_proof_result) => {
                     let next_proof_kv = next_proof_result.unwrap();
-                    let next_proof_state_version =
-                        u64::from_be_bytes((*next_proof_kv.0).try_into().unwrap());
+                    let next_proof_state_version = StateVersion::from_bytes(next_proof_kv.0);
                     let next_proof: LedgerProof = scrypto_decode(next_proof_kv.1.as_ref()).unwrap();
 
                     let mut payload_size_including_next_proof_txns = payload_size_so_far;
@@ -826,7 +826,7 @@ impl QueryableProofStore for RocksDBStore {
                             Some(next_txn_result) => {
                                 let next_txn_kv = next_txn_result.unwrap();
                                 let next_txn_state_version =
-                                    u64::from_be_bytes((*next_txn_kv.0).try_into().unwrap());
+                                    StateVersion::from_bytes(next_txn_kv.0);
                                 let next_txn_payload = next_txn_kv.1.to_vec();
 
                                 payload_size_including_next_proof_txns +=
@@ -880,6 +880,14 @@ impl QueryableProofStore for RocksDBStore {
         latest_usable_proof.map(|proof| (txns, proof))
     }
 
+    fn get_first_proof(&self) -> Option<LedgerProof> {
+        self.get_first(&LedgerProofByStateVersion)
+    }
+
+    fn get_first_epoch_proof(&self) -> Option<LedgerProof> {
+        self.get_first(&LedgerProofByEpoch)
+    }
+
     fn get_epoch_proof(&self, epoch: Epoch) -> Option<LedgerProof> {
         self.db
             .get_cf(
@@ -888,14 +896,6 @@ impl QueryableProofStore for RocksDBStore {
             )
             .unwrap()
             .map(|bytes| scrypto_decode(bytes.as_ref()).unwrap())
-    }
-
-    fn get_first_proof(&self) -> Option<LedgerProof> {
-        self.get_first(&LedgerProofByStateVersion)
-    }
-
-    fn get_first_epoch_proof(&self) -> Option<LedgerProof> {
-        self.get_first(&LedgerProofByEpoch)
     }
 
     fn get_last_proof(&self) -> Option<LedgerProof> {
@@ -949,20 +949,23 @@ impl<P: Payload> ReadableTreeStore<P> for RocksDBStore {
     }
 }
 
-impl ReadableAccuTreeStore<u64, TransactionTreeHash> for RocksDBStore {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<TransactionTreeHash>> {
+impl ReadableAccuTreeStore<StateVersion, TransactionTreeHash> for RocksDBStore {
+    fn get_tree_slice(
+        &self,
+        state_version: &StateVersion,
+    ) -> Option<TreeSlice<TransactionTreeHash>> {
         self.get_by_key(
             &TransactionAccuTreeSliceByStateVersion,
-            &state_version.to_be_bytes(),
+            &state_version.to_bytes(),
         )
     }
 }
 
-impl ReadableAccuTreeStore<u64, ReceiptTreeHash> for RocksDBStore {
-    fn get_tree_slice(&self, state_version: &u64) -> Option<TreeSlice<ReceiptTreeHash>> {
+impl ReadableAccuTreeStore<StateVersion, ReceiptTreeHash> for RocksDBStore {
+    fn get_tree_slice(&self, state_version: &StateVersion) -> Option<TreeSlice<ReceiptTreeHash>> {
         self.get_by_key(
             &ReceiptAccuTreeSliceByStateVersion,
-            &state_version.to_be_bytes(),
+            &state_version.to_bytes(),
         )
     }
 }
@@ -1004,7 +1007,7 @@ impl RocksDBStore {
     fn batch_update_account_change_index_from_receipt(
         &self,
         batch: &mut WriteBatch,
-        state_version: u64,
+        state_version: StateVersion,
         receipt: &LocalTransactionReceipt,
     ) {
         for (address, _) in receipt
@@ -1017,7 +1020,7 @@ impl RocksDBStore {
                 continue;
             }
             let mut key = address.to_vec();
-            key.extend(state_version.to_be_bytes());
+            key.extend(state_version.to_bytes());
             batch.put_cf(self.cf_handle(&AccountChangeStateVersions), key, []);
         }
     }
@@ -1025,7 +1028,7 @@ impl RocksDBStore {
     fn batch_update_account_change_index_from_committed_transaction(
         &self,
         batch: &mut WriteBatch,
-        state_version: u64,
+        state_version: StateVersion,
         transaction_bundle: &CommittedTransactionBundle,
     ) {
         self.batch_update_account_change_index_from_receipt(
@@ -1039,16 +1042,16 @@ impl RocksDBStore {
             ExtensionsDataKeys::AccountChangeIndexLastProcessedStateVersion
                 .to_string()
                 .as_bytes(),
-            state_version.to_be_bytes(),
+            state_version.to_bytes(),
         );
     }
 
     fn update_account_change_index_from_store(
         &mut self,
-        start_state_version_inclusive: u64,
+        start_state_version_inclusive: StateVersion,
         limit: u64,
-    ) -> u64 {
-        let start_state_version_bytes = start_state_version_inclusive.to_be_bytes();
+    ) -> StateVersion {
+        let start_state_version_bytes = start_state_version_inclusive.to_bytes();
         let mut receipts_iter = self.db.iterator_cf(
             self.cf_handle(&LocalTransactionExecutionByStateVersion),
             IteratorMode::From(&start_state_version_bytes, Direction::Forward),
@@ -1062,11 +1065,9 @@ impl RocksDBStore {
             match receipts_iter.next() {
                 Some(next_receipt_result) => {
                     let next_receipt_kv = next_receipt_result.unwrap();
+                    let next_receipt_state_version = StateVersion::from_bytes(next_receipt_kv.0);
 
-                    let next_receipt_state_version =
-                        u64::from_be_bytes((*next_receipt_kv.0).try_into().unwrap());
-
-                    let expected_state_version = start_state_version_inclusive + index;
+                    let expected_state_version = start_state_version_inclusive.relative(index);
                     if expected_state_version != next_receipt_state_version {
                         panic!(
                             "DB inconsistency! Missing receipt at state version {expected_state_version}"
@@ -1095,7 +1096,7 @@ impl RocksDBStore {
             ExtensionsDataKeys::AccountChangeIndexLastProcessedStateVersion
                 .to_string()
                 .as_bytes(),
-            last_state_version.to_be_bytes(),
+            last_state_version.to_bytes(),
         );
 
         self.db
@@ -1107,7 +1108,7 @@ impl RocksDBStore {
 }
 
 impl AccountChangeIndexExtension for RocksDBStore {
-    fn account_change_index_last_processed_state_version(&self) -> u64 {
+    fn account_change_index_last_processed_state_version(&self) -> StateVersion {
         self.db
             .get_pinned_cf(
                 self.cf_handle(&ExtensionsData),
@@ -1116,8 +1117,8 @@ impl AccountChangeIndexExtension for RocksDBStore {
                     .as_bytes(),
             )
             .unwrap()
-            .map(|pinnable_slice| u64::from_be_bytes(pinnable_slice.as_ref().try_into().unwrap()))
-            .unwrap_or(0)
+            .map(StateVersion::from_bytes)
+            .unwrap_or(StateVersion::pre_genesis())
     }
 
     fn catchup_account_change_index(&mut self) {
@@ -1137,7 +1138,7 @@ impl AccountChangeIndexExtension for RocksDBStore {
 
         while last_processed_state_version < last_state_version {
             last_processed_state_version = self.update_account_change_index_from_store(
-                last_processed_state_version + 1,
+                last_processed_state_version.next(),
                 MAX_TRANSACTION_BATCH,
             );
             info!("Account Change Index updated to {last_processed_state_version}/{last_state_version}");
@@ -1153,9 +1154,13 @@ pub struct RocksDBAccountChangeIndexIterator<'a> {
 }
 
 impl<'a> RocksDBAccountChangeIndexIterator<'a> {
-    fn new(from_state_version: u64, account: GlobalAddress, store: &'a RocksDBStore) -> Self {
+    fn new(
+        from_state_version: StateVersion,
+        account: GlobalAddress,
+        store: &'a RocksDBStore,
+    ) -> Self {
         let mut key = account.to_vec();
-        key.extend(from_state_version.to_be_bytes());
+        key.extend(from_state_version.to_bytes());
         Self {
             account_bytes: account.to_vec(),
             account_change_iter: store.db.iterator_cf(
@@ -1167,15 +1172,15 @@ impl<'a> RocksDBAccountChangeIndexIterator<'a> {
 }
 
 impl Iterator for RocksDBAccountChangeIndexIterator<'_> {
-    type Item = u64;
+    type Item = StateVersion;
 
-    fn next(&mut self) -> Option<u64> {
+    fn next(&mut self) -> Option<StateVersion> {
         match self.account_change_iter.next() {
             Some(entry) => {
                 let (key, _value) = entry.unwrap();
                 let (address_bytes, state_version_bytes) =
-                    key.split_at(key.len() - size_of::<u64>());
-                let state_version = u64::from_be_bytes(state_version_bytes.try_into().unwrap());
+                    key.split_at(key.len() - StateVersion::BYTE_LEN);
+                let state_version = StateVersion::from_bytes(state_version_bytes);
                 if address_bytes != self.account_bytes {
                     None
                 } else {
@@ -1191,8 +1196,8 @@ impl IterableAccountChangeIndex for RocksDBStore {
     fn get_state_versions_for_account_iter(
         &self,
         account: GlobalAddress,
-        from_state_version: u64,
-    ) -> Box<dyn Iterator<Item = u64> + '_> {
+        from_state_version: StateVersion,
+    ) -> Box<dyn Iterator<Item = StateVersion> + '_> {
         Box::new(RocksDBAccountChangeIndexIterator::new(
             from_state_version,
             account,
@@ -1226,7 +1231,10 @@ mod tests {
 
         assert!(encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![0])) < iterator_start);
         assert!(encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![0, 3])) < iterator_start);
-        assert!(encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![0, 4])) == iterator_start);
+        assert_eq!(
+            encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![0, 4])),
+            iterator_start
+        );
         assert!(iterator_start < encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![0, 5])));
         assert!(
             iterator_start < encode_to_rocksdb_bytes(&partition_key, &DbSortKey(vec![0, 5, 7]))


### PR DESCRIPTION
This introduces type-safety and checked math operations.

I also propagated the usage of Engine's `Epoch` a bit into our code, as a drive-by.