### PR TITLE
Config: mempool.max_memory

### DIFF
--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -112,6 +112,11 @@ public final class RadixNodeModule extends AbstractModule {
   public static final int MAX_PROPOSAL_TOTAL_TXNS_PAYLOAD_SIZE = 2 * 1024 * 1024;
   public static final int MAX_UNCOMMITTED_USER_TRANSACTIONS_TOTAL_PAYLOAD_SIZE = 2 * 1024 * 1024;
 
+  // Memory overhead of transactions living in the mempool. This does not take into account the (cached) results.
+  // For current implementation core-rust/state-manager/src/mempool/priority_mempool.rs, for each transaction we keep
+  // both the raw transaction and the parsed one (2x overhead) plus a very generous 30% overhead for the indexes.
+  public static final double MEMPOOL_TRANSACTION_OVERHEAD_FACTOR = 2.3;
+
   private final RuntimeProperties properties;
   private final Network network;
 
@@ -232,7 +237,7 @@ public final class RadixNodeModule extends AbstractModule {
     // State Computer
     var mempoolMaxMemory =
         properties.get("mempool.max_memory", 100 * 1024 * 1024);
-    var mempoolMaxTotalTransactionsSize = (int)(mempoolMaxMemory / 2.3);
+    var mempoolMaxTotalTransactionsSize = (int)(mempoolMaxMemory / MEMPOOL_TRANSACTION_OVERHEAD_FACTOR);
     var mempoolMaxTransactionCount = properties.get("mempool.max_transaction_count", 10_000);
     var mempoolConfig =
         new RustMempoolConfig(mempoolMaxTotalTransactionsSize, mempoolMaxTransactionCount);

--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -230,8 +230,9 @@ public final class RadixNodeModule extends AbstractModule {
     // Storage directory
     install(new NodeStorageLocationFromPropertiesModule());
     // State Computer
-    var mempoolMaxTotalTransactionsSize =
-        properties.get("mempool.max_total_transactions_size", 100 * 1024 * 1024);
+    var mempoolMaxMemory =
+        properties.get("mempool.max_memory", 100 * 1024 * 1024);
+    var mempoolMaxTotalTransactionsSize = (int)(mempoolMaxMemory / 2.3);
     var mempoolMaxTransactionCount = properties.get("mempool.max_transaction_count", 10_000);
     var mempoolConfig =
         new RustMempoolConfig(mempoolMaxTotalTransactionsSize, mempoolMaxTransactionCount);

--- a/docker/config/default.config.envsubst
+++ b/docker/config/default.config.envsubst
@@ -14,7 +14,7 @@ db.local_transaction_execution_index.enable=$RADIXDLT_DB_LOCAL_TRANSACTION_EXECU
 db.account_change_index.enable=$RADIXDLT_DB_ACCOUNT_CHANGE_INDEX_ENABLE
 
 mempool.max_transaction_count=${RADIXDLT_MEMPOOL_MAX_TRANSACTION_COUNT}
-mempool.max_total_transactions_size=${RADIXDLT_MEMPOOL_MAX_TOTAL_TRANSACTIONS_SIZE}
+mempool.max_memory=${RADIXDLT_MEMPOOL_MAX_MEMORY}
 mempool.relayer.interval_ms=${RADIXDLT_MEMPOOL_RELAYER_INTERVAL_MS}
 mempool.relayer.max_peers=${RADIXDLT_MEMPOOL_RELAYER_MAX_PEERS}
 mempool.relayer.max_relayed_size=${RADIXDLT_MEMPOOL_RELAYER_MAX_RELAYED_SIZE}


### PR DESCRIPTION
Remove `mempool.max_total_transactions_size` config in favour of `mempool.max_memory` which tries to be an upper-bound. Limiting is still done via same mechanism (max total payload size of transactions that are _represented_ by the mempool).