### PR TITLE
Refactor metrics

### DIFF
--- a/core-rust/node-common/src/metrics.rs
+++ b/core-rust/node-common/src/metrics.rs
@@ -1,0 +1,205 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+use prometheus::core::*;
+use prometheus::*;
+use radix_engine_common::types::ComponentAddress;
+
+/// A syntactic sugar trait allowing for an inline "create + register" metric definition.
+pub trait AtDefaultRegistryExt<R> {
+    /// Unwraps a Prometheus metric creation `Result` and registers it at the given registry.
+    fn registered_at(self, registry: &Registry) -> R;
+}
+
+impl<T: Collector + Clone + 'static> AtDefaultRegistryExt<T> for Result<T> {
+    fn registered_at(self, registry: &Registry) -> T {
+        let collector = self.unwrap();
+        registry.register(Box::new(collector.clone())).unwrap();
+        collector
+    }
+}
+
+pub fn opts(name: &str, help: &str) -> Opts {
+    Opts::new(format!("rn_{name}"), help)
+}
+
+pub fn new_histogram(opts: Opts, buckets: Vec<f64>) -> Result<Histogram> {
+    Histogram::with_opts(HistogramOpts::from(opts).buckets(buckets))
+}
+
+pub fn equidistant_buckets(number_of_buckets: usize, min: f64, max: f64) -> Vec<f64> {
+    let range = max - min;
+    (1..number_of_buckets + 1)
+        .map(|bucket| {
+            let bucket = bucket as f64 / number_of_buckets as f64;
+
+            bucket * range + min
+        })
+        .collect()
+}
+
+// Given a limit, builds buckets for a Histogram with higher resolution for higher values.
+// This gives percentile buckets: 0-25, 25-50, 50-75, 75-80, 80-85, 85-90, 90-92, 92-94, 94-96, 96-98, 98-100
+pub fn higher_resolution_for_higher_values_buckets_for_limit(limit: usize) -> Vec<f64> {
+    let limit = limit as f64;
+    let mut buckets = equidistant_buckets(3, 0.0, 0.75 * limit);
+    buckets.extend(equidistant_buckets(3, 0.75 * limit, 0.9 * limit));
+    buckets.extend(equidistant_buckets(5, 0.9 * limit, limit));
+    buckets
+}
+
+// Given a limit, builds buckets for a Histogram with higher resolution for lower values.
+// This gives percentile buckets: 0-2, 2-4, 4-6, 6-8, 8-10, 10-15, 15-20, 20-25, 25-50, 50-75, 75-100
+pub fn higher_resolution_for_lower_values_buckets_for_limit(limit: usize) -> Vec<f64> {
+    let limit = limit as f64;
+    let mut buckets = equidistant_buckets(5, 0.0, 0.1 * limit);
+    buckets.extend(equidistant_buckets(3, 0.1 * limit, 0.25 * limit));
+    buckets.extend(equidistant_buckets(3, 0.25 * limit, limit));
+    buckets
+}
+
+/// Creates a new `Histogram` tailored to measuring time durations.
+/// The name (found in `Opts`) is expected to be a verb (describing the measured action) and will be
+/// auto-suffixed with a conventional `_seconds` string. The measurements are thus expected to be
+/// reported in seconds (possibly fractional).
+/// The buckets should represent expected interesting ranges of the measurements (i.e. their upper
+/// bounds). The last `+inf` bucket will be auto-added - this means that an empty bucket list may be
+/// passed here, and the timer will work in a `Summary` mode (i.e. tracking just sum and count).
+pub fn new_timer(opts: Opts, buckets: Vec<f64>) -> Result<Histogram> {
+    let mut adjusted_opts = opts;
+    adjusted_opts.name = format!("{}_seconds", adjusted_opts.name);
+    let mut adjusted_buckets = buckets;
+    adjusted_buckets.push(f64::INFINITY);
+    new_histogram(adjusted_opts, adjusted_buckets)
+}
+
+// TODO - capture the metric types on a generic wrapper around the GenericCounter, and ensure the provided labels match the types, like in Java.
+pub trait TakesMetricLabels {
+    type Metric;
+
+    fn with_label(&self, label1: impl MetricLabel) -> Self::Metric;
+    fn with_two_labels(&self, label1: impl MetricLabel, label2: impl MetricLabel) -> Self::Metric;
+    fn with_three_labels(
+        &self,
+        label1: impl MetricLabel,
+        label2: impl MetricLabel,
+        label3: impl MetricLabel,
+    ) -> Self::Metric;
+}
+
+impl<T: MetricVecBuilder> TakesMetricLabels for MetricVec<T> {
+    type Metric = <T as MetricVecBuilder>::M;
+
+    fn with_label(&self, label1: impl MetricLabel) -> Self::Metric {
+        self.with_label_values(&[label1.prometheus_label_name().as_ref()])
+    }
+
+    fn with_two_labels(&self, label1: impl MetricLabel, label2: impl MetricLabel) -> Self::Metric {
+        self.with_label_values(&[
+            label1.prometheus_label_name().as_ref(),
+            label2.prometheus_label_name().as_ref(),
+        ])
+    }
+
+    fn with_three_labels(
+        &self,
+        label1: impl MetricLabel,
+        label2: impl MetricLabel,
+        label3: impl MetricLabel,
+    ) -> Self::Metric {
+        self.with_label_values(&[
+            label1.prometheus_label_name().as_ref(),
+            label2.prometheus_label_name().as_ref(),
+            label3.prometheus_label_name().as_ref(),
+        ])
+    }
+}
+
+/// Typically applied to enums or Errors where we wish to derive a label name.
+/// Note the label name returned should be in a fixed, small-ish sized-set, to prevent
+/// issues with tracking too many metrics, or combinatorial explosion of metrics with different labels.
+pub trait MetricLabel {
+    /// Typically &str, but could also be String if it's dynamic (as long as it's in a fixed small set)
+    type StringReturnType: AsRef<str>;
+
+    /// Returns the string label associated with this enum value.
+    fn prometheus_label_name(&self) -> Self::StringReturnType;
+}
+
+/// We implement it for &T so that you can pass references in to function parameters taking `impl MetricLabel`
+impl<T: MetricLabel> MetricLabel for &T {
+    type StringReturnType = <T as MetricLabel>::StringReturnType;
+
+    fn prometheus_label_name(&self) -> Self::StringReturnType {
+        T::prometheus_label_name(self)
+    }
+}
+
+impl MetricLabel for ComponentAddress {
+    type StringReturnType = String;
+
+    fn prometheus_label_name(&self) -> Self::StringReturnType {
+        self.to_hex()
+    }
+}

