### PR TITLE
tests: Add test for Olympia RRI conversion

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -230,6 +230,7 @@ dependencies {
     implementation 'com.stijndewitt.undertow.cors:undertow-cors-filter'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 
+    testImplementation project(path: ':common')
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testImplementation 'org.awaitility:awaitility'
     testImplementation 'org.mockito:mockito-core'

--- a/core/src/test/java/com/radixdlt/genesis/olympia/converter/resource/OlympiaNonXrdConverterTest.java
+++ b/core/src/test/java/com/radixdlt/genesis/olympia/converter/resource/OlympiaNonXrdConverterTest.java
@@ -1,0 +1,96 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+package com.radixdlt.genesis.olympia.converter.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.radixdlt.networks.Network;
+import com.radixdlt.rev2.NetworkDefinition;
+import com.radixdlt.serialization.TestSetupUtils;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OlympiaNonXrdConverterTest {
+
+  @BeforeClass
+  public static void setupBouncyCastle() {
+    TestSetupUtils.installBouncyCastleProvider();
+  }
+
+  @Test
+  public void olympiaToBabylonResourceAddress() {
+    final var input = "floop_rr1q0p0hzap6ckxqdk6khesyft62w34e0vdd06msn9snhfqknl370";
+    final var inputAddress = OlympiaNonXrdConverter.olympiaRriToReAddr(input);
+    assertThat(Hex.toHexString(inputAddress.getBytes()))
+        .isEqualTo("03c2fb8ba1d62c6036dab5f302257a53a35cbd8d6bf5b84cb09dd2");
+    final var outputAddress = OlympiaNonXrdConverter.olympiaToBabylonResourceAddress(inputAddress);
+    final var outputString = outputAddress.encode(NetworkDefinition.from(Network.MAINNET));
+    assertThat(outputAddress.toHexString())
+        .isEqualTo("5daf0c933573efb4aba9a666ee0ec6e54ca28ade8931620af36b0e66d8eb");
+    assertThat(outputString)
+        .isEqualTo("resource_rdx1tkhseye4w0hmf2af5enwurkxu4x29zk73yckyzhndv8xdk8tp2tn8q");
+  }
+}


### PR DESCRIPTION
For the 30 byte addresses on mainnet, we have:
```
Olympia String: floop_rr1q0p0hzap6ckxqdk6khesyft62w34e0vdd06msn9snhfqknl370
Olympia ReAddr bytes: 03c2fb8ba1d62c6036dab5f302257a53a35cbd8d6bf5b84cb09dd2
Babylon Address bytes: 5daf0c933573efb4aba9a666ee0ec6e54ca28ade8931620af36b0e66d8eb
Babylon string: resource_rdx1tkhseye4w0hmf2af5enwurkxu4x29zk73yckyzhndv8xdk8tp2tn8q
```

Note - XRD will get special cased