### PR TITLE
Core API: lower stream cap

### DIFF
--- a/core-rust/core-api-server/src/core_api/constants.rs
+++ b/core-rust/core-api-server/src/core_api/constants.rs
@@ -1,5 +1,5 @@
 pub(crate) const MAX_STREAM_COUNT_PER_REQUEST: u16 = 10000;
-pub(crate) const CAP_STREAM_RESPONSE_WHEN_ABOVE_BYTES: usize = 40 * 1024 * 1024;
+pub(crate) const CAP_STREAM_RESPONSE_WHEN_ABOVE_BYTES: usize = 15 * 1024 * 1024;
 
 // TODO - Change this to be slightly larger than the double the max transaction payload size.
 // (We double due to the hex encoding of the payload)


### PR DESCRIPTION
Decrease core-api stream cap limit from 40MB to 15MB.