### PR TITLE
Refactor: Unifying the "series executor" usage + Moving it to separate module

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/StateManagerSbor.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/StateManagerSbor.java
@@ -152,6 +152,7 @@ public final class StateManagerSbor {
     LedgerHeader.registerCodec(codecMap);
     TimestampedValidatorSignature.registerCodec(codecMap);
     PrepareRequest.registerCodec(codecMap);
+    RoundHistory.registerCodec(codecMap);
     PrepareResult.registerCodec(codecMap);
     CommittableTransaction.registerCodec(codecMap);
     RejectedTransaction.registerCodec(codecMap);

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/PrepareRequest.java
@@ -64,12 +64,10 @@
 
 package com.radixdlt.statecomputer.commit;
 
-import com.radixdlt.rev2.ComponentAddress;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.transactions.RawLedgerTransaction;
 import com.radixdlt.transactions.RawNotarizedTransaction;
-import com.radixdlt.utils.UInt64;
 import java.util.List;
 
 public record PrepareRequest(
@@ -77,12 +75,7 @@ public record PrepareRequest(
     List<RawLedgerTransaction> ancestorTransactions,
     LedgerHashes ancestorLedgerHashes,
     List<RawNotarizedTransaction> proposedTransactions,
-    boolean isFallback,
-    UInt64 epoch,
-    UInt64 roundNumber,
-    List<ComponentAddress> gapRoundLeaderAddresses,
-    ComponentAddress proposerAddress,
-    long proposerTimestampMs) {
+    RoundHistory roundHistory) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         PrepareRequest.class,

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/RoundHistory.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/RoundHistory.java
@@ -62,16 +62,23 @@
  * permissions under this License.
  */
 
-mod executable_logic;
-mod ledger_transaction;
-mod preview;
-mod round_update_transaction;
-mod series_execution;
-mod validation;
+package com.radixdlt.statecomputer.commit;
 
-pub use executable_logic::*;
-pub use ledger_transaction::*;
-pub use preview::*;
-pub use round_update_transaction::*;
-pub use series_execution::*;
-pub use validation::*;
+import com.radixdlt.rev2.ComponentAddress;
+import com.radixdlt.sbor.codec.CodecMap;
+import com.radixdlt.sbor.codec.StructCodec;
+import com.radixdlt.utils.UInt64;
+import java.util.List;
+
+public record RoundHistory(
+    boolean isFallback,
+    UInt64 epoch,
+    UInt64 roundNumber,
+    List<ComponentAddress> gapRoundLeaderAddresses,
+    ComponentAddress proposerAddress,
+    long proposerTimestampMs) {
+  public static void registerCodec(CodecMap codecMap) {
+    codecMap.register(
+        RoundHistory.class, codecs -> StructCodec.fromRecordComponents(RoundHistory.class, codecs));
+  }
+}

--- a/core-rust/state-manager/src/transaction/series_execution.rs
+++ b/core-rust/state-manager/src/transaction/series_execution.rs
@@ -1,0 +1,297 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+use std::fmt::Formatter;
+use std::time::Duration;
+
+use crate::query::*;
+use crate::staging::{ExecutionCache, ReadableStore};
+use crate::store::traits::*;
+use crate::transaction::*;
+use crate::*;
+
+use ::transaction::model::IntentHash;
+use ::transaction::prelude::*;
+use parking_lot::Mutex;
+use radix_engine::transaction::RejectResult;
+use utils::rust::collections::NonIterMap;
+
+const TRANSACTION_RUNTIME_WARN_THRESHOLD: Duration = Duration::from_millis(500);
+
+/// An internal delegate for executing a series of consecutive transactions while tracking their
+/// progress.
+pub struct TransactionSeriesExecutor<'s, S> {
+    store: &'s S,
+    execution_cache: &'s Mutex<ExecutionCache>,
+    execution_configurator: &'s ExecutionConfigurator,
+    epoch_identifiers: EpochTransactionIdentifiers,
+    epoch_header: Option<LedgerHeader>,
+    state_tracker: StateTracker,
+}
+
+impl<'s, S> TransactionSeriesExecutor<'s, S>
+where
+    S: ReadableStore + QueryableProofStore + TransactionIdentifierLoader,
+{
+    /// Creates a new executor for a lifetime of entire transaction batch execution (i.e. for all
+    /// transactions in a prepared vertex, or in a commit request).
+    /// The borrowed `store` should be already locked (i.e. final database writes, if any, should be
+    /// performed under the same lock).
+    /// The locking of the borrowed `execution_cache` will be handled by this executor.
+    pub fn new(
+        store: &'s S,
+        execution_cache: &'s Mutex<ExecutionCache>,
+        execution_configurator: &'s ExecutionConfigurator,
+    ) -> Self {
+        let epoch_header = store
+            .get_last_epoch_proof()
+            .map(|epoch_proof| epoch_proof.ledger_header);
+        Self {
+            store,
+            execution_cache,
+            execution_configurator,
+            epoch_identifiers: epoch_header
+                .as_ref()
+                .map(EpochTransactionIdentifiers::from)
+                .unwrap_or_else(EpochTransactionIdentifiers::pre_genesis),
+            epoch_header,
+            state_tracker: StateTracker::new(store.get_top_ledger_hashes()),
+        }
+    }
+
+    /// Executes the given already-validated ledger transaction (against the borrowed `store` and
+    /// `execution_cache`).
+    /// Uses an internal [`StateTracker`] to track the progression of *committable* transactions.
+    /// The passed description will only be used for logging/errors/panics (and will be augmented by
+    /// the transaction's ledger hash).
+    pub fn execute(
+        &mut self,
+        config_type: ConfigType,
+        transaction: &ValidatedLedgerTransaction,
+        description: impl Display,
+    ) -> Result<ProcessedCommitResult, RejectResult> {
+        let description = DescribedTransactionHash {
+            ledger_hash: transaction.ledger_transaction_hash(),
+            description,
+        };
+        let mut execution_cache = self.execution_cache.lock();
+        let processed = execution_cache.execute_transaction(
+            self.store,
+            self.epoch_identifiers(),
+            self.state_tracker.state_version,
+            &self.state_tracker.ledger_hashes.transaction_root,
+            &transaction.ledger_transaction_hash(),
+            self.execution_configurator
+                .wrap(transaction.get_executable(), config_type)
+                .warn_after(TRANSACTION_RUNTIME_WARN_THRESHOLD, &description),
+        );
+        let result = processed.expect_commit_or_reject(&description).cloned();
+        if let Ok(commit) = &result {
+            self.state_tracker.update(commit);
+        }
+        result
+    }
+
+    /// Returns a ledger header which started the current epoch (i.e. in which the transactions are
+    /// being executed), or [`None`] if the ledger state is pre-genesis.
+    pub fn epoch_header(&self) -> Option<&LedgerHeader> {
+        self.epoch_header.as_ref()
+    }
+
+    /// Returns transaction identifiers at the beginning of the current epoch (i.e. in which the
+    /// transactions are being executed), or [`EpochTransactionIdentifiers::pre_genesis`].
+    pub fn epoch_identifiers(&self) -> &EpochTransactionIdentifiers {
+        &self.epoch_identifiers
+    }
+
+    /// Returns the ledger hashes resulting from the most recent `execute()` call.
+    pub fn latest_ledger_hashes(&self) -> &LedgerHashes {
+        &self.state_tracker.ledger_hashes
+    }
+
+    /// Returns the state version after the most recent `execute()` call.
+    pub fn latest_state_version(&self) -> StateVersion {
+        self.state_tracker.state_version
+    }
+
+    /// Returns the epoch change indication resulting from the most recent `execute()` call, or
+    /// [`None`] if that call did not change the epoch.
+    /// Please note that it is illegal (and enforced by this executor) to execute transactions after
+    /// the epoch change.
+    pub fn next_epoch(&self) -> Option<&NextEpoch> {
+        self.state_tracker.next_epoch.as_ref()
+    }
+}
+
+/// A source of intent hash duplication.
+#[derive(Debug, Clone)]
+pub enum IntentHashDuplicateWith {
+    /// Some other newly-proposed transaction has the same intent hash.
+    Proposed,
+    /// Some ancestor transaction (i.e. already-prepared-but-not-yet-committed one) has the same
+    /// intent hash.
+    Ancestor,
+    /// Some committed transaction (i.e. already persisted on ledger) has the same intent hash.
+    Committed,
+}
+
+/// An internal implementation delegate dealing with intent hash duplicates.
+// TODO: Remove after this responsibility is implemented by the Engine.
+pub struct DuplicateIntentHashDetector<'s, S> {
+    store: &'s S,
+    recorded_intent_hashes: NonIterMap<IntentHash, IntentHashDuplicateWith>,
+}
+
+impl<'s, S: for<'a> TransactionIndex<&'a IntentHash>> DuplicateIntentHashDetector<'s, S> {
+    pub fn new(store: &'s S) -> Self {
+        Self {
+            store,
+            recorded_intent_hashes: NonIterMap::new(),
+        }
+    }
+
+    /// Records an intent hash of an ancestor (i.e. one of already-prepared-but-not-yet-committed)
+    /// transaction.
+    /// Please note that duplicates are not possible for ancestor transactions (since they were all
+    /// checked against this during previous prepare operations), and hence the `check_ancestor()`
+    /// method does not exist.
+    pub fn record_ancestor(&mut self, intent_hash: IntentHash) {
+        self.recorded_intent_hashes
+            .insert(intent_hash, IntentHashDuplicateWith::Ancestor);
+    }
+
+    /// Checks whether the given intent hash of a newly-proposed transaction clashes with any other
+    /// transaction (i.e. an already committed one, or an ancestor, or another proposed one).
+    pub fn check_proposed(
+        &mut self,
+        intent_hash: &IntentHash,
+    ) -> Result<(), IntentHashDuplicateWith> {
+        if let Some(duplicate_with) = self.recorded_intent_hashes.get(intent_hash) {
+            return Err(duplicate_with.clone());
+        }
+        let committed_at_version = self.store.get_txn_state_version_by_identifier(intent_hash);
+        if committed_at_version.is_some() {
+            // we insert this to our map only as an optimization (avoid repeating the same DB read)
+            self.recorded_intent_hashes
+                .insert(*intent_hash, IntentHashDuplicateWith::Committed);
+            return Err(IntentHashDuplicateWith::Committed);
+        }
+        Ok(())
+    }
+
+    /// Records an intent hash of a proposed transaction which is expected to be committed.
+    /// From this point on, it will be taken into account by the `check_proposed()` method.
+    pub fn record_committable_proposed(&mut self, intent_hash: IntentHash) {
+        self.recorded_intent_hashes
+            .insert(intent_hash, IntentHashDuplicateWith::Proposed);
+    }
+}
+
+/// A simple `Display` augmenting the human-readable transaction description with its ledger hash.
+struct DescribedTransactionHash<D> {
+    ledger_hash: LedgerTransactionHash,
+    description: D,
+}
+
+impl<D: Display> Display for DescribedTransactionHash<D> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (ledger hash {})", self.description, self.ledger_hash)
+    }
+}
+
+/// A low-level tracker of consecutive state version / ledger hashes / epoch changes.
+struct StateTracker {
+    state_version: StateVersion,
+    ledger_hashes: LedgerHashes,
+    next_epoch: Option<NextEpoch>,
+}
+
+impl StateTracker {
+    /// Initializes the tracker to a known state (assuming it is not an end-state of an epoch).
+    pub fn new(ledger_hashes_entry: (StateVersion, LedgerHashes)) -> Self {
+        Self {
+            state_version: ledger_hashes_entry.0,
+            ledger_hashes: ledger_hashes_entry.1,
+            next_epoch: None,
+        }
+    }
+
+    /// Bumps the state version and records the next ledger hashes (from the given transaction
+    /// results).
+    /// This method validates that no further transaction should happen after an epoch change.
+    pub fn update(&mut self, result: &ProcessedCommitResult) {
+        if let Some(next_epoch) = &self.next_epoch {
+            panic!(
+                "the {:?} has happened at {:?} (version {}) and must not be followed by {:?}",
+                next_epoch,
+                self.ledger_hashes,
+                self.state_version,
+                result.hash_structures_diff.ledger_hashes
+            );
+        }
+        self.state_version = self.state_version.next();
+        self.ledger_hashes = result.hash_structures_diff.ledger_hashes;
+        self.next_epoch = result.next_epoch();
+    }
+}

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -274,6 +274,11 @@ pub struct PrepareRequest {
     pub ancestor_transactions: Vec<RawLedgerTransaction>,
     pub ancestor_ledger_hashes: LedgerHashes,
     pub proposed_transactions: Vec<RawNotarizedTransaction>,
+    pub round_history: RoundHistory,
+}
+
+#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+pub struct RoundHistory {
     pub is_fallback: bool,
     pub epoch: Epoch,
     pub round: Round,

