### PR TITLE
Accepting message as an argument to transaction preview endpoint

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -6014,6 +6014,9 @@ components:
           items:
             $ref: "#/components/schemas/PublicKey"
           description: A list of public keys to be used as transaction signers
+        message:
+          description: An optional transaction message. Only affects the costing.
+          $ref: "#/components/schemas/TransactionMessage"
         flags:
           type: object
           required:

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_preview_request.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_preview_request.rs
@@ -42,6 +42,8 @@ pub struct TransactionPreviewRequest {
     /// A list of public keys to be used as transaction signers
     #[serde(rename = "signer_public_keys")]
     pub signer_public_keys: Vec<crate::core_api::generated::models::PublicKey>,
+    #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
+    pub message: Option<Box<crate::core_api::generated::models::TransactionMessage>>,
     #[serde(rename = "flags")]
     pub flags: Box<crate::core_api::generated::models::TransactionPreviewRequestFlags>,
 }
@@ -59,6 +61,7 @@ impl TransactionPreviewRequest {
             tip_percentage,
             nonce,
             signer_public_keys,
+            message: None,
             flags: Box::new(flags),
         }
     }

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -104,6 +104,7 @@ pub(crate) async fn handle_transaction_callpreview(
                 assume_all_signature_proofs: true,
                 skip_epoch_check: true,
             },
