### PR TITLE
Storing the results of executing "genesis scenarios" in the persistence

### DIFF
--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -764,9 +764,10 @@ where
         if !scenarios_to_run.is_empty() {
             info!("Running {} scenarios", scenarios_to_run.len());
             let mut next_nonce: u32 = 0;
-            for scenario_name in scenarios_to_run.iter() {
+            for (sequence_number, scenario_name) in scenarios_to_run.iter().enumerate() {
                 next_nonce = self.execute_genesis_scenario(
                     &mut genesis_commit_request_factory,
+                    sequence_number,
                     scenario_name.as_str(),
                     initial_epoch,
                     next_nonce,
@@ -793,6 +794,7 @@ where
     fn execute_genesis_scenario(
         &self,
         genesis_commit_request_factory: &mut GenesisCommitRequestFactory,
+        sequence_number: usize,
         scenario_name: &str,
         epoch: Epoch,
         nonce: u32,
@@ -805,7 +807,6 @@ where
                     scenario_name
                 )
             });
-        let scenario_base_version = genesis_commit_request_factory.state_version;
         let mut previous = None;
         let mut committed_transactions = Vec::new();
         info!("Running scenario: {}", scenario_name);
@@ -864,7 +865,7 @@ where
                             .join("\n")
                     );
                     let mut write_store = self.store.write();
-                    write_store.put(scenario_base_version, executed_scenario);
+                    write_store.put(sequence_number, executed_scenario);
                     return end_state.next_unused_nonce;
                 }
             }

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -81,11 +81,17 @@ use radix_engine::transaction::{RejectResult, TransactionReceipt};
 use radix_engine_interface::blueprints::consensus_manager::{
     ConsensusManagerConfig, EpochChangeCondition,
 };
+use transaction_scenarios::scenario::*;
+use transaction_scenarios::scenarios::*;
 
 use parking_lot::{Mutex, RwLock};
 use prometheus::Registry;
 use tracing::{info, warn};
 
+use crate::store::traits::scenario::{
+    DescribedAddress, ExecutedGenesisScenario, ExecutedGenesisScenarioStore,
+    ExecutedScenarioTransaction,
+};
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -265,7 +271,7 @@ where
     pub fn prepare_scenario_transaction(
         &self,
         scenario_name: &str,
-        next: &transaction_scenarios::scenario::NextTransaction,
+        next: &NextTransaction,
     ) -> (ScenarioPrepareResult, TransactionReceipt) {
         let qualified_name = format!(
             "{} scenario - {} transaction",
@@ -631,7 +637,7 @@ struct TransactionMetricsData {
 
 impl<S> StateManager<S>
 where
-    S: CommitStore,
+    S: CommitStore + ExecutedGenesisScenarioStore,
     S: ReadableStore,
     S: for<'a> TransactionIndex<&'a IntentHash>,
     S: QueryableProofStore + TransactionIdentifierLoader,
@@ -756,68 +762,15 @@ where
         // These scenarios are committed before we start consensus / rounds after the genesis wrap-up.
         // This is a little weird, but should be fine.
         if !scenarios_to_run.is_empty() {
-            use transaction_scenarios::scenario::*;
             info!("Running {} scenarios", scenarios_to_run.len());
-            let encoder = AddressBech32Encoder::new(&self.network);
             let mut next_nonce: u32 = 0;
-            let epoch = initial_epoch;
             for scenario_name in scenarios_to_run.iter() {
-                let mut scenario = self
-                    .find_scenario(epoch, next_nonce, scenario_name)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "Could not find scenario with logical name: {}",
-                            scenario_name
-                        )
-                    });
-                let mut committed_transaction_count = 0;
-                let mut previous = None;
-                info!("Running scenario: {}", scenario_name);
-                loop {
-                    let next = scenario
-                        .next(previous.as_ref())
-                        .map_err(|err| err.into_full(&scenario))
-                        .unwrap();
-                    match next {
-                        NextAction::Transaction(next) => {
-                            let (prepare_result, basic_receipt) =
-                                self.prepare_scenario_transaction(scenario_name, &next);
-                            if let Some(commit_request) =
-                                genesis_commit_request_factory.create_for_scenario(prepare_result)
-                            {
-                                committed_transaction_count += 1;
-                                let resultant_state_version =
-                                    commit_request.proof.ledger_header.state_version;
-                                self.commit_genesis(commit_request);
-                                info!(
-                                    "Committed {} at state_version {}",
-                                    &next.logical_name, resultant_state_version
-                                );
-                            }
-                            previous = Some(basic_receipt);
-                        }
-                        NextAction::Completed(end_state) => {
-                            let formatted_addresses = end_state
-                                .output
-                                .interesting_addresses
-                                .0
-                                .iter()
-                                .map(|(descriptor, address)| {
-                                    format!("  - {}: {}", descriptor, address.display(&encoder))
-                                })
-                                .collect::<Vec<_>>()
-                                .join("\n");
-                            info!(
-                                "Completed committing {} transactions for scenario {}, with resultant addresses:\n{}",
-                                committed_transaction_count,
-                                scenario_name,
-                                formatted_addresses
-                            );
-                            next_nonce = end_state.next_unused_nonce;
-                            break;
-                        }
-                    }
-                }
+                next_nonce = self.execute_genesis_scenario(
+                    &mut genesis_commit_request_factory,
+                    scenario_name.as_str(),
+                    initial_epoch,
+                    next_nonce,
+                );
             }
             info!("Scenarios finished");
         }
