### PR TITLE
Shutdown the Node completely (in Prod, in SimulationTest) on uncaught rx-java exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,10 +120,6 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: Run steady-state integration tests
         # If you need better logging, you should add --info to the below command to output application logs.
-        #   This is useful to debug failures caused by an uncaught exception.
-        #   In this case, the node calls System.exit(X), which appear in the integration test logs
-        #   as something like:
-        # "Process 'Gradle Test Executor 1' finished with non-zero exit value 255"
         run: ./gradlew clean runSteadyStateIntegrationTests --refresh-dependencies
   targeted-integration:
     name: Targeted integration tests
@@ -151,10 +147,6 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: Run targeted integration tests
         # If you need better logging, you should add --info to the below command to output application logs.
-        #   This is useful to debug failures caused by an uncaught exception.
-        #   In this case, the node calls System.exit(X), which appear in the integration test logs
-        #   as something like:
-        # "Process 'Gradle Test Executor 1' finished with non-zero exit value 255"
         run: ./gradlew clean runTargetedIntegrationTests --refresh-dependencies --parallel
   cross-xwin:
     name: Cross compile to Windows

--- a/cli-tools/src/main/java/com/radixdlt/shell/RadixShell.java
+++ b/cli-tools/src/main/java/com/radixdlt/shell/RadixShell.java
@@ -235,8 +235,7 @@ public final class RadixShell {
 
     public Node(Injector injector) {
       this.injector = injector;
-      this.moduleRunners =
-          injector.getInstance(Key.get(new TypeLiteral<Map<String, ModuleRunner>>() {}));
+      this.moduleRunners = injector.getInstance(Key.get(new TypeLiteral<>() {}));
     }
 
     public <T> T getInstance(Key<T> key) {
@@ -248,7 +247,13 @@ public final class RadixShell {
     }
 
     public void startRunner(String runner) {
-      moduleRunners.get(runner).start();
+      moduleRunners
+          .get(runner)
+          .start(
+              error -> {
+                log.error("Unhandled exception in runner {}; stopping all runners", runner, error);
+                moduleRunners.values().forEach(ModuleRunner::stop);
+              });
     }
 
     public void stopRunner(String runner) {

--- a/cli-tools/src/main/java/com/radixdlt/shell/RadixShell.java
+++ b/cli-tools/src/main/java/com/radixdlt/shell/RadixShell.java
@@ -251,7 +251,7 @@ public final class RadixShell {
           .get(runner)
           .start(
               error -> {
-                log.error("Unhandled exception in runner {}; stopping all runners", runner, error);
+                log.error("Uncaught exception in runner {}; stopping all runners", runner, error);
                 moduleRunners.values().forEach(ModuleRunner::stop);
               });
     }

--- a/core/src/main/java/com/radixdlt/RadixNodeApplication.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeApplication.java
@@ -126,7 +126,7 @@ public final class RadixNodeApplication {
                   runningNode.self(),
                   startupTime.toMillis());
               runningNode.reportSelfStartupTime(startupTime);
-              Runtime.getRuntime().addShutdownHook(new Thread(runningNode::shutdown));
+              runningNode.installShutdownHook();
             })
         // Call .join() to block on the future completing, ensuring that errors during
         // bootstrapping are not swallowed, and propagate to the "Unable to start" handler.

--- a/core/src/main/java/com/radixdlt/RadixNodeApplication.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeApplication.java
@@ -136,8 +136,7 @@ public final class RadixNodeApplication {
   }
 
   private static void exitWithError() {
-    // This (or more likely, the one in ModuleRunnerImpl.java) may cause integration test errors
-    // which look like:
+    // When this happens, the integration test errors look like:
     // "Process 'Gradle Test Executor 1' finished with non-zero exit value 255"
     java.lang.System.exit(-1);
   }

--- a/core/src/main/java/com/radixdlt/RadixNodeApplication.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeApplication.java
@@ -116,7 +116,7 @@ public final class RadixNodeApplication {
     */
     Runtime.getRuntime()
         .addShutdownHook(
-            new Thread(radixNodeBootstrapperHandle::shutdown, "Bootstrapper-Shutdown"));
+            new Thread(radixNodeBootstrapperHandle::onShutdown, "Bootstrapper-Shutdown"));
     radixNodeBootstrapperHandle
         .radixNodeFuture()
         .thenAccept(
@@ -129,7 +129,7 @@ public final class RadixNodeApplication {
                   startupTime.toMillis());
               runningNode.reportSelfStartupTime(startupTime);
               Runtime.getRuntime()
-                  .addShutdownHook(new Thread(runningNode::shutdown, "Node-Shutdown"));
+                  .addShutdownHook(new Thread(runningNode::onShutdown, "Node-Shutdown"));
             })
         // Call .join() to block on the future completing, ensuring that errors during
         // bootstrapping are not swallowed, and propagate to the "Unable to start" handler.

