### PR TITLE
Optimization-only: checking the execution cache for an already-computed transaction root

### DIFF
--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -211,6 +211,20 @@ impl ExecutionCache {
         self.base_transaction_root = *new_base_transaction_root;
     }
 
+    pub fn get_cached_transaction_root(
+        &self,
+        parent_transaction_root: &TransactionTreeHash,
+        ledger_transaction_hash: &LedgerTransactionHash,
+    ) -> Option<&TransactionTreeHash> {
+        self.transaction_placement_to_key
+            .get(&TransactionPlacement::new(
+                parent_transaction_root,
+                ledger_transaction_hash,
+            ))
+            .and_then(|transaction_key| self.key_to_internal_transaction_ids.get(*transaction_key))
+            .and_then(|ids| ids.committed_transaction_root.as_ref())
+    }
+
     fn get_existing_stage_key(&self, transaction_root: &TransactionTreeHash) -> StageKey {
         if *transaction_root == self.base_transaction_root {
             StageKey::Root


### PR DESCRIPTION
This PR simply addresses a recent TODO.
Note: there is still some inefficiency there, but only during ledger sync (we first compute the transaction tree slice for the sake of consistency check, and then compute it again later together with all the other "hash structures diffs" for the sake of storing them in the DB).