### PR TITLE
New metrics: Node's wallclock and proposer timestamp from last commit

### DIFF
--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -262,6 +262,7 @@ public record Metrics(
   public record Misc(
       TypedInfo<Config> config,
       Timer nodeStartup,
+      GetterGauge wallclockEpochSecond,
       Counter vertexStoreSaved,
       GetterGauge peerCount) {}
 

--- a/core-rust/core-api-server/src/core_api/conversions/context.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/context.rs
@@ -40,7 +40,7 @@ impl MappingContext {
         mut self,
         format_options: &Option<Box<models::SborFormatOptions>>,
     ) -> Self {
-        let mut options = &mut self.sbor_options;
+        let options = &mut self.sbor_options;
         if let Some(formats) = format_options {
             if let Some(value) = formats.raw {
                 options.include_raw = value;
@@ -56,7 +56,7 @@ impl MappingContext {
         mut self,
         format_options: &Option<Box<models::TransactionFormatOptions>>,
     ) -> Self {
-        let mut options = &mut self.transaction_options;
+        let options = &mut self.transaction_options;
         if let Some(formats) = format_options {
             if let Some(value) = formats.manifest {
                 options.include_manifest = value;
@@ -84,7 +84,7 @@ impl MappingContext {
         mut self,
         format_options: &Option<Box<models::SubstateFormatOptions>>,
     ) -> Self {
-        let mut options = &mut self.substate_options;
+        let options = &mut self.substate_options;
         if let Some(formats) = format_options {
             if let Some(value) = formats.hash {
                 options.include_hash = value;

--- a/core-rust/state-manager/src/metrics.rs
+++ b/core-rust/state-manager/src/metrics.rs
@@ -79,6 +79,7 @@ pub struct LedgerMetrics {
     pub transactions_committed: IntCounter,
     pub consensus_rounds_committed: IntCounterVec,
     pub last_update_epoch_second: Gauge,
+    pub last_update_proposer_epoch_second: Gauge,
 }
 
 pub struct CommittedTransactionsMetrics {
@@ -124,6 +125,11 @@ impl LedgerMetrics {
                 "Last timestamp at which the ledger was updated.",
             ))
             .registered_at(registry),
+            last_update_proposer_epoch_second: Gauge::with_opts(opts(
+                "ledger_last_update_proposer_epoch_second",
+                "Proposer timestamp from the last proof written to the ledger.",
+            ))
+            .registered_at(registry),
         }
     }
 
@@ -132,6 +138,7 @@ impl LedgerMetrics {
         added_transactions: usize,
         new_state_version: StateVersion,
         validator_proposal_counters: Vec<(ComponentAddress, LeaderRoundCounter)>,
+        proposer_timestamp_ms: i64,
     ) {
         self.state_version.set(new_state_version.number() as i64);
         self.transactions_committed
@@ -156,6 +163,8 @@ impl LedgerMetrics {
                 .unwrap()
                 .as_secs_f64(),
         );
+        self.last_update_proposer_epoch_second
+            .set(proposer_timestamp_ms as f64 / 1000.0);
     }
 }
 


### PR DESCRIPTION
The 2 most obvious metrics that will be used for future higher-level health metrics (see https://whimsical.com/node-status-and-health-metrics-QXjDREqeRDvGDu6xg3J8wx)