--- a/core/src/main/java/com/radixdlt/RunningRadixNode.java
+++ b/core/src/main/java/com/radixdlt/RunningRadixNode.java
@@ -90,7 +90,6 @@ import org.apache.logging.log4j.Logger;
 
 public final class RunningRadixNode {
   private static final Logger log = LogManager.getLogger();
-  public static RunningRadixNode ki;
 
   private final Injector injector;
 
@@ -126,8 +125,8 @@ public final class RunningRadixNode {
       final var moduleRunner = moduleRunners.get(module);
       moduleRunner.start(
           error -> {
-            log.error("Unhandled exception in runner {}; shutting down the node", module, error);
-            runningNode.shutdown();
+            log.error("Uncaught exception in runner {}; shutting down the node", module, error);
+            runningNode.shutdownFromModule(String.format("an error in runner %s", module));
           });
     }
 
@@ -164,16 +163,16 @@ public final class RunningRadixNode {
     Runtime.getRuntime().addShutdownHook(hook);
   }
 
-  public void shutdown() {
+  private void shutdownFromModule(String reason) {
     final @Nullable Thread hook = this.shutdownHook.getAndSet(null);
     if (hook != null) {
       Runtime.getRuntime().removeShutdownHook(hook);
     }
-    doShutdown("internal reasons");
+    doShutdown(reason);
   }
 
   private void shutdownFromHook() {
-    doShutdown("a shutdown hook");
+    doShutdown("a requested shutdown (via the Java shutdown hook)");
   }
 
   private void doShutdown(String reason) {

--- a/core/src/main/java/com/radixdlt/RunningRadixNode.java
+++ b/core/src/main/java/com/radixdlt/RunningRadixNode.java
@@ -150,7 +150,7 @@ public final class RunningRadixNode {
     this.injector.getInstance(Metrics.class).misc().nodeStartup().observe(startupTimeMs);
   }
 
-  public void shutdown() {
+  public void onShutdown() {
     // using System.out.printf as logger no longer works reliably in a shutdown hook
     System.out.printf("Node %s is shutting down...\n", this.self());
 

--- a/core/src/main/java/com/radixdlt/bootstrap/RadixNodeBootstrapper.java
+++ b/core/src/main/java/com/radixdlt/bootstrap/RadixNodeBootstrapper.java
@@ -105,7 +105,7 @@ public final class RadixNodeBootstrapper {
   public sealed interface RadixNodeBootstrapperHandle {
     CompletableFuture<UnstartedRadixNode> radixNodeFuture();
 
-    void shutdown();
+    void onShutdown();
 
     record Resolved(UnstartedRadixNode radixNode) implements RadixNodeBootstrapperHandle {
       @Override
@@ -114,7 +114,7 @@ public final class RadixNodeBootstrapper {
       }
 
       @Override
-      public void shutdown() {
+      public void onShutdown() {
         // no-op
       }
     }
@@ -127,7 +127,7 @@ public final class RadixNodeBootstrapper {
       }
 
       @Override
-      public void shutdown() {
+      public void onShutdown() {
         olympiaGenesisBootstrapper.cleanup();
       }
     }
@@ -139,7 +139,7 @@ public final class RadixNodeBootstrapper {
       }
 
       @Override
-      public void shutdown() {
+      public void onShutdown() {
         // no-op
       }
     }

--- a/core/src/main/java/com/radixdlt/modules/ModuleRunner.java
+++ b/core/src/main/java/com/radixdlt/modules/ModuleRunner.java
@@ -64,10 +64,15 @@
 
 package com.radixdlt.modules;
 
+import java.util.function.Consumer;
+
 /** Manages a module */
 public interface ModuleRunner {
-  /** Start running the module */
-  void start();
+  /**
+   * Start running the module. The given error handler will be notified each time an unhandled
+   * exception escapes the module's worker thread.
+   */
+  void start(Consumer<Throwable> errorHandler);
 
   /** Stop running the module */
   void stop();

--- a/core/src/main/java/com/radixdlt/modules/ModuleRunner.java
+++ b/core/src/main/java/com/radixdlt/modules/ModuleRunner.java
@@ -69,8 +69,12 @@ import java.util.function.Consumer;
 /** Manages a module */
 public interface ModuleRunner {
   /**
-   * Start running the module. The given error handler will be notified each time an unhandled
-   * exception escapes the module's worker thread.
+   * Start running the module.
+   *
+   * <p>The given error handler will be notified each time an unhandled exception escapes the
+   * module's worker thread. The handler's responsibility is only to perform a clean-up of this
+   * module (and then an application exit, or a re-instantiation). In other words: it should be
+   * assumed that a module instance is not operational after reporting its very first error.
    */
   void start(Consumer<Throwable> errorHandler);
 

--- a/core/src/test-core/java/com/radixdlt/harness/simulation/network/SimulationNodes.java
+++ b/core/src/test-core/java/com/radixdlt/harness/simulation/network/SimulationNodes.java
@@ -255,14 +255,12 @@ public class SimulationNodes {
           .entrySet()
           .stream()
           .filter(not(e -> nodeDisabledModuleRunners.contains(e.getKey())))
-          .forEach(
-              e ->
-                  e.getValue()
-                      .start(
-                          error -> {
-                            log.error("uncaught {} error; stopping the network", e.getKey(), error);
-                            this.stop();
-                          }));
+          .forEach(e -> e.getValue().start(error -> this.onModuleError(e.getKey(), error)));
+    }
+
+    private void onModuleError(String module, Throwable error) {
+      log.error("Uncaught error from module {}; stopping the network", module, error);
+      this.stop();
     }
 
     private void addObservables(NodeId node, Injector injector) {

--- a/core/src/test-core/java/com/radixdlt/harness/simulation/network/SimulationNodes.java
+++ b/core/src/test-core/java/com/radixdlt/harness/simulation/network/SimulationNodes.java
@@ -98,6 +98,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /** A multi-node bft test network where the network and latencies of each message is simulated. */
 public class SimulationNodes {
@@ -195,6 +197,8 @@ public class SimulationNodes {
   }
 
   private class RunningNetworkImpl implements RunningNetwork {
+    private static final Logger log = LogManager.getLogger();
+
     private final ImmutableMap<NodeId, ImmutableSet<String>> disabledModuleRunners;
     private final Map<NodeId, Injector> nodes;
 
@@ -251,7 +255,14 @@ public class SimulationNodes {
           .entrySet()
           .stream()
           .filter(not(e -> nodeDisabledModuleRunners.contains(e.getKey())))
-          .forEach(e -> e.getValue().start());
+          .forEach(
+              e ->
+                  e.getValue()
+                      .start(
+                          error -> {
+                            log.error("uncaught {} error; stopping the network", e.getKey(), error);
+                            this.stop();
+                          }));
     }
 
     private void addObservables(NodeId node, Injector injector) {
@@ -339,7 +350,12 @@ public class SimulationNodes {
           .get(node)
           .getInstance(Key.get(new TypeLiteral<Map<String, ModuleRunner>>() {}))
           .get(name)
-          .start();
+          .start(
+              error -> {
+                log.error(
+                    "uncaught error in individually run {}; stopping the network", name, error);
+                this.stop();
+              });
     }
 
     @Override

--- a/core/src/test/java/com/radixdlt/mempool/MempoolRunnerTest.java
+++ b/core/src/test/java/com/radixdlt/mempool/MempoolRunnerTest.java
@@ -152,7 +152,7 @@ public final class MempoolRunnerTest {
   @Test
   public void dispatched_mempool_add_arrives_at_state_computer() {
     Guice.createInjector(createModule()).injectMembers(this);
-    moduleRunners.get(Runners.MEMPOOL).start(error -> log.error("uncaught runner error", error));
+    moduleRunners.get(Runners.MEMPOOL).start(error -> log.error("Uncaught runner error", error));
 
     MempoolAdd mempoolAdd = MempoolAdd.create(RawNotarizedTransaction.create(new byte[0]));
     mempoolAddEventDispatcher.dispatch(mempoolAdd);

--- a/core/src/test/java/com/radixdlt/mempool/MempoolRunnerTest.java
+++ b/core/src/test/java/com/radixdlt/mempool/MempoolRunnerTest.java
@@ -100,9 +100,13 @@ import com.radixdlt.utils.TimeSupplier;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.Comparator;
 import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 
 public final class MempoolRunnerTest {
+  private static final Logger log = LogManager.getLogger();
+
   @Inject private Map<String, ModuleRunner> moduleRunners;
   @Inject private EventDispatcher<MempoolAdd> mempoolAddEventDispatcher;
 
@@ -148,7 +152,7 @@ public final class MempoolRunnerTest {
   @Test
   public void dispatched_mempool_add_arrives_at_state_computer() {
     Guice.createInjector(createModule()).injectMembers(this);
-    moduleRunners.get(Runners.MEMPOOL).start();
+    moduleRunners.get(Runners.MEMPOOL).start(error -> log.error("uncaught runner error", error));
 
     MempoolAdd mempoolAdd = MempoolAdd.create(RawNotarizedTransaction.create(new byte[0]));
     mempoolAddEventDispatcher.dispatch(mempoolAdd);


### PR DESCRIPTION
This fixes the problem overlooked by https://github.com/radixdlt/babylon-node/pull/550, described at https://github.com/radixdlt/babylon-node/pull/550#issuecomment-1638094885.

Here is an example log for a failing `com.radixdlt.integration.steady_state.simulation.rev2.consensus_mempool_ledger_sync.SanityTest` after this PR:

```
... // Node runs
# 2023-07-18T13:35:01,953 [INFO/EventLoggerModule/BFT no...x3x8kavk8] (EventLoggerModule.java:249) - lgr_commit{epoch=2 round=109 version=115 txn_root=579900040f428f89 user_txns=0}
# 2023-07-18T13:35:01,953 [INFO/EventLoggerModule/BFT no...m0jvla7jl] (EventLoggerModule.java:249) - lgr_commit{epoch=2 round=109 version=115 txn_root=579900040f428f89 user_txns=0}
... // one of the rx-java workers gets an uncaught error (here, caused by a rust panic, but that's not a requirement)
# 2023-07-18T13:35:02,601 [ERROR/RunningNetworkImpl/BFT no...0w20kj09v] (SimulationNodes.java:263) - uncaught consensus error; stopping the network
com.radixdlt.exceptions.RustPanicException: random panic in prepare
	at com.radixdlt.statecomputer.RustStateComputer.prepare(Native Method) ~[core-rust-bridge-SNAPSHOT-refactor~complete_shutdown_on_uncaught_rx_error-809ae27093.jar:?]
	at com.radixdlt.sbor.Natives.lambda$builder$0(Natives.java:140) ~[core-rust-bridge-SNAPSHOT-refactor~complete_shutdown_on_uncaught_rx_error-809ae27093.jar:?]
	... // snipped
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]


Expecting all elements of:
  {CONSENSUS_SAFETY=Optional.empty, CONSENSUS_LIVENESS=Optional[TestInvariantError{desc=Highest QC hasn't increased from EpochRound{epoch=2 round=116} after 10 SECONDS}], CONSENSUS_NO_TIMEOUTS=Optional.empty, CONSENSUS_NO_EPOCH_TIMEOUTS=Optional.empty, CONSENSUS_DIRECT_PARENTS=Optional.empty, CONSENSUS_TO_LEDGER_PROCESSED=Optional.empty, PROPOSER_TIMESTAMP_CHECK=Optional.empty, LEDGER_IN_ORDER=Optional.empty}
to satisfy given requirements, but these elements did not:

... // the test fails due to liveness break (because of entire network being shut down)
CONSENSUS_LIVENESS=Optional[TestInvariantError{desc=Highest QC hasn't increased from EpochRound{epoch=2 round=116} after 10 SECONDS}]
error: 
Expecting an empty Optional but was containing value: TestInvariantError{desc=Highest QC hasn't increased from EpochRound{epoch=2 round=116} after 10 SECONDS}
java.lang.AssertionError: 
Expecting all elements of:
  {CONSENSUS_SAFETY=Optional.empty, CONSENSUS_LIVENESS=Optional[TestInvariantError{desc=Highest QC hasn't increased from EpochRound{epoch=2 round=116} after 10 SECONDS}], CONSENSUS_NO_TIMEOUTS=Optional.empty, CONSENSUS_NO_EPOCH_TIMEOUTS=Optional.empty, CONSENSUS_DIRECT_PARENTS=Optional.empty, CONSENSUS_TO_LEDGER_PROCESSED=Optional.empty, PROPOSER_TIMESTAMP_CHECK=Optional.empty, LEDGER_IN_ORDER=Optional.empty}
to satisfy given requirements, but these elements did not:

CONSENSUS_LIVENESS=Optional[TestInvariantError{desc=Highest QC hasn't increased from EpochRound{epoch=2 round=116} after 10 SECONDS}]
error: 
Expecting an empty Optional but was containing value: TestInvariantError{desc=Highest QC hasn't increased from EpochRound{epoch=2 round=116} after 10 SECONDS}
	at com.radixdlt.integration.steady_state.simulation.rev2.consensus_mempool_ledger_sync.SanityTest.rev2_consensus_mempool_ledger_sync_cause_no_unexpected_errors(SanityTest.java:141)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	... // usual Gradle log
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)


OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[2m2023-07-18T11:34:46.476326Z[0m [32m INFO[0m [2mstate_manager::state_manager[0m[2m:[0m Committing system flash
[2m2023-07-18T11:34:46.483754Z[0m [32m INFO[0m [2mstate_manager::state_manager[0m[2m:[0m Committing system bootstrap
... // rust logs, printed after java logs for unclear reasons, as they always are
[2m2023-07-18T11:34:47.579982Z[0m [32m INFO[0m [2mstate_manager::state_manager[0m[2m:[0m Genesis transactions successfully executed in 188.245ms
thread '<unnamed>' panicked at 'random panic in prepare', state-manager/src/state_manager.rs:330:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[0K[1mcom.radixdlt.integration.steady_state.simulation.rev2.consensus_mempool_ledger_sync.SanityTest[22m rev2_consensus_mempool_ledger_sync_cause_no_unexpected_errors[31m FAILED[31m (29.4s)[31m
```
