### PR TITLE
Using parent map for accurate computation of balance changes in LTS endpoints

### DIFF
--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_account_transaction_outcomes.rs
@@ -3,6 +3,7 @@ use state_manager::store::traits::{
     extensions::IterableAccountChangeIndex, ConfigurableDatabase, QueryableProofStore,
     QueryableTransactionStore,
 };
+use std::ops::Deref;
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_stream_account_transaction_outcomes(
@@ -75,6 +76,7 @@ pub(crate) async fn handle_lts_stream_account_transaction_outcomes(
     let mut current_total_size = response.get_json_size();
     for state_version in state_versions.take(limit) {
         let committed_transaction_outcome = to_api_lts_committed_transaction_outcome(
+            database.deref(),
             &mapping_context,
             state_version,
             database

--- a/core-rust/core-api-server/src/core_api/handlers/lts/stream_transaction_outcomes.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/stream_transaction_outcomes.rs
@@ -2,6 +2,7 @@ use crate::core_api::*;
 use state_manager::store::traits::{
     CommittedTransactionBundle, ConfigurableDatabase, IterableTransactionStore, QueryableProofStore,
 };
+use std::ops::Deref;
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_stream_transaction_outcomes(
@@ -63,6 +64,7 @@ pub(crate) async fn handle_lts_stream_transaction_outcomes(
             ..
         } = bundle;
         let committed_transaction = to_api_lts_committed_transaction_outcome(
+            database.deref(),
             &mapping_context,
             state_version,
             receipt,

--- a/core/src/test/java/com/radixdlt/api/core/LtsTransactionOutcomesTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/LtsTransactionOutcomesTest.java
@@ -193,16 +193,18 @@ public class LtsTransactionOutcomesTest extends DeterministicCoreApiTestBase {
           account2AddressStr,
           account1ToAccount2XrdTransferWithFeeFromAccount1Amount);
 
-      // Slightly weird transaction, the fee payment calculation guesses wrong for now.
-      // TODO: Uncomment this test when fee calculation is fixed to make fewer assumptions
-      //
-      // assertNoNonFeeXrdBalanceChange(account1ToAccount2XrdTransferWithFeeFromAccount2.stateVersion, faucetAddressStr);
-      //
-      // assertNonFeeXrdBalanceChange(account1ToAccount2XrdTransferWithFeeFromAccount2.stateVersion,
-      // account1AddressStr, -account1ToAccount2XrdTransferWithFeeFromAccount2Amount);
-      //
-      // assertNonFeeXrdBalanceChange(account1ToAccount2XrdTransferWithFeeFromAccount2.stateVersion,
-      // account2AddressStr, account1ToAccount2XrdTransferWithFeeFromAccount2Amount);
+      assertNoNonFeeXrdBalanceChange(
+          account1ToAccount2XrdTransferWithFeeFromAccount2.stateVersion(), faucetAddressStr);
+
+      assertNonFeeXrdBalanceChange(
+          account1ToAccount2XrdTransferWithFeeFromAccount2.stateVersion(),
+          account1AddressStr,
+          -account1ToAccount2XrdTransferWithFeeFromAccount2Amount);
+
+      assertNonFeeXrdBalanceChange(
+          account1ToAccount2XrdTransferWithFeeFromAccount2.stateVersion(),
+          account2AddressStr,
+          account1ToAccount2XrdTransferWithFeeFromAccount2Amount);
 
       // Even though the faucet paid the fee, it didn't have any other balance transfers
       assertNoNonFeeXrdBalanceChange(


### PR DESCRIPTION
Finally, a feature enabled by https://github.com/radixdlt/babylon-node/pull/511.

The uncommented asserts in the test started passing immediately after this impl, which is a bit suspicious.