--- a/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
+++ b/core/src/main/java/com/radixdlt/rev2/REv2StateComputer.java
@@ -88,6 +88,7 @@ import com.radixdlt.serialization.Serialization;
 import com.radixdlt.statecomputer.RustStateComputer;
 import com.radixdlt.statecomputer.commit.CommitRequest;
 import com.radixdlt.statecomputer.commit.PrepareRequest;
+import com.radixdlt.statecomputer.commit.RoundHistory;
 import com.radixdlt.transactions.PreparedNotarizedTransaction;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt64;
@@ -254,12 +255,13 @@ public final class REv2StateComputer implements StateComputerLedger.StateCompute
             ancestorTransactions,
             REv2ToConsensus.ledgerHashes(preparedUncommittedLedgerHashes),
             proposedTransactions,
-            roundDetails.isFallback(),
-            UInt64.fromNonNegativeLong(roundDetails.epoch()),
-            UInt64.fromNonNegativeLong(roundDetails.roundNumber()),
-            gapRoundLeaderAddresses,
-            roundDetails.roundProposer().getActiveValidatorAddress(),
-            roundDetails.proposerTimestampMs());
+            new RoundHistory(
+                roundDetails.isFallback(),
+                UInt64.fromNonNegativeLong(roundDetails.epoch()),
+                UInt64.fromNonNegativeLong(roundDetails.roundNumber()),
+                gapRoundLeaderAddresses,
+                roundDetails.roundProposer().getActiveValidatorAddress(),
+                roundDetails.proposerTimestampMs()));
 
     var result = stateComputer.prepare(prepareRequest);
     var committableTransactions =


### PR DESCRIPTION
I also move out some other internal helpers of state manager, so that we can keep that file <1000 lines :p