--- a/core-rust/state-manager/src/jni/state_manager.rs
+++ b/core-rust/state-manager/src/jni/state_manager.rs
@@ -226,6 +226,7 @@ impl JNIStateManager {
         );
         let mempool = Arc::new(parking_lot::const_rwlock(PriorityMempool::new(
             mempool_config,
+            &metric_registry,
         )));
         let mempool_relay_dispatcher = MempoolRelayDispatcher::new(env, j_state_manager).unwrap();
         let mempool_manager = Arc::new(MempoolManager::new(

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::mempool::metrics::MempoolMetrics;
+use super::metrics::MempoolManagerMetrics;
 use crate::mempool::priority_mempool::*;
 use crate::mempool::*;
 use crate::MempoolAddSource;
@@ -88,7 +88,7 @@ pub struct MempoolManager {
     mempool: Arc<RwLock<PriorityMempool>>,
     relay_dispatcher: Option<MempoolRelayDispatcher>,
     cached_committability_validator: CachedCommittabilityValidator<StateManagerDatabase>,
-    metrics: MempoolMetrics,
+    metrics: MempoolManagerMetrics,
 }
 
 impl MempoolManager {
@@ -103,7 +103,7 @@ impl MempoolManager {
             mempool,
             relay_dispatcher: Some(relay_dispatcher),
             cached_committability_validator,
-            metrics: MempoolMetrics::new(metric_registry),
+            metrics: MempoolManagerMetrics::new(metric_registry),
         }
     }
 
@@ -117,7 +117,7 @@ impl MempoolManager {
             mempool,
             relay_dispatcher: None,
             cached_committability_validator,
-            metrics: MempoolMetrics::new(metric_registry),
+            metrics: MempoolManagerMetrics::new(metric_registry),
         }
     }
 }
