### PR TITLE
Add option to disable fees; Use correct ledger header for BFTSync; va…

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/statemanager/StateManagerConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statemanager/StateManagerConfig.java
@@ -75,7 +75,8 @@ public record StateManagerConfig(
     Option<RustMempoolConfig> mempoolConfigOpt,
     DatabaseBackendConfig databaseBackendConfig,
     DatabaseFlags databaseFlags,
-    LoggingConfig loggingConfig) {
+    LoggingConfig loggingConfig,
+    boolean noFees) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         StateManagerConfig.class,

--- a/core-rust/state-manager/src/transaction/executable_logic.rs
+++ b/core-rust/state-manager/src/transaction/executable_logic.rs
@@ -57,7 +57,7 @@ pub struct ExecutionConfigurator {
 }
 
 impl ExecutionConfigurator {
-    pub fn new(logging_config: &LoggingConfig) -> Self {
+    pub fn new(logging_config: &LoggingConfig, fee_reserve_config: FeeReserveConfig) -> Self {
         let trace = logging_config.engine_trace;
         Self {
             scrypto_interpreter: ScryptoVm {
@@ -65,7 +65,7 @@ impl ExecutionConfigurator {
                 wasm_instrumenter: WasmInstrumenter::default(),
                 wasm_metering_config: WasmMeteringConfig::default(),
             },
-            fee_reserve_config: FeeReserveConfig::default(),
+            fee_reserve_config,
             execution_configs: HashMap::from([
                 (
                     ConfigType::Genesis,

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -128,6 +128,7 @@ mod tests {
     };
     use parking_lot::RwLock;
     use prometheus::Registry;
+    use radix_engine::transaction::FeeReserveConfig;
     use radix_engine_common::network::NetworkDefinition;
     use radix_engine_common::{dec, manifest_args};
     use radix_engine_interface::constants::FAUCET;
@@ -149,7 +150,10 @@ mod tests {
             InMemoryStore::new(DatabaseFlags::default()),
         )));
         let metric_registry = Registry::new();
-        let execution_configurator = Arc::new(ExecutionConfigurator::new(&logging_config));
+        let execution_configurator = Arc::new(ExecutionConfigurator::new(
+            &logging_config,
+            FeeReserveConfig::default(),
+        ));
         let pending_transaction_result_cache = Arc::new(parking_lot::const_rwlock(
             PendingTransactionResultCache::new(10000, 10000),
         ));

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
@@ -86,11 +86,11 @@ import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.rev2.modules.MockedVertexStoreModule;
 import com.radixdlt.rev2.modules.REv2StateManagerModule;
+import com.radixdlt.statemanager.DatabaseFlags;
 import com.radixdlt.sync.SyncRelayConfig;
 import java.util.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -98,7 +98,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-@Ignore // Ignore all these tests until we can fix them properly
 public final class MultiNodeRebootTest {
   @Parameterized.Parameters
   public static Collection<Object[]> numNodes() {
@@ -215,11 +214,15 @@ public final class MultiNodeRebootTest {
                         numValidators,
                         Decimal.of(1),
                         GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
-                            this.roundsPerEpoch)),
+                                this.roundsPerEpoch)
+                            .totalEmissionXrdPerEpoch(Decimal.of(0))),
                     REv2StateManagerModule.DatabaseType.ROCKS_DB,
+                    new DatabaseFlags(true, false),
                     StateComputerConfig.REV2ProposerConfig.transactionGenerator(
-                        new REV2TransactionGenerator(), 1)),
-                SyncRelayConfig.of(5000, 10, 5000L))));
+                        new REV2TransactionGenerator(), 1),
+                    false,
+                    true),
+                SyncRelayConfig.of(100, 10, 500))));
   }
 
   private void runTest(

--- a/core/src/main/java/com/radixdlt/consensus/epoch/BFTSyncFactory.java
+++ b/core/src/main/java/com/radixdlt/consensus/epoch/BFTSyncFactory.java
@@ -64,17 +64,16 @@
 
 package com.radixdlt.consensus.epoch;
 
-import com.radixdlt.consensus.BFTConfiguration;
+import com.radixdlt.consensus.LedgerHeader;
 import com.radixdlt.consensus.liveness.PacemakerState;
 import com.radixdlt.consensus.safety.SafetyRules;
 import com.radixdlt.consensus.sync.BFTSync;
 import com.radixdlt.consensus.vertexstore.VertexStoreAdapter;
 
-/** Creates a new bft sync given a vertex store and pacemaker */
 public interface BFTSyncFactory {
   BFTSync create(
       SafetyRules safetyRules,
       VertexStoreAdapter vertexStore,
       PacemakerState pacemakerState,
-      BFTConfiguration configuration);
+      LedgerHeader currentLedgerHeader);
 }

