### PR TITLE
Introducing a common JNI call wrapper to surface all Rust panics as Java exceptions

### DIFF
--- a/core-rust/state-manager/src/jni/state_manager.rs
+++ b/core-rust/state-manager/src/jni/state_manager.rs
@@ -98,7 +98,9 @@ extern "system" fn Java_com_radixdlt_statemanager_StateManager_init(
     j_state_manager: JObject,
     j_config: jbyteArray,
 ) {
-    JNIStateManager::init(&env, j_state_manager, j_config);
+    jni_call(&env, || {
+        JNIStateManager::init(&env, j_state_manager, j_config)
+    });
 }
 
 #[no_mangle]
@@ -107,7 +109,7 @@ extern "system" fn Java_com_radixdlt_statemanager_StateManager_cleanup(
     _class: JClass,
     j_state_manager: JObject,
 ) {
-    JNIStateManager::cleanup(&env, j_state_manager);
+    jni_call(&env, || JNIStateManager::cleanup(&env, j_state_manager));
 }
 
 #[no_mangle]


### PR DESCRIPTION
This is the first part of the ["Handle panics nicer"](https://whimsical.com/babylon-work-tracker-Am2s7hSa7xHd5yCxgub67a@7YNFXnKbZAPNdd1f6K1ae) effort.

Some notes:
- The basic idea is captured in the title, and the impl details are captured in the rustdoc of `jni_call()`
  - Actually that `jni_call()` introduces a new "convention" that we must adhere to in our JNI layer, if we want to stay panic-safe (this PR propagates that convention across the current codebase)
- This PR does not introduce any new error-handling / exception-handling behavior; in particular:
  - Previously, a Rust `panic()` inside JNI was causing the app to shut down (in an "undefined behavior" way - but reliably)
  - After this PR, instead, a Java `RustPanicException` is unhandled in the RX loop, which initiates the hopefully-more-graceful shutdown + gives a nice continuation of the backtrace on Java's side