### PR TITLE
fix: update jre and jdk version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     software-properties-common=0.96.20.2-2.1 \
   && add-apt-repository -y ppa:openjdk-r/ppa \
   && apt-get install -y --no-install-recommends \
-    openjdk-17-jdk=17.0.6+10-1~deb11u1 \
+    openjdk-17-jdk=17.0.7+7-1~deb11u1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && wget -q https://services.gradle.org/distributions/gradle-7.2-bin.zip \
@@ -224,7 +224,7 @@ LABEL org.opencontainers.image.authors="devops@radixdlt.com"
 # - gettext-base is needed for envsubst in config_radixdlt.sh
 RUN apt-get update -y \
   && apt-get -y --no-install-recommends install \
-    openjdk-17-jre-headless=17.0.6+10-1~deb11u1 \
+    openjdk-17-jre-headless=17.0.7+7-1~deb11u1 \
     unzip=6.0-26+deb11u1 \
     daemontools=1:0.76-7 \
     libssl-dev=1.1.1n-0+deb11u5 \


### PR DESCRIPTION
Version 17.0.6+10-1 had been removed because of security updates and can no longer be installed.

Here are the patchnotes from 
https://metadata.ftp-master.debian.org/changelogs//main/o/openjdk-17/openjdk-17_17.0.7+7-2_changelog
```
openjdk-17 (17.0.7+7-1) unstable; urgency=high

  * OpenJDK 17.0.7 release, build 7.
    - CVE-2023-21930, CVE-2023-21937, CVE-2023-21938, CVE-2023-21939,
      CVE-2023-21954, CVE-2023-21967, CVE-2023-21968.
    - Release notes:
      https://mail.openjdk.org/pipermail/jdk-updates-dev/2023-April/021899.html

  [ Vladimir Petko ]
  * Refresh patches.
  * debian/copyright: Convert to machine readable format.
  * Update watch file.
  * Update tag and version handling in the rules file.
  * debian/JB-jre-headless.postinst.in: trigger ca-certificates-java after
    the JRE is set up.
  * d/control: add jtreg6 dependencies, regenerate control.
  * d/rules: only compile google tests when with_check is enabled, disable them
    for bullseye and jammy.
  * d/rules: always use jtreg6.
  * d/p/exclude-broken-tests.patch: add OpenJDK 17 failures.
  * d/p/*: add patches for jtreg tests:
    - disable-thumb-assertion.patch: fix JDK-8305481.
    - update-assertion-for-armhf.patch: fix JDK-8305480.
    - misalign-pointer-for-armhf.patch: packaging-specific patch to fix test
    - failure introduced by d/p/m68k-support.diff.
    - log-generated-classes-test.patch: workaround JDK-8166162.
    - update-permission-test.patch: add security permissions for testng 7.
    - ldap-timeout-test-use-ip.patch, test-use-ip-address.patch: Ubuntu-specific
    - patches to workaround missing DNS resolver on the build machines.
    - exclude_broken_tests.patch: quarantine failing tests.
  * d/t/{jdk,hotspot,jaxp,lantools}: run tier1 and tier2 jtreg tests only,
  * add test options from OpenJDK Makefile, patch problem list to exclude
    architecture-specific failing tests.
  * d/t/*: fix test environment: add missing -nativepath (LP: #2001563).
  * d/t/jdk: provide dbus session for the window manager (LP: #2001576).
  * d/t/jtreg-autopkgtest.in: pass JTREG home to locate junit.jar, regenerate
  * d/t/jtreg-autopkgtest.sh (LP: #2016206).
  * d/rules: pack external debug symbols with build-id, do not strip JVM shared
    libraries (LP: #2012326, LP: #2016739).
  * drop d/p/{jaw-classpath.diff, jaw-optional.diff}: the atk wrapper is
    disabled and these patches cause class data sharing tests to fail.
    LP: #2016194.

 -- Matthias Klose <doko@debian.org>  Tue, 06 Jun 2023 13:36:52 +0200

openjdk-17 (17.0.6+10-1) unstable; urgency=high

  * OpenJDK 17.0.6 release, build 10.
    - CVE-2023-21835, CVE-2023-21843
    - Release notes:
      https://www.oracle.com/java/technologies/javase/17-0-6-relnotes.html

  [ Vladimir Petko ]
  * debian/patches/*: Refresh patches for the new release and drop unused
    patches.
  * debian/rules: add lunar to jtreg version selection.
  ```