+            message: MessageV1::None,
         })
         .map_err(|err| match err {
             PreviewError::TransactionValidationError(err) => {

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -100,7 +100,7 @@ impl<S: ReadableStore + QueryableProofStore + TransactionIdentifierLoader> Trans
                 },
                 instructions,
                 blobs,
-                message: MessageV1::None,
+                message: preview_request.message,
             },
             signer_public_keys: preview_request.signer_public_keys,
             flags: preview_request.flags,
@@ -129,7 +129,7 @@ mod tests {
     use radix_engine_common::network::NetworkDefinition;
     use std::sync::Arc;
     use transaction::builder::ManifestBuilder;
-    use transaction::model::PreviewFlags;
+    use transaction::model::{MessageV1, PreviewFlags};
 
     #[test]
     fn test_preview_processed_substate_changes() {
@@ -207,6 +207,7 @@ mod tests {
                 assume_all_signature_proofs: true,
                 skip_epoch_check: false,
             },
+            message: MessageV1::None,
         });
 
         // just checking that we're getting some processed substate changes back in the response

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -299,6 +299,7 @@ pub struct PreviewRequest {
     pub nonce: u32,
     pub signer_public_keys: Vec<PublicKey>,
     pub flags: PreviewFlags,
+    pub message: MessageV1,
 }
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionPreviewRequest.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionPreviewRequest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.radixdlt.api.core.generated.models.PublicKey;
+import com.radixdlt.api.core.generated.models.TransactionMessage;
 import com.radixdlt.api.core.generated.models.TransactionPreviewRequestFlags;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -45,6 +46,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   TransactionPreviewRequest.JSON_PROPERTY_TIP_PERCENTAGE,
   TransactionPreviewRequest.JSON_PROPERTY_NONCE,
   TransactionPreviewRequest.JSON_PROPERTY_SIGNER_PUBLIC_KEYS,
+  TransactionPreviewRequest.JSON_PROPERTY_MESSAGE,
   TransactionPreviewRequest.JSON_PROPERTY_FLAGS
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -78,6 +80,9 @@ public class TransactionPreviewRequest {
 
   public static final String JSON_PROPERTY_SIGNER_PUBLIC_KEYS = "signer_public_keys";
   private List<PublicKey> signerPublicKeys = new ArrayList<>();
+
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  private TransactionMessage message;
 
   public static final String JSON_PROPERTY_FLAGS = "flags";
   private TransactionPreviewRequestFlags flags;
@@ -366,6 +371,32 @@ public class TransactionPreviewRequest {
   }
 
 
+  public TransactionPreviewRequest message(TransactionMessage message) {
+    this.message = message;
+    return this;
+  }
+
+   /**
+   * Get message
+   * @return message
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public TransactionMessage getMessage() {
+    return message;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setMessage(TransactionMessage message) {
+    this.message = message;
+  }
+
+
   public TransactionPreviewRequest flags(TransactionPreviewRequestFlags flags) {
     this.flags = flags;
     return this;
@@ -414,12 +445,13 @@ public class TransactionPreviewRequest {
         Objects.equals(this.tipPercentage, transactionPreviewRequest.tipPercentage) &&
         Objects.equals(this.nonce, transactionPreviewRequest.nonce) &&
         Objects.equals(this.signerPublicKeys, transactionPreviewRequest.signerPublicKeys) &&
+        Objects.equals(this.message, transactionPreviewRequest.message) &&
         Objects.equals(this.flags, transactionPreviewRequest.flags);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(network, manifest, blobsHex, startEpochInclusive, endEpochExclusive, notaryPublicKey, notaryIsSignatory, tipPercentage, nonce, signerPublicKeys, flags);
+    return Objects.hash(network, manifest, blobsHex, startEpochInclusive, endEpochExclusive, notaryPublicKey, notaryIsSignatory, tipPercentage, nonce, signerPublicKeys, message, flags);
   }
 
   @Override
@@ -436,6 +468,7 @@ public class TransactionPreviewRequest {
     sb.append("    tipPercentage: ").append(toIndentedString(tipPercentage)).append("\n");
     sb.append("    nonce: ").append(toIndentedString(nonce)).append("\n");
     sb.append("    signerPublicKeys: ").append(toIndentedString(signerPublicKeys)).append("\n");
+    sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    flags: ").append(toIndentedString(flags)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/core/src/test/java/com/radixdlt/api/core/TransactionPreviewTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/TransactionPreviewTest.java
@@ -1,0 +1,138 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+package com.radixdlt.api.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.radixdlt.api.DeterministicCoreApiTestBase;
+import com.radixdlt.api.core.generated.models.*;
+import com.radixdlt.rev2.Manifest;
+import com.radixdlt.utils.Bytes;
+import com.radixdlt.utils.PrivateKeys;
+import org.junit.Test;
+
+public class TransactionPreviewTest extends DeterministicCoreApiTestBase {
+  @Test
+  public void transaction_previewed_with_message_consumes_more_cost_units() throws Exception {
+    try (var test = buildRunningServerTest()) {
+      test.suppressUnusedWarning();
+
+      // Prepare a base request (no message)
+      var manifest = Manifest.valid().apply(new Manifest.Parameters(networkDefinition));
+      var baseRequest =
+          new TransactionPreviewRequest()
+              .network(networkLogicalName)
+              .startEpochInclusive(0L)
+              .endEpochExclusive(100L)
+              .tipPercentage(1)
+              .nonce(10L)
+              .flags(
+                  new TransactionPreviewRequestFlags()
+                      .useFreeCredit(true)
+                      .assumeAllSignatureProofs(true)
+                      .skipEpochCheck(true))
+              .manifest(manifest);
+
+      // Prepare a complex message separately
+      var largeEncryptedMessage =
+          new EncryptedTransactionMessage()
+              .encryptedHex(Bytes.toHexString(new byte[1000]))
+              .addCurveDecryptorSetsItem(
+                  new EncryptedMessageCurveDecryptorSet()
+                      .dhEphemeralPublicKey(
+                          new EcdsaSecp256k1PublicKey()
+                              .keyHex(
+                                  Bytes.toHexString(
+                                      PrivateKeys.ofNumeric(1)
+                                          .getPublicKey()
+                                          .getCompressedBytes())))
+                      .addDecryptorsItem(
+                          new EncryptedMessageDecryptor()
+                              .publicKeyFingerprintHex(Bytes.toHexString(new byte[8]))
+                              .aesWrappedKeyHex(Bytes.toHexString(new byte[24]))));
+
+      // Ask for costing of a base request
+      var noMessageCost =
+          getTransactionApi()
+              .transactionPreviewPost(baseRequest)
+              .getReceipt()
+              .getFeeSummary()
+              .getCostUnitsConsumed();
+
+      // Ask for costing of a preview request with a large message
+      var largeEncryptedMessageCost =
+          getTransactionApi()
+              .transactionPreviewPost(baseRequest.message(largeEncryptedMessage))
+              .getReceipt()
+              .getFeeSummary()
+              .getCostUnitsConsumed();
+
+      // Message should add some cost
+      // TODO(after fix in the Engine): this should assert `.isGreaterThan()`, as the test's name
+      // suggests
+      assertThat(largeEncryptedMessageCost).isEqualTo(noMessageCost);
+    }
+  }
+}


### PR DESCRIPTION
A follow up to https://github.com/radixdlt/babylon-node/pull/540.

Apparently the costing of messages (in preview) is bugged now, but I added the test anyway (and hopefully it will fail on next scrypto update, and my TODO will tell the poor soul how to fix it).