### PR TITLE
Mempool improvements part 2

### DIFF
--- a/core-rust/core-api-server/src/core_api/server.rs
+++ b/core-rust/core-api-server/src/core_api/server.rs
@@ -84,8 +84,8 @@ use super::{constants::LARGE_REQUEST_MAX_BYTES, handlers::*, not_found_error, Re
 
 use crate::core_api::models::ErrorResponse;
 use handle_status_network_configuration as handle_provide_info_at_root_path;
+use state_manager::mempool::priority_mempool::PriorityMempool;
 use state_manager::mempool_manager::MempoolManager;
-use state_manager::simple_mempool::SimpleMempool;
 use state_manager::store::StateManagerDatabase;
 use state_manager::transaction::{CommittabilityValidator, TransactionPreviewer};
 use state_manager::PendingTransactionResultCache;
@@ -96,7 +96,7 @@ pub struct CoreApiState {
     pub state_manager: Arc<ActualStateManager>,
     pub database: Arc<RwLock<StateManagerDatabase>>,
     pub pending_transaction_result_cache: Arc<RwLock<PendingTransactionResultCache>>,
-    pub mempool: Arc<RwLock<SimpleMempool>>,
+    pub mempool: Arc<RwLock<PriorityMempool>>,
     pub mempool_manager: Arc<MempoolManager>,
     pub committability_validator: Arc<CommittabilityValidator<StateManagerDatabase>>,
     pub transaction_previewer: Arc<TransactionPreviewer<StateManagerDatabase>>,

--- a/core-rust/state-manager/src/jni/mempool.rs
+++ b/core-rust/state-manager/src/jni/mempool.rs
@@ -66,7 +66,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::jni::state_manager::JNIStateManager;
-use crate::simple_mempool::MempoolTransaction;
+use crate::mempool::priority_mempool::MempoolTransaction;
 
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;

--- a/core-rust/state-manager/src/jni/state_manager.rs
+++ b/core-rust/state-manager/src/jni/state_manager.rs
@@ -64,7 +64,7 @@
 
 use std::sync::{Arc, MutexGuard};
 
-use crate::mempool::simple_mempool::SimpleMempool;
+use crate::mempool::priority_mempool::PriorityMempool;
 use crate::state_manager::{LoggingConfig, StateManager};
 use crate::store::{DatabaseBackendConfig, DatabaseFlags, StateManagerDatabase};
 use jni::objects::{JClass, JObject};
@@ -144,7 +144,7 @@ pub struct JNIStateManager {
     pub state_manager: Arc<ActualStateManager>,
     pub database: Arc<RwLock<StateManagerDatabase>>,
     pub pending_transaction_result_cache: Arc<RwLock<PendingTransactionResultCache>>,
-    pub mempool: Arc<RwLock<SimpleMempool>>,
+    pub mempool: Arc<RwLock<PriorityMempool>>,
     pub mempool_manager: Arc<MempoolManager>,
     pub committability_validator: Arc<CommittabilityValidator<StateManagerDatabase>>,
     pub transaction_previewer: Arc<TransactionPreviewer<StateManagerDatabase>>,
@@ -202,7 +202,7 @@ impl JNIStateManager {
             committability_validator.clone(),
             pending_transaction_result_cache.clone(),
         );
-        let mempool = Arc::new(parking_lot::const_rwlock(SimpleMempool::new(
+        let mempool = Arc::new(parking_lot::const_rwlock(PriorityMempool::new(
             mempool_config,
         )));
         let mempool_relay_dispatcher = MempoolRelayDispatcher::new(env, j_state_manager).unwrap();
@@ -273,7 +273,7 @@ impl JNIStateManager {
         Self::get_state(env, j_state_manager).database.clone()
     }
 
-    pub fn get_mempool(env: &JNIEnv, j_state_manager: JObject) -> Arc<RwLock<SimpleMempool>> {
+    pub fn get_mempool(env: &JNIEnv, j_state_manager: JObject) -> Arc<RwLock<PriorityMempool>> {
         Self::get_state(env, j_state_manager).mempool.clone()
     }
 

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -143,6 +143,10 @@ impl MempoolManager {
         max_count: usize,
         max_payload_size_bytes: u64,
     ) -> Vec<Arc<MempoolTransaction>> {
+        // TODO: Definitely a better algorithm could be used here, especially with extra information like:
+        // which peer/peers are we sending this to? or what do we know about said peer to have in it's mempool?
+        // However (NOTE/WARN): changing transactions selection without careful consideration of the peer selection,
+        // can lead to a scenario where we keep sending same transactions to same peer.
         let candidate_transactions = self.mempool.read().get_k_random_transactions(max_count * 2);
 
         let mut payload_size_so_far = 0;
@@ -164,6 +168,7 @@ impl MempoolManager {
     /// from the mempool.
     /// Obeys the given limit on the number of actually executed (i.e. not cached) transactions.
     pub fn reevaluate_transaction_committability(&self, max_reevaluated_count: u32) {
+        // TODO: better selection of transactions based on last time/state version against it was reevaluated.
         const MIN_TRANSACTIONS_TO_CHECK_FOR_REEVALUATION: u32 = 100;
         let candidate_transactions = self.mempool.read().get_k_random_transactions(max(
             max_reevaluated_count,

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -62,30 +62,28 @@
  * permissions under this License.
  */
 
+use crate::mempool::priority_mempool::*;
 use crate::mempool::*;
-use crate::simple_mempool::MempoolTransaction;
 use crate::{MempoolAddSource, MempoolMetrics, TakesMetricLabels};
 use prometheus::Registry;
-use rand::seq::SliceRandom;
 use transaction::model::*;
 
+use std::cmp::max;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 
 use crate::mempool_relay_dispatcher::MempoolRelayDispatcher;
-use crate::simple_mempool::SimpleMempool;
 use crate::store::StateManagerDatabase;
 use crate::transaction::{
     CachedCommittabilityValidator, ForceRecalculation, PrevalidatedCheckMetadata,
 };
 use parking_lot::RwLock;
-use rand::thread_rng;
 use tracing::warn;
 
-/// A high-level API giving a thread-safe access to the `SimpleMempool`.
+/// A high-level API giving a thread-safe access to the `PriorityMempool`.
 pub struct MempoolManager {
-    mempool: Arc<RwLock<SimpleMempool>>,
+    mempool: Arc<RwLock<PriorityMempool>>,
     relay_dispatcher: Option<MempoolRelayDispatcher>,
     cached_committability_validator: CachedCommittabilityValidator<StateManagerDatabase>,
     metrics: MempoolMetrics,
@@ -94,7 +92,7 @@ pub struct MempoolManager {
 impl MempoolManager {
     /// Creates a manager and registers its metrics.
     pub fn new(
-        mempool: Arc<RwLock<SimpleMempool>>,
+        mempool: Arc<RwLock<PriorityMempool>>,
         relay_dispatcher: MempoolRelayDispatcher,
         cached_committability_validator: CachedCommittabilityValidator<StateManagerDatabase>,
         metric_registry: &Registry,
@@ -109,7 +107,7 @@ impl MempoolManager {
 
     /// Creates a testing manager (without the JNI-based relay dispatcher) and registers its metrics.
     pub fn new_for_testing(
-        mempool: Arc<RwLock<SimpleMempool>>,
+        mempool: Arc<RwLock<PriorityMempool>>,
         cached_committability_validator: CachedCommittabilityValidator<StateManagerDatabase>,
         metric_registry: &Registry,
     ) -> Self {
@@ -145,23 +143,36 @@ impl MempoolManager {
         max_count: usize,
         max_payload_size_bytes: u64,
     ) -> Vec<Arc<MempoolTransaction>> {
-        // TODO: don't grab whole mempool. Use a reservoir sampling method or a priority/round robin algorithm.
-        // Note that the round robin approach needs extra care to avoid relaying same transactions to same nodes.
-        let candidate_transactions = self.mempool.read().get_all_transactions();
+        let candidate_transactions = self.mempool.read().get_k_random_transactions(max_count * 2);
 
-        Self::pick_subset_with_limits(candidate_transactions, max_count, max_payload_size_bytes)
+        let mut payload_size_so_far = 0;
+        candidate_transactions
+            .into_iter()
+            .filter(|transaction| {
+                let increased_payload_size = payload_size_so_far + transaction.raw.0.len() as u64;
+                let fits = increased_payload_size <= max_payload_size_bytes;
+                if fits {
+                    payload_size_so_far = increased_payload_size;
+                }
+                fits
+            })
+            .take(max_count)
+            .collect()
     }
 
     /// Checks the committability of a random subset of transactions and removes the rejected ones
     /// from the mempool.
     /// Obeys the given limit on the number of actually executed (i.e. not cached) transactions.
     pub fn reevaluate_transaction_committability(&self, max_reevaluated_count: u32) {
-        // TODO: instead of getting whole mempool use a priority queue/round robin.
-        let mut candidate_transactions = self.mempool.read().get_all_transactions();
+        const MIN_TRANSACTIONS_TO_CHECK_FOR_REEVALUATION: u32 = 100;
+        let candidate_transactions = self.mempool.read().get_k_random_transactions(max(
+            max_reevaluated_count,
+            MIN_TRANSACTIONS_TO_CHECK_FOR_REEVALUATION,
+        )
+            as usize);
 
         let mut transactions_to_remove = Vec::new();
         let mut reevaluated_count = 0;
-        candidate_transactions.shuffle(&mut thread_rng());
         for candidate_transaction in candidate_transactions {
             let (record, was_cached) = self
                 .cached_committability_validator
@@ -371,27 +382,6 @@ impl MempoolManager {
         self.metrics
             .current_total_transactions_size
             .sub(removed.bytes as i64);
-    }
-
-    fn pick_subset_with_limits(
-        mut candidate_transactions: Vec<Arc<MempoolTransaction>>,
-        max_count: usize,
-        max_payload_size_bytes: u64,
-    ) -> Vec<Arc<MempoolTransaction>> {
-        candidate_transactions.shuffle(&mut thread_rng());
-        let mut payload_size_so_far = 0;
-        candidate_transactions
-            .into_iter()
-            .filter(|transaction| {
-                let increased_payload_size = payload_size_so_far + transaction.raw.0.len() as u64;
-                let fits = increased_payload_size <= max_payload_size_bytes;
-                if fits {
-                    payload_size_so_far = increased_payload_size;
-                }
-                fits
-            })
-            .take(max_count)
-            .collect()
     }
 }
 

--- a/core-rust/state-manager/src/mempool/mod.rs
+++ b/core-rust/state-manager/src/mempool/mod.rs
@@ -154,4 +154,4 @@ impl ToString for MempoolAddError {
 pub mod mempool_manager;
 pub mod mempool_relay_dispatcher;
 pub mod pending_transaction_result_cache;
-pub mod simple_mempool;
+pub mod priority_mempool;

--- a/core-rust/state-manager/src/mempool/priority_mempool.rs
+++ b/core-rust/state-manager/src/mempool/priority_mempool.rs
@@ -174,7 +174,7 @@ pub struct PriorityMempool {
     remaining_transaction_count: u32,
     /// Max sum of transactions size that can live in [`self.data`].
     remaining_total_transactions_size: u64,
-    /// Keeps ordering of the transactions by proposal priority (best transaction is highest tip percentage and )
+    /// Keeps ordering of the transactions by proposal priority (best transaction is highest tip percentage and longest time in mempool)
     proposal_priority_index: BTreeSet<MempoolDataProposalPriorityOrdering>,
     /// Mapping from [`NotarizedTransactionHash`] to [`Arc<MempoolData>`] containing [`MempoolTransaction`] with said payload hash.
     /// We use [`IndexMap`] for it's O(1) [`get_index`] needed for efficient random sampling.

--- a/core-rust/state-manager/src/mempool/priority_mempool.rs
+++ b/core-rust/state-manager/src/mempool/priority_mempool.rs
@@ -63,12 +63,14 @@
  */
 
 use node_common::config::MempoolConfig;
+use rand::seq::index::sample;
 use tracing::warn;
 use transaction::model::*;
+use utils::prelude::indexmap::IndexMap;
 
 use crate::mempool::*;
 
-use std::cmp::{max, Ordering};
+use std::cmp::{max, min, Ordering};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
@@ -167,27 +169,33 @@ impl PartialOrd for MempoolDataProposalPriorityOrdering {
     }
 }
 
-pub struct SimpleMempool {
+pub struct PriorityMempool {
+    /// Max number of different (by [`NotarizedTransactionHash`]) transactions that can live at any moment of time in the mempool.
     remaining_transaction_count: u32,
+    /// Max sum of transactions size that can live in [`self.data`].
     remaining_total_transactions_size: u64,
+    /// Keeps ordering of the transactions by proposal priority (best transaction is highest tip percentage and )
     proposal_priority_index: BTreeSet<MempoolDataProposalPriorityOrdering>,
-    data: HashMap<NotarizedTransactionHash, Arc<MempoolData>>,
+    /// Mapping from [`NotarizedTransactionHash`] to [`Arc<MempoolData>`] containing [`MempoolTransaction`] with said payload hash.
+    /// We use [`IndexMap`] for it's O(1) [`get_index`] needed for efficient random sampling.
+    data: IndexMap<NotarizedTransactionHash, Arc<MempoolData>>,
+    /// Mapping from [`IntentHash`] to all transactions ([`NotarizedTransactionHash`]) that submit said intent.
     intent_lookup: HashMap<IntentHash, HashSet<NotarizedTransactionHash>>,
 }
 
-impl SimpleMempool {
-    pub fn new(config: MempoolConfig) -> SimpleMempool {
-        SimpleMempool {
+impl PriorityMempool {
+    pub fn new(config: MempoolConfig) -> PriorityMempool {
+        PriorityMempool {
             remaining_transaction_count: config.max_transaction_count,
             remaining_total_transactions_size: config.max_total_transactions_size,
             proposal_priority_index: BTreeSet::new(),
-            data: HashMap::new(),
+            data: IndexMap::new(),
             intent_lookup: HashMap::new(),
         }
     }
 }
 
-impl SimpleMempool {
+impl PriorityMempool {
     /// ASSUMPTION: Mempool does not already contain the transaction (panics otherwise).
     /// Tries to add a new transaction into the mempool.
     /// Will return either a [`Vec`] of [`MempoolData`] that was evicted in order to fit the new transaction or an error
@@ -382,15 +390,18 @@ impl SimpleMempool {
         Some(&self.data.get(payload_hash)?.transaction)
     }
 
-    // This method needs to be removed. Consumers of SimpleMempool should not require full state retrieval.
-    pub fn get_all_transactions(&self) -> Vec<Arc<MempoolTransaction>> {
-        self.data
-            .values()
-            .map(|transaction_data| {
-                // Clone the Arc - this is relatively cheap
-                transaction_data.transaction.clone()
-            })
-            .collect()
+    /// Returns [`count`] randomly sampled transactions from the mempool.
+    /// If count is higher than the mempool size, all transaction are returned (in random order).
+    /// Complexity is given by [`sample`] which is usually O(count).
+    pub fn get_k_random_transactions(&self, count: usize) -> Vec<Arc<MempoolTransaction>> {
+        sample(
+            &mut rand::thread_rng(),
+            self.data.len(),
+            min(count, self.data.len()),
+        )
+        .into_iter()
+        .map(|index| self.data.get_index(index).unwrap().1.transaction.clone())
+        .collect()
     }
 
     /// Picks an subset of transactions to form the proposal.
@@ -437,7 +448,7 @@ mod tests {
     use transaction::model::*;
     use transaction::signing::secp256k1::Secp256k1Signature;
 
-    use crate::mempool::simple_mempool::*;
+    use crate::mempool::priority_mempool::*;
 
     fn create_fake_pub_key() -> PublicKey {
         PublicKey::Secp256k1(Secp256k1PublicKey([0; Secp256k1PublicKey::LENGTH]))
@@ -511,7 +522,7 @@ mod tests {
         let mt2 = create_fake_pending_transaction(2, 0, 0);
         let mt3 = create_fake_pending_transaction(3, 0, 0);
 
-        let mut mp = SimpleMempool::new(MempoolConfig {
+        let mut mp = PriorityMempool::new(MempoolConfig {
             max_transaction_count: 5,
             max_total_transactions_size: 2 * 1024 * 1024,
         });
@@ -559,7 +570,7 @@ mod tests {
         let intent_2_payload_1 = create_fake_pending_transaction(2, 1, 0);
         let intent_2_payload_2 = create_fake_pending_transaction(2, 2, 0);
 
-        let mut mp = SimpleMempool::new(MempoolConfig {
+        let mut mp = PriorityMempool::new(MempoolConfig {
             max_transaction_count: 10,
             max_total_transactions_size: 2 * 1024 * 1024,
         });
@@ -723,7 +734,7 @@ mod tests {
             now + Duration::from_secs(3),
         ];
 
-        let mut mp = SimpleMempool::new(MempoolConfig {
+        let mut mp = PriorityMempool::new(MempoolConfig {
             max_transaction_count: 4,
             max_total_transactions_size: 2 * 1024 * 1024,
         });

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -112,7 +112,7 @@ impl<S: ReadableStore + QueryableProofStore + TransactionIdentifierLoader> Trans
 mod tests {
     use crate::jni::state_manager::ActualStateManager;
     use crate::mempool_manager::MempoolManager;
-    use crate::simple_mempool::SimpleMempool;
+    use crate::priority_mempool::PriorityMempool;
     use crate::store::{DatabaseFlags, InMemoryStore, StateManagerDatabase};
     use crate::transaction::{
         CachedCommittabilityValidator, CommittabilityValidator, ExecutionConfigurator,
@@ -162,7 +162,7 @@ mod tests {
             committability_validator,
             pending_transaction_result_cache.clone(),
         );
-        let mempool = Arc::new(parking_lot::const_rwlock(SimpleMempool::new(
+        let mempool = Arc::new(parking_lot::const_rwlock(PriorityMempool::new(
             MempoolConfig {
                 max_total_transactions_size: 10 * 1024 * 1024,
                 max_transaction_count: 10,

--- a/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolFillAndEmptyTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolFillAndEmptyTest.java
@@ -101,6 +101,7 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Slow.class)
 public final class REv2MempoolFillAndEmptyTest {
+  private static final int MAX_MEMPOOL_TRANSACTION_COUNT = 1000;
   private static final Logger logger = LogManager.getLogger();
 
   private DeterministicTest createTest() {
@@ -121,7 +122,10 @@ public final class REv2MempoolFillAndEmptyTest {
                             Decimal.of(1),
                             GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(100000)),
                         REv2StateManagerModule.DatabaseType.IN_MEMORY,
-                        StateComputerConfig.REV2ProposerConfig.defaultMempool(
+                        StateComputerConfig.REV2ProposerConfig.mempool(
+                            10,
+                            10 * 1024 * 1024,
+                            new RustMempoolConfig(100 * 1024 * 1024, MAX_MEMPOOL_TRANSACTION_COUNT),
                             new MempoolRelayConfig(0, 100))),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
@@ -140,7 +144,7 @@ public final class REv2MempoolFillAndEmptyTest {
     var mempoolDispatcher =
         test.getInstance(0, Key.get(new TypeLiteral<EventDispatcher<MempoolAdd>>() {}));
 
-    while (mempoolReader.getCount() < 100) {
+    while (mempoolReader.getCount() < MAX_MEMPOOL_TRANSACTION_COUNT) {
       if (rateLimiter.tryAcquire()) {
         logger.info("Filling Mempool...  Current Size: {}", mempoolReader.getCount());
       }


### PR DESCRIPTION
This PR includes: 

- Remove the `get_all_transactions` in favour of `get_k_random_transactions` inside (formerly) `SimpleMempool` to be used by `MempoolManager`. 
- Rename `SimpleMempool` to `PriorityMempool`
- Fix a previously altered test