### PR TITLE
Splitting the simplified "commit genesis" logic out of the "regular commit"

### DIFF
--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -177,9 +177,7 @@ extern "system" fn Java_com_radixdlt_statecomputer_RustStateComputer_commit(
         request_payload,
         |commit_request: CommitRequest| -> Result<(), InvalidCommitRequestError> {
             let state_manager = JNIStateManager::get_state_manager(&env, j_state_manager);
-            state_manager
-                .commit(commit_request, false)
-                .map(|_unused| ())
+            state_manager.commit(commit_request)
         },
     )
 }

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -297,10 +297,10 @@ impl MempoolManager {
     /// Removes all the transactions that have the given intent hashes.
     /// This method is meant to be called for transactions that were successfully committed - and
     /// this assumption is important for metric correctness.
-    pub fn remove_committed(&self, intent_hashes: &[IntentHash]) {
+    pub fn remove_committed<'a>(&self, intent_hashes: impl IntoIterator<Item = &'a IntentHash>) {
         let mut write_mempool = self.mempool.write();
         let removed = intent_hashes
-            .iter()
+            .into_iter()
             .flat_map(|intent_hash| write_mempool.remove_transactions(intent_hash))
             .collect::<Vec<_>>();
         drop(write_mempool);

--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -427,12 +427,11 @@ impl Accumulator<ProcessedTransactionReceipt> for ImmutableStore {
 
     fn accumulate(&mut self, processed: &ProcessedTransactionReceipt) {
         if let ProcessedTransactionReceipt::Commit(commit) = processed {
-            let database_updates = commit.database_updates.clone();
-            for (db_partition_key, partition_updates) in database_updates {
+            for (db_partition_key, partition_updates) in &commit.database_updates {
                 for (db_sort_key, database_update) in partition_updates {
-                    let db_substate_key = (db_partition_key.clone(), db_sort_key);
+                    let db_substate_key = (db_partition_key.clone(), db_sort_key.clone());
                     self.substate_updates
-                        .insert(db_substate_key, database_update);
+                        .insert(db_substate_key, database_update.clone());
                 }
             }
             let hash_structures_diff = &commit.hash_structures_diff;


### PR DESCRIPTION
I spotted this refactoring opportunity during recent work inside state manager.

Basically, I think the difference in behavior needed for "genesis commit" vs "regular commit" is significant enough to warrant 2 separate methods:
- genesis is already constructed "validated" (no need for parsing/validating)
- genesis does not require all the consistency checks (e.g. commit request cannot "be invalid/mismatching", because we literally just fabricated the proof in the caller)
- genesis transactions are not tracked in mempool/cache

Having just a single "commit" feels cool for many reasons (e.g. the logic won't diverge; the bugfixes/refactors are only needed in one place; etc.). But it became less cool after seeing `if genesis { ...`, hence my refactor.