@@ -837,14 +790,93 @@ where
         final_ledger_proof
     }
 
+    fn execute_genesis_scenario(
+        &self,
+        genesis_commit_request_factory: &mut GenesisCommitRequestFactory,
+        scenario_name: &str,
+        epoch: Epoch,
+        nonce: u32,
+    ) -> u32 {
+        let mut scenario = self
+            .find_scenario(epoch, nonce, scenario_name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Could not find scenario with logical name: {}",
+                    scenario_name
+                )
+            });
+        let scenario_base_version = genesis_commit_request_factory.state_version;
+        let mut previous = None;
+        let mut committed_transactions = Vec::new();
+        info!("Running scenario: {}", scenario_name);
+        loop {
+            let next = scenario
+                .next(previous.as_ref())
+                .map_err(|err| err.into_full(&scenario))
+                .unwrap();
+            match next {
+                NextAction::Transaction(next) => {
+                    let (prepare_result, basic_receipt) =
+                        self.prepare_scenario_transaction(scenario_name, &next);
+                    let intent_hash = prepare_result.validated.intent_hash_if_user().unwrap();
+                    if let Some(commit_request) =
+                        genesis_commit_request_factory.create_for_scenario(prepare_result)
+                    {
+                        self.commit_genesis(commit_request);
+                        committed_transactions.push(ExecutedScenarioTransaction {
+                            logical_name: next.logical_name.clone(),
+                            state_version: genesis_commit_request_factory.state_version,
+                            intent_hash,
+                        });
+                        info!(
+                            "Committed {} at state_version {}",
+                            &next.logical_name, genesis_commit_request_factory.state_version
+                        );
+                    }
+                    previous = Some(basic_receipt);
+                }
+                NextAction::Completed(end_state) => {
+                    let encoder = AddressBech32Encoder::new(&self.network);
+                    let executed_scenario = ExecutedGenesisScenario {
+                        logical_name: scenario.metadata().logical_name.to_string(),
+                        committed_transactions,
+                        addresses: end_state
+                            .output
+                            .interesting_addresses
+                            .0
+                            .into_iter()
+                            .map(|(descriptor, address)| DescribedAddress {
+                                logical_name: descriptor,
+                                rendered_address: address.display(&encoder).to_string(),
+                            })
+                            .collect(),
+                    };
+                    info!(
+                        "Completed committing {} transactions for scenario {}, with resultant addresses:\n{}",
+                        executed_scenario.committed_transactions.len(),
+                        executed_scenario.logical_name,
+                        executed_scenario.addresses
+                            .iter()
+                            .map(|address| format!(
+                                "  - {}: {}", address.logical_name, address.rendered_address
+                            ))
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    );
+                    let mut write_store = self.store.write();
+                    write_store.put(scenario_base_version, executed_scenario);
+                    return end_state.next_unused_nonce;
+                }
+            }
+        }
+    }
+
     fn find_scenario(
         &self,
         epoch: Epoch,
         next_nonce: u32,
         scenario_name: &str,
-    ) -> Option<Box<dyn transaction_scenarios::scenario::ScenarioInstance>> {
-        use transaction_scenarios::scenario::*;
-        use transaction_scenarios::scenarios::*;
+    ) -> Option<Box<dyn ScenarioInstance>> {
         for scenario_builder in get_builder_for_every_scenario() {
             let scenario =
                 scenario_builder(ScenarioCore::new(self.network.clone(), epoch, next_nonce));

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -103,7 +103,8 @@ pub enum DatabaseBackendConfig {
     CommitStore,
     SubstateNodeAncestryStore,
     IterableAccountChangeIndex,
-    IterableTransactionStore
+    IterableTransactionStore,
+    ExecutedGenesisScenarioStore
 )]
 pub enum StateManagerDatabase {
     InMemory(InMemoryStore),

--- a/core-rust/state-manager/src/store/in_memory.rs
+++ b/core-rust/state-manager/src/store/in_memory.rs
@@ -76,6 +76,7 @@ use crate::{
 
 use crate::query::TransactionIdentifierLoader;
 use crate::store::node_ancestry_resolver::NodeAncestryResolver;
+use crate::store::traits::scenario::{ExecutedGenesisScenario, ExecutedGenesisScenarioStore};
 use core::ops::Bound::{Included, Unbounded};
 use node_common::utils::IsAccountExt;
 use radix_engine_common::types::{Epoch, GlobalAddress, NodeId};
@@ -108,6 +109,7 @@ pub struct InMemoryStore {
     receipt_tree_slices: BTreeMap<StateVersion, TreeSlice<ReceiptTreeHash>>,
     account_change_index_last_state_version: StateVersion,
     account_change_index_set: HashMap<GlobalAddress, BTreeSet<StateVersion>>,
+    executed_genesis_scenarios: BTreeMap<StateVersion, ExecutedGenesisScenario>,
 }
 
 impl InMemoryStore {
@@ -131,6 +133,7 @@ impl InMemoryStore {
             receipt_tree_slices: BTreeMap::new(),
             account_change_index_last_state_version: StateVersion::pre_genesis(),
             account_change_index_set: HashMap::new(),
+            executed_genesis_scenarios: BTreeMap::new(),
         }
     }
 
@@ -332,6 +335,13 @@ impl CommitStore for InMemoryStore {
             .insert(commit_state_version, commit_bundle.transaction_tree_slice);
         self.receipt_tree_slices
             .insert(commit_state_version, commit_bundle.receipt_tree_slice);
+    }
+}
+
+impl ExecutedGenesisScenarioStore for InMemoryStore {
+    fn put(&mut self, base_version: StateVersion, scenario: ExecutedGenesisScenario) {
+        self.executed_genesis_scenarios
+            .insert(base_version, scenario);
     }
 }
 

--- a/core-rust/state-manager/src/store/in_memory.rs
+++ b/core-rust/state-manager/src/store/in_memory.rs
@@ -76,7 +76,9 @@ use crate::{
 
 use crate::query::TransactionIdentifierLoader;
 use crate::store::node_ancestry_resolver::NodeAncestryResolver;
-use crate::store::traits::scenario::{ExecutedGenesisScenario, ExecutedGenesisScenarioStore};
+use crate::store::traits::scenario::{
+    ExecutedGenesisScenario, ExecutedGenesisScenarioStore, ScenarioSequenceNumber,
+};
 use core::ops::Bound::{Included, Unbounded};
 use node_common::utils::IsAccountExt;
 use radix_engine_common::types::{Epoch, GlobalAddress, NodeId};
@@ -109,7 +111,7 @@ pub struct InMemoryStore {
     receipt_tree_slices: BTreeMap<StateVersion, TreeSlice<ReceiptTreeHash>>,
     account_change_index_last_state_version: StateVersion,
     account_change_index_set: HashMap<GlobalAddress, BTreeSet<StateVersion>>,
-    executed_genesis_scenarios: BTreeMap<StateVersion, ExecutedGenesisScenario>,
+    executed_genesis_scenarios: BTreeMap<ScenarioSequenceNumber, ExecutedGenesisScenario>,
 }
 
 impl InMemoryStore {
@@ -339,9 +341,8 @@ impl CommitStore for InMemoryStore {
 }
 
 impl ExecutedGenesisScenarioStore for InMemoryStore {
-    fn put(&mut self, base_version: StateVersion, scenario: ExecutedGenesisScenario) {
-        self.executed_genesis_scenarios
-            .insert(base_version, scenario);
+    fn put(&mut self, number: ScenarioSequenceNumber, scenario: ExecutedGenesisScenario) {
+        self.executed_genesis_scenarios.insert(number, scenario);
     }
 }
 

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -410,6 +410,8 @@ pub mod scenario {
 
     use transaction::model::IntentHash;
 
+    pub type ScenarioSequenceNumber = usize;
+
     #[derive(Debug, Categorize, Encode, Decode)]
     pub struct ExecutedGenesisScenario {
         pub logical_name: String,
@@ -432,7 +434,7 @@ pub mod scenario {
 
     #[enum_dispatch]
     pub trait ExecutedGenesisScenarioStore {
-        fn put(&mut self, base_version: StateVersion, scenario: ExecutedGenesisScenario);
+        fn put(&mut self, number: ScenarioSequenceNumber, scenario: ExecutedGenesisScenario);
     }
 }
 

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -405,6 +405,37 @@ pub mod commit {
     }
 }
 
+pub mod scenario {
+    use super::*;
+
+    use transaction::model::IntentHash;
+
+    #[derive(Debug, Categorize, Encode, Decode)]
+    pub struct ExecutedGenesisScenario {
+        pub logical_name: String,
+        pub committed_transactions: Vec<ExecutedScenarioTransaction>,
+        pub addresses: Vec<DescribedAddress>,
+    }
+
+    #[derive(Debug, Categorize, Encode, Decode)]
+    pub struct DescribedAddress {
+        pub logical_name: String,
+        pub rendered_address: String, // we store it pre-rendered, since `GlobalAddress` has no SBOR coding
+    }
+
+    #[derive(Debug, Categorize, Encode, Decode)]
+    pub struct ExecutedScenarioTransaction {
+        pub logical_name: String,
+        pub state_version: StateVersion,
+        pub intent_hash: IntentHash,
+    }
+
+    #[enum_dispatch]
+    pub trait ExecutedGenesisScenarioStore {
+        fn put(&mut self, base_version: StateVersion, scenario: ExecutedGenesisScenario);
+    }
+}
+
 pub mod extensions {
     use super::*;
     use radix_engine::types::GlobalAddress;


### PR DESCRIPTION
This is the first PR for the "expose Genesis Scenarios' results from Core API".
It only stores the results in the DB (and has no observable behavior yet - the API change is coming in another PR).