--- a/core/src/main/java/com/radixdlt/consensus/epoch/EpochsConsensusModule.java
+++ b/core/src/main/java/com/radixdlt/consensus/epoch/EpochsConsensusModule.java
@@ -417,7 +417,7 @@ public class EpochsConsensusModule extends AbstractModule {
       @BFTSyncPatienceMillis int bftSyncPatienceMillis,
       Metrics metrics,
       Hasher hasher) {
-    return (safetyRules, vertexStore, pacemakerState, configuration) ->
+    return (safetyRules, vertexStore, pacemakerState, currentLedgerHeader) ->
         new BFTSync(
             self,
             syncRequestRateLimiter,
@@ -430,7 +430,7 @@ public class EpochsConsensusModule extends AbstractModule {
             syncLedgerRequestSender,
             timeoutDispatcher,
             unexpectedEventEventDispatcher,
-            configuration.getVertexStoreState().getRootHeader(),
+            currentLedgerHeader,
             random,
             bftSyncPatienceMillis,
             metrics);

--- a/core/src/main/java/com/radixdlt/consensus/vertexstore/VertexStoreAdapter.java
+++ b/core/src/main/java/com/radixdlt/consensus/vertexstore/VertexStoreAdapter.java
@@ -125,17 +125,7 @@ public final class VertexStoreAdapter {
   public VertexStore.InsertQcResult insertQc(QuorumCertificate qc) {
     final var result = vertexStore.insertQc(qc);
     if (result instanceof VertexStore.InsertQcResult.Inserted inserted) {
-      // TODO: why is this if statement needed?
-      if (inserted.committedUpdate().isEmpty()) {
-        this.highQCUpdateDispatcher.dispatch(BFTHighQCUpdate.create(inserted.vertexStoreState()));
-      }
-      inserted
-          .committedUpdate()
-          .onPresent(
-              committedUpdate ->
-                  this.bftCommittedDispatcher.dispatch(
-                      new BFTCommittedUpdate(
-                          committedUpdate.committedVertices(), inserted.vertexStoreState())));
+      dispatchPostQcInsertionEvents(inserted);
     }
     return result;
   }
@@ -150,22 +140,29 @@ public final class VertexStoreAdapter {
 
   public void insertVertexChain(VertexChain vertexChain) {
     final var result = vertexStore.insertVertexChain(vertexChain);
-    result
-        .insertedQcs()
-        .forEach(
-            insertedQc -> {
-              this.highQCUpdateDispatcher.dispatch(
-                  BFTHighQCUpdate.create(insertedQc.vertexStoreState()));
-              insertedQc
-                  .committedUpdate()
-                  .onPresent(
-                      committedUpdate ->
-                          this.bftCommittedDispatcher.dispatch(
-                              new BFTCommittedUpdate(
-                                  committedUpdate.committedVertices(),
-                                  insertedQc.vertexStoreState())));
-            });
+    result.insertedQcs().forEach(this::dispatchPostQcInsertionEvents);
     result.insertUpdates().forEach(bftUpdateDispatcher::dispatch);
+  }
+
+  private void dispatchPostQcInsertionEvents(VertexStore.InsertQcResult.Inserted inserted) {
+    // This is a bit of a hack.
+    // We don't want to persist the vertex store state (via PersistentVertexStore)
+    // if the state is already being persisted alongside commit.
+    // This implicitly assumes that:
+    // - BFTHighQCUpdate triggers vertex store state persistence
+    //    (that's why this if statement is needed)
+    // - no other component needs this event if we're also committing
+    if (inserted.committedUpdate().isEmpty()) {
+      this.highQCUpdateDispatcher.dispatch(BFTHighQCUpdate.create(inserted.vertexStoreState()));
+    }
+
+    inserted
+        .committedUpdate()
+        .onPresent(
+            committedUpdate ->
+                this.bftCommittedDispatcher.dispatch(
+                    new BFTCommittedUpdate(
+                        committedUpdate.committedVertices(), inserted.vertexStoreState())));
   }
 
   public Optional<ImmutableList<VertexWithHash>> getVertices(HashCode vertexId, int count) {

--- a/core/src/main/java/com/radixdlt/modules/ConsensusModule.java
+++ b/core/src/main/java/com/radixdlt/modules/ConsensusModule.java
@@ -229,7 +229,7 @@ public final class ConsensusModule extends AbstractModule {
       EventDispatcher<LocalSyncRequest> syncLedgerRequestSender,
       ScheduledEventDispatcher<VertexRequestTimeout> timeoutDispatcher,
       EventDispatcher<ConsensusByzantineEvent> unexpectedEventEventDispatcher,
-      @LastProof LedgerProof ledgerLastProof, // Use this instead of configuration.getRoot()
+      @LastProof LedgerProof ledgerLastProof,
       Random random,
       @BFTSyncPatienceMillis int bftSyncPatienceMillis,
       Hasher hasher,
@@ -247,7 +247,7 @@ public final class ConsensusModule extends AbstractModule {
         syncLedgerRequestSender,
         timeoutDispatcher,
         unexpectedEventEventDispatcher,
-        ledgerLastProof,
+        ledgerLastProof.getHeader(),
         random,
         bftSyncPatienceMillis,
         metrics);

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
@@ -108,6 +108,7 @@ public final class REv2StateManagerModule extends AbstractModule {
   private final DatabaseFlags databaseFlags;
   private final Option<RustMempoolConfig> mempoolConfig;
   private final boolean debugLogging;
+  private final boolean noFees;
 
   private REv2StateManagerModule(
       int maxNumTransactionsPerProposal,
@@ -116,7 +117,8 @@ public final class REv2StateManagerModule extends AbstractModule {
       DatabaseType databaseType,
       DatabaseFlags databaseFlags,
       Option<RustMempoolConfig> mempoolConfig,
-      boolean debugLogging) {
+      boolean debugLogging,
+      boolean noFees) {
     this.maxNumTransactionsPerProposal = maxNumTransactionsPerProposal;
     this.maxProposalTotalTxnsPayloadSize = maxProposalTotalTxnsPayloadSize;
     this.maxUncommittedUserTransactionsTotalPayloadSize =
@@ -125,6 +127,7 @@ public final class REv2StateManagerModule extends AbstractModule {
     this.databaseFlags = databaseFlags;
     this.mempoolConfig = mempoolConfig;
     this.debugLogging = debugLogging;
+    this.noFees = noFees;
   }
 
   public static REv2StateManagerModule create(
@@ -141,6 +144,7 @@ public final class REv2StateManagerModule extends AbstractModule {
         databaseType,
         databaseFlags,
         mempoolConfig,
+        false,
         false);
   }
 
@@ -150,7 +154,8 @@ public final class REv2StateManagerModule extends AbstractModule {
       DatabaseType databaseType,
       DatabaseFlags databaseFlags,
       Option<RustMempoolConfig> mempoolConfig,
-      boolean debugLogging) {
+      boolean debugLogging,
+      boolean noFees) {
     return new REv2StateManagerModule(
         maxNumTransactionsPerProposal,
         maxProposalTotalTxnsPayloadSize,
@@ -158,7 +163,8 @@ public final class REv2StateManagerModule extends AbstractModule {
         databaseType,
         databaseFlags,
         mempoolConfig,
-        debugLogging);
+        debugLogging,
+        noFees);
   }
 
   @Override
@@ -204,7 +210,8 @@ public final class REv2StateManagerModule extends AbstractModule {
                     mempoolConfig,
                     databaseBackendConfig,
                     databaseFlags,
-                    getLoggingConfig()));
+                    getLoggingConfig(),
+                    noFees));
           }
 
           @Provides

--- a/core/src/test-core/java/com/radixdlt/harness/deterministic/DeterministicNodes.java
+++ b/core/src/test-core/java/com/radixdlt/harness/deterministic/DeterministicNodes.java
@@ -206,6 +206,7 @@ public final class DeterministicNodes implements AutoCloseable {
                 bind(Metrics.class).toInstance(new MetricsInitializer().initialize());
                 bind(ControlledTimeSupplier.class).toInstance(new ControlledTimeSupplier(time));
                 bind(TimeSupplier.class).to(ControlledTimeSupplier.class);
+                bind(DeterministicProcessor.class).in(Scopes.SINGLETON);
               }
 
               @Provides

--- a/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
@@ -413,7 +413,8 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         rev2Config.databaseType(),
                         rev2Config.databaseFlags(),
                         Option.none(),
-                        rev2Config.debugLogging()));
+                        rev2Config.debugLogging(),
+                        rev2Config.noFees()));
               }
               case REV2ProposerConfig.Mempool mempool -> {
                 install(new MempoolRelayerModule(10000));
@@ -427,7 +428,8 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         rev2Config.databaseType(),
                         rev2Config.databaseFlags(),
                         Option.some(mempool.mempoolConfig()),
-                        rev2Config.debugLogging()));
+                        rev2Config.debugLogging(),
+                        rev2Config.noFees()));
               }
             }
           }