@@ -200,23 +200,16 @@ impl MempoolManager {
 
         if !transactions_to_remove.is_empty() {
             let mut write_mempool = self.mempool.write();
-            let removed = transactions_to_remove
+            transactions_to_remove
                 .iter()
-                .filter_map(|transaction_to_remove| {
+                .for_each(|transaction_to_remove| {
                     write_mempool.remove_by_payload_hash(
                         &transaction_to_remove
                             .validated
                             .prepared
                             .notarized_transaction_hash(),
-                    )
-                })
-                .fold(TransactionSizeAccumulator::new(), |acc, evicted| {
-                    acc.accumulate(&evicted.transaction)
+                    );
                 });
-            self.metrics.current_transactions.sub(removed.count as i64);
-            self.metrics
-                .current_total_transactions_size
-                .sub(removed.bytes as i64);
         }
     }
 
@@ -307,19 +300,7 @@ impl MempoolManager {
                     source,
                     Instant::now(),
                 ) {
-                    Ok(evicted) => {
-                        self.metrics.submission_added.with_label(source).inc();
-                        self.metrics
-                            .current_transactions
-                            .add(1 - evicted.len() as i64);
-                        let evicted_size = evicted.into_iter().fold(0, |sum, evicted| {
-                            sum - evicted.transaction.raw.0.len() as i64
-                        });
-                        self.metrics
-                            .current_total_transactions_size
-                            .add(mempool_transaction.raw.0.len() as i64 - evicted_size);
-                        Ok(mempool_transaction)
-                    }
+                    Ok(_evicted) => Ok(mempool_transaction),
                     Err(error) => {
                         self.metrics
                             .submission_rejected
@@ -350,16 +331,10 @@ impl MempoolManager {
             .collect::<Vec<_>>();
         drop(write_mempool);
         removed
-            .iter()
+            .into_iter()
             .filter(|data| data.source == MempoolAddSource::CoreApi)
             .map(|data| data.added_at.elapsed().as_secs_f64())
             .for_each(|wait| self.metrics.from_local_api_to_commit_wait.observe(wait));
-        self.metrics.current_transactions.sub(removed.len() as i64);
-        self.metrics.current_total_transactions_size.sub(
-            removed.into_iter().fold(0, |sum, evicted| {
-                sum + evicted.transaction.raw.0.len() as i64
-            }),
-        );
     }
 
     /// Removes the transactions specified by the given user payload hashes (while checking
@@ -377,36 +352,10 @@ impl MempoolManager {
         rejected_transactions: &[(&IntentHash, &NotarizedTransactionHash)],
     ) {
         let mut write_mempool = self.mempool.write();
-        let removed = rejected_transactions
+        rejected_transactions
             .iter()
-            .filter_map(|(_intent_hash, user_payload_hash)| {
-                write_mempool.remove_by_payload_hash(user_payload_hash)
-            })
-            .fold(TransactionSizeAccumulator::new(), |acc, evicted| {
-                acc.accumulate(&evicted.transaction)
+            .for_each(|(_intent_hash, user_payload_hash)| {
+                write_mempool.remove_by_payload_hash(user_payload_hash);
             });
-        self.metrics.current_transactions.sub(removed.count as i64);
-        self.metrics
-            .current_total_transactions_size
-            .sub(removed.bytes as i64);
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct TransactionSizeAccumulator {
-    pub count: usize,
-    pub bytes: usize,
-}
-
-impl TransactionSizeAccumulator {
-    pub fn new() -> Self {
-        Self { count: 0, bytes: 0 }
-    }
-
-    pub fn accumulate(&self, mempool_transaction: &MempoolTransaction) -> Self {
-        Self {
-            count: self.count + 1,
-            bytes: self.bytes + mempool_transaction.raw.0.len(),
-        }
     }
 }

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -62,9 +62,11 @@
  * permissions under this License.
  */
 
+use crate::mempool::metrics::MempoolMetrics;
 use crate::mempool::priority_mempool::*;
 use crate::mempool::*;
-use crate::{MempoolAddSource, MempoolMetrics, TakesMetricLabels};
+use crate::MempoolAddSource;
+use node_common::metrics::TakesMetricLabels;
 use prometheus::Registry;
 use transaction::model::*;
 

--- a/core-rust/state-manager/src/mempool/metrics.rs
+++ b/core-rust/state-manager/src/mempool/metrics.rs
@@ -71,6 +71,9 @@ pub struct MempoolMetrics {
     pub current_transactions: IntGauge,
     pub current_total_transactions_size: IntGauge,
     pub submission_added: IntCounterVec,
+}
+
+pub struct MempoolManagerMetrics {
     pub submission_rejected: IntCounterVec,
     pub from_local_api_to_commit_wait: Histogram,
 }
@@ -81,18 +84,28 @@ impl MempoolMetrics {
             current_transactions: IntGauge::with_opts(opts(
                 "mempool_current_transactions",
                 "Number of transactions in progress in the mempool.",
-            )).registered_at(registry),
+            ))
+            .registered_at(registry),
             current_total_transactions_size: IntGauge::with_opts(opts(
                 "mempool_current_total_transactions_size",
                 "Total size in bytes of transactions in mempool.",
-            )).registered_at(registry),
+            ))
+            .registered_at(registry),
             submission_added: IntCounterVec::new(
                 opts(
                     "mempool_submission_added_total",
                     "Count of submissions added to the mempool.",
                 ),
                 &["source"],
-            ).registered_at(registry),
+            )
+            .registered_at(registry),
+        }
+    }
+}
+
+impl MempoolManagerMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
             submission_rejected: IntCounterVec::new(
                 opts(
                     "mempool_submission_rejected_total",

--- a/core-rust/state-manager/src/mempool/mod.rs
+++ b/core-rust/state-manager/src/mempool/mod.rs
@@ -153,5 +153,6 @@ impl ToString for MempoolAddError {
 
 pub mod mempool_manager;
 pub mod mempool_relay_dispatcher;
+pub mod metrics;
 pub mod pending_transaction_result_cache;
 pub mod priority_mempool;

--- a/core-rust/state-manager/src/metrics.rs
+++ b/core-rust/state-manager/src/metrics.rs
@@ -63,16 +63,10 @@
  */
 
 use crate::limits::VertexLimitsExceeded;
-use crate::{MempoolAddError, MempoolAddSource, RejectionReason};
-use node_common::config::limits::{
-    DEFAULT_MAX_TOTAL_VERTEX_SUBSTATE_READ_COUNT, DEFAULT_MAX_TOTAL_VERTEX_SUBSTATE_READ_SIZE,
-    DEFAULT_MAX_TOTAL_VERTEX_SUBSTATE_WRITE_COUNT, DEFAULT_MAX_TOTAL_VERTEX_SUBSTATE_WRITE_SIZE,
-    DEFAULT_MAX_TOTAL_VERTEX_TRANSACTIONS_SIZE,
-};
-use prometheus::core::*;
+use node_common::config::limits::*;
+use node_common::metrics::*;
 use prometheus::*;
 use radix_engine::transaction::ExecutionConfig;
-use radix_engine_common::types::ComponentAddress;
 use radix_engine_constants::DEFAULT_MAX_TRANSACTION_SIZE;
 
 pub struct LedgerMetrics {
@@ -97,14 +91,6 @@ pub struct VertexPrepareMetrics {
     pub proposal_transactions_size: Histogram,
     pub wasted_proposal_bandwidth: Histogram,
     pub stop_reason: IntCounterVec,
-}
-
-pub struct MempoolMetrics {
-    pub current_transactions: IntGauge,
-    pub current_total_transactions_size: IntGauge,
-    pub submission_added: IntCounterVec,
-    pub submission_rejected: IntCounterVec,
-    pub from_local_api_to_commit_wait: Histogram,
 }
 
 impl LedgerMetrics {
@@ -262,182 +248,7 @@ impl VertexPrepareMetrics {
     }
 }
 
-impl MempoolMetrics {
-    pub fn new(registry: &Registry) -> Self {
-        Self {
-            current_transactions: IntGauge::with_opts(opts(
-                "mempool_current_transactions",
-                "Number of transactions in progress in the mempool.",
-            )).registered_at(registry),
-            current_total_transactions_size: IntGauge::with_opts(opts(
-                "mempool_current_total_transactions_size",
-                "Total size in bytes of transactions in mempool.",
-            )).registered_at(registry),
-            submission_added: IntCounterVec::new(
-                opts(
-                    "mempool_submission_added_total",
-                    "Count of submissions added to the mempool.",
-                ),
-                &["source"],
-            ).registered_at(registry),
-            submission_rejected: IntCounterVec::new(
-                opts(
-                    "mempool_submission_rejected_total",
-                    "Count of the submissions rejected by the mempool.",
-                ),
-                &["source", "rejection_reason"],
-            ).registered_at(registry),
-            from_local_api_to_commit_wait: new_timer(
-                opts(
-                    "mempool_from_local_api_to_commit_wait",
-                    "Time spent in the mempool, by a transaction coming from local API, until successful commit."
-                ),
-                vec![0.01, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]
-            ).registered_at(registry)
-        }
-    }
-}
-
-/// A syntactic sugar trait allowing for an inline "create + register" metric definition.
-trait AtDefaultRegistryExt<R> {
-    /// Unwraps a Prometheus metric creation `Result` and registers it at the given registry.
-    fn registered_at(self, registry: &Registry) -> R;
-}
-
-impl<T: Collector + Clone + 'static> AtDefaultRegistryExt<T> for Result<T> {
-    fn registered_at(self, registry: &Registry) -> T {
-        let collector = self.unwrap();
-        registry.register(Box::new(collector.clone())).unwrap();
-        collector
-    }
-}
-
-fn opts(name: &str, help: &str) -> Opts {
-    Opts::new(format!("rn_{name}"), help)
-}
-
-fn new_histogram(opts: Opts, buckets: Vec<f64>) -> Result<Histogram> {
-    Histogram::with_opts(HistogramOpts::from(opts).buckets(buckets))
-}
-
-fn equidistant_buckets(number_of_buckets: usize, min: f64, max: f64) -> Vec<f64> {
-    let range = max - min;
-    (1..number_of_buckets + 1)
-        .map(|bucket| {
-            let bucket = bucket as f64 / number_of_buckets as f64;
-
-            bucket * range + min
-        })
-        .collect()
-}
-
-// Given a limit, builds buckets for a Histogram with higher resolution for higher values.
-// This gives percentile buckets: 0-25, 25-50, 50-75, 75-80, 80-85, 85-90, 90-92, 92-94, 94-96, 96-98, 98-100
-fn higher_resolution_for_higher_values_buckets_for_limit(limit: usize) -> Vec<f64> {
-    let limit = limit as f64;
-    let mut buckets = equidistant_buckets(3, 0.0, 0.75 * limit);
-    buckets.extend(equidistant_buckets(3, 0.75 * limit, 0.9 * limit));
-    buckets.extend(equidistant_buckets(5, 0.9 * limit, limit));
-    buckets
-}
-
-// Given a limit, builds buckets for a Histogram with higher resolution for lower values.
-// This gives percentile buckets: 0-2, 2-4, 4-6, 6-8, 8-10, 10-15, 15-20, 20-25, 25-50, 50-75, 75-100
-fn higher_resolution_for_lower_values_buckets_for_limit(limit: usize) -> Vec<f64> {
-    let limit = limit as f64;
-    let mut buckets = equidistant_buckets(5, 0.0, 0.1 * limit);
-    buckets.extend(equidistant_buckets(3, 0.1 * limit, 0.25 * limit));
-    buckets.extend(equidistant_buckets(3, 0.25 * limit, limit));
-    buckets
-}
-
-/// Creates a new `Histogram` tailored to measuring time durations.
-/// The name (found in `Opts`) is expected to be a verb (describing the measured action) and will be
-/// auto-suffixed with a conventional `_seconds` string. The measurements are thus expected to be
-/// reported in seconds (possibly fractional).
-/// The buckets should represent expected interesting ranges of the measurements (i.e. their upper
-/// bounds). The last `+inf` bucket will be auto-added - this means that an empty bucket list may be
-/// passed here, and the timer will work in a `Summary` mode (i.e. tracking just sum and count).
-fn new_timer(opts: Opts, buckets: Vec<f64>) -> Result<Histogram> {
-    let mut adjusted_opts = opts;
-    adjusted_opts.name = format!("{}_seconds", adjusted_opts.name);
-    let mut adjusted_buckets = buckets;
-    adjusted_buckets.push(f64::INFINITY);
-    new_histogram(adjusted_opts, adjusted_buckets)
-}
-
-// TODO - capture the metric types on a generic wrapper around the GenericCounter, and ensure the provided labels match the types, like in Java.
-pub trait TakesMetricLabels {
-    type Metric;
-
-    fn with_label(&self, label1: impl MetricLabel) -> Self::Metric;
-    fn with_two_labels(&self, label1: impl MetricLabel, label2: impl MetricLabel) -> Self::Metric;
-    fn with_three_labels(
-        &self,
-        label1: impl MetricLabel,
-        label2: impl MetricLabel,
-        label3: impl MetricLabel,
-    ) -> Self::Metric;
-}
-
-impl<T: MetricVecBuilder> TakesMetricLabels for MetricVec<T> {
-    type Metric = <T as MetricVecBuilder>::M;
-
-    fn with_label(&self, label1: impl MetricLabel) -> Self::Metric {
-        self.with_label_values(&[label1.prometheus_label_name().as_ref()])
-    }
-
-    fn with_two_labels(&self, label1: impl MetricLabel, label2: impl MetricLabel) -> Self::Metric {
-        self.with_label_values(&[
-            label1.prometheus_label_name().as_ref(),
-            label2.prometheus_label_name().as_ref(),
-        ])
-    }
-
-    fn with_three_labels(
-        &self,
-        label1: impl MetricLabel,
-        label2: impl MetricLabel,
-        label3: impl MetricLabel,
-    ) -> Self::Metric {
-        self.with_label_values(&[
-            label1.prometheus_label_name().as_ref(),
-            label2.prometheus_label_name().as_ref(),
-            label3.prometheus_label_name().as_ref(),
-        ])
-    }
-}
-
-/// Typically applied to enums or Errors where we wish to derive a label name.
-/// Note the label name returned should be in a fixed, small-ish sized-set, to prevent
-/// issues with tracking too many metrics, or combinatorial explosion of metrics with different labels.
-pub trait MetricLabel {
-    /// Typically &str, but could also be String if it's dynamic (as long as it's in a fixed small set)
-    type StringReturnType: AsRef<str>;
-
-    /// Returns the string label associated with this enum value.
-    fn prometheus_label_name(&self) -> Self::StringReturnType;
-}
-
-/// We implement it for &T so that you can pass references in to function parameters taking `impl MetricLabel`
-impl<T: MetricLabel> MetricLabel for &T {
-    type StringReturnType = <T as MetricLabel>::StringReturnType;
-
-    fn prometheus_label_name(&self) -> Self::StringReturnType {
-        T::prometheus_label_name(self)
-    }
-}
-
 // Concrete types used for metric labels:
-
-impl MetricLabel for ComponentAddress {
-    type StringReturnType = String;
-
-    fn prometheus_label_name(&self) -> Self::StringReturnType {
-        self.to_hex()
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConsensusRoundResolution {
     Successful,
@@ -453,32 +264,6 @@ impl MetricLabel for ConsensusRoundResolution {
             ConsensusRoundResolution::Successful => "Successful",
             ConsensusRoundResolution::MissedByFallback => "MissedByFallback",
             ConsensusRoundResolution::MissedByGap => "MissedByGap",
-        }
-    }
-}
-
-impl MetricLabel for MempoolAddSource {
-    type StringReturnType = &'static str;
-
-    fn prometheus_label_name(&self) -> Self::StringReturnType {
-        match *self {
-            MempoolAddSource::CoreApi => "CoreApi",
-            MempoolAddSource::MempoolSync => "MempoolSync",
-        }
-    }
-}
-
-impl MetricLabel for MempoolAddError {
-    type StringReturnType = &'static str;
-
-    fn prometheus_label_name(&self) -> Self::StringReturnType {
-        match self {
-            MempoolAddError::PriorityThresholdNotMet { .. } => "PriorityThresholdNotMet",
-            MempoolAddError::Rejected(rejection) => match &rejection.reason {
-                RejectionReason::FromExecution(_) => "ExecutionError",
-                RejectionReason::ValidationError(_) => "ValidationError",
-            },
-            MempoolAddError::Duplicate(_) => "Duplicate",
         }
     }
 }

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -75,6 +75,7 @@ use ::transaction::errors::TransactionValidationError;
 use ::transaction::model::{IntentHash, NotarizedTransactionHash};
 use ::transaction::prelude::*;
 use node_common::config::limits::VertexLimitsConfig;
+use node_common::metrics::TakesMetricLabels;
 
 use radix_engine::system::bootstrap::*;
 use radix_engine::transaction::{RejectResult, TransactionReceipt};

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -150,7 +150,9 @@ mod tests {
             &logging_config,
             FeeReserveConfig::default(),
         ));
-        let pending_transaction_result_cache = Arc::new(parking_lot::const_rwlock(
+        let pending_transaction_result_cache: Arc<
+            parking_lot::lock_api::RwLock<parking_lot::RawRwLock, PendingTransactionResultCache>,
+        > = Arc::new(parking_lot::const_rwlock(
             PendingTransactionResultCache::new(10000, 10000),
         ));
         let committability_validator = Arc::new(CommittabilityValidator::new(
@@ -168,6 +170,7 @@ mod tests {
                 max_total_transactions_size: 10 * 1024 * 1024,
                 max_transaction_count: 10,
             },
+            &metric_registry,
         )));
         let mempool_manager = Arc::new(MempoolManager::new_for_testing(
             mempool,


### PR DESCRIPTION
In this PR:
- Move metrics infra into node-common.
- Move mempool metrics under mempool/
- Move metrics update logic out of state_manager.rs
- Split MempoolMetrics and move part of it in the mempool itself
- Fix missed mempool submission rejection metrics