--- a/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
+++ b/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
@@ -119,9 +119,10 @@ public sealed interface StateComputerConfig {
       REv2StateManagerModule.DatabaseType databaseType,
       DatabaseFlags databaseFlags,
       REV2ProposerConfig proposerConfig,
-      boolean debugLogging) {
+      boolean debugLogging,
+      boolean noFees) {
     return new REv2StateComputerConfig(
-        networkId, genesis, databaseType, databaseFlags, proposerConfig, debugLogging);
+        networkId, genesis, databaseType, databaseFlags, proposerConfig, debugLogging, noFees);
   }
 
   static StateComputerConfig rev2(
@@ -131,7 +132,7 @@ public sealed interface StateComputerConfig {
       DatabaseFlags databaseFlags,
       REV2ProposerConfig proposerConfig) {
     return new REv2StateComputerConfig(
-        networkId, genesis, databaseType, databaseFlags, proposerConfig, false);
+        networkId, genesis, databaseType, databaseFlags, proposerConfig, false, false);
   }
 
   static StateComputerConfig rev2(
@@ -140,7 +141,13 @@ public sealed interface StateComputerConfig {
       REv2StateManagerModule.DatabaseType databaseType,
       REV2ProposerConfig proposerConfig) {
     return new REv2StateComputerConfig(
-        networkId, genesis, databaseType, new DatabaseFlags(true, false), proposerConfig, false);
+        networkId,
+        genesis,
+        databaseType,
+        new DatabaseFlags(true, false),
+        proposerConfig,
+        false,
+        false);
   }
 
   sealed interface MockedMempoolConfig {
@@ -195,7 +202,8 @@ public sealed interface StateComputerConfig {
       REv2StateManagerModule.DatabaseType databaseType,
       DatabaseFlags databaseFlags,
       REV2ProposerConfig proposerConfig,
-      boolean debugLogging)
+      boolean debugLogging,
+      boolean noFees)
       implements StateComputerConfig {}
 
   sealed interface REV2ProposerConfig {

--- a/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
@@ -111,7 +111,8 @@ public final class RustMempoolTest {
             Option.some(new RustMempoolConfig(mempoolSize)),
             DatabaseBackendConfig.inMemory(),
             new DatabaseFlags(false, false),
-            LoggingConfig.getDefault());
+            LoggingConfig.getDefault(),
+            false);
     final var metrics = new MetricsInitializer().initialize();
 
     try (var stateManager = new StateManager(NOOP_DISPATCHER, config)) {
@@ -174,7 +175,8 @@ public final class RustMempoolTest {
             Option.some(new RustMempoolConfig(mempoolSize)),
             DatabaseBackendConfig.inMemory(),
             new DatabaseFlags(false, false),
-            LoggingConfig.getDefault());
+            LoggingConfig.getDefault(),
+            false);
     final var metrics = new MetricsInitializer().initialize();
 
     try (var stateManager = new StateManager(NOOP_DISPATCHER, config)) {
@@ -307,7 +309,8 @@ public final class RustMempoolTest {
             Option.some(new RustMempoolConfig(mempoolSize)),
             DatabaseBackendConfig.inMemory(),
             new DatabaseFlags(false, false),
-            LoggingConfig.getDefault());
+            LoggingConfig.getDefault(),
+            false);
     final var metrics = new MetricsInitializer().initialize();
 
     try (var stateManager = new StateManager(NOOP_DISPATCHER, config)) {


### PR DESCRIPTION
…rious improvements around MultiNodeRebootTest.

Included in this PR:

- add an option to disable fees (and, as a consequence, validator rewards) in tests, e.g. if we want a fixed-stake validator set
- use the latest ledger header when instantiating BFTSync (see comment in EpochManager)
- remove `runOnThreads` from BFTSync - it was a temporary debug info; no longer needed
- update ledger sync request timeout from 5000 ms to 100 in MultiNodeRebootTest - this tests relies on this in some cases (and 5s was enough wait time to trigger a failure)
- don't dispatch BFTHighQCUpdate if we're dispatching BFTCommittedUpdate in VertexStore