### PR TITLE
Core API metrics

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "blake2",
  "chrono",
  "futures",
+ "futures-util",
  "hex",
  "hyper",
  "jni",
@@ -339,6 +340,7 @@ dependencies = [
  "serde_json",
  "state-manager",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "transaction",
@@ -2162,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8bd22a874a2d0b70452d5597b12c537331d49060824a95f49f108994f94aa4c"
+checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
 dependencies = [
  "bitflags 2.3.3",
  "bytes",

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -35,7 +35,6 @@ utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "rcnet-v2-
 
 jni = { version = "0.19.0" }
 tracing = { version = "0.1" }
-lazy_static = { version = "1.4.0" }
 tokio = { version = "1.21.0", features = ["rt-multi-thread"] }
 parking_lot = { version = "0.12" }
 prometheus = { version = "0.13.2", default-features = false, features = [] }

--- a/core-rust/core-api-server/Cargo.toml
+++ b/core-rust/core-api-server/Cargo.toml
@@ -31,7 +31,9 @@ serde_json = { workspace = true }
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 hex = { version = "0.4.3", default-features = false }
 futures = { version = "0.3" }
+futures-util = "0.3.28"
 axum = { version = "0.6.6", features = ["http1", "json"] }
-tower-http = { version = "0.4.0", features = ["catch-panic"] }
+tower = "0.4.13"
+tower-http = { version = "0.4.3", features = ["catch-panic"]}
 hyper = { version = "0.14.20", features = ["server", "http1"] }
 paste = { version = "1.0.12", default-features = false }

--- a/core-rust/core-api-server/src/core_api/conversions/context.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/context.rs
@@ -40,7 +40,7 @@ impl MappingContext {
         mut self,
         format_options: &Option<Box<models::SborFormatOptions>>,
     ) -> Self {
-        let mut options = &mut self.sbor_options;
+        let options = &mut self.sbor_options;
         if let Some(formats) = format_options {
             if let Some(value) = formats.raw {
                 options.include_raw = value;
@@ -56,7 +56,7 @@ impl MappingContext {
         mut self,
         format_options: &Option<Box<models::TransactionFormatOptions>>,
     ) -> Self {
-        let mut options = &mut self.transaction_options;
+        let options = &mut self.transaction_options;
         if let Some(formats) = format_options {
             if let Some(value) = formats.manifest {
                 options.include_manifest = value;
@@ -84,7 +84,7 @@ impl MappingContext {
         mut self,
         format_options: &Option<Box<models::SubstateFormatOptions>>,
     ) -> Self {
-        let mut options = &mut self.substate_options;
+        let options = &mut self.substate_options;
         if let Some(formats) = format_options {
             if let Some(value) = formats.hash {
                 options.include_hash = value;

--- a/core-rust/core-api-server/src/core_api/metrics.rs
+++ b/core-rust/core-api-server/src/core_api/metrics.rs
@@ -67,27 +67,18 @@ use prometheus::*;
 
 #[derive(Debug, Clone)]
 pub struct CoreApiMetrics {
-    pub requests_count: IntCounterVec,
-    pub requests_duration: HistogramVec,
-    pub requests_pending: IntGaugeVec,
+    pub handle_request: HistogramVec,
+    pub requests_accepted: IntCounterVec,
     pub requests_not_found: IntCounter,
 }
 
 impl CoreApiMetrics {
     pub fn new(registry: &Registry) -> Self {
         CoreApiMetrics {
-            requests_count: IntCounterVec::new(
+            handle_request: new_timer_vec(
                 opts(
-                    "core_api_requests_count",
-                    "Count of total core api requests by endpoint and status.",
-                ),
-                &["endpoint", "status"],
-            )
-            .registered_at(registry),
-            requests_duration: new_timer_vec(
-                opts(
-                    "core_api_requests_duration",
-                    "Time spent by request and status.",
+                    "core_api_handle_request",
+                    "Time spent by endpoint and status.",
                 ),
                 &["endpoint", "status"],
                 vec![
@@ -95,10 +86,10 @@ impl CoreApiMetrics {
                 ],
             )
             .registered_at(registry),
-            requests_pending: IntGaugeVec::new(
+            requests_accepted: IntCounterVec::new(
                 opts(
-                    "core_api_requests_pending",
-                    "Number of pending requests by endpoint.",
+                    "core_api_requests_accepted",
+                    "Number of accepted requests by endpoint.",
                 ),
                 &["endpoint"],
             )

--- a/core-rust/core-api-server/src/core_api/metrics.rs
+++ b/core-rust/core-api-server/src/core_api/metrics.rs
@@ -62,32 +62,52 @@
  * permissions under this License.
  */
 
-mod constants;
-mod conversions;
-mod errors;
-mod extractors;
-mod handlers;
-mod helpers;
-mod metrics;
-mod metrics_layer;
-mod server;
+use node_common::metrics::*;
+use prometheus::*;
 
-#[allow(unused)]
-#[rustfmt::skip]
-#[allow(clippy::all)]
-mod generated;
-
-pub(crate) use constants::*;
-pub(crate) use conversions::*;
-pub(crate) use errors::*;
-pub(crate) use extractors::*;
-pub(crate) use helpers::*;
-pub(crate) use server::{create_server, CoreApiServerConfig, CoreApiState};
-
-pub(crate) mod models {
-    pub(crate) use super::generated::models::*;
-    pub(crate) use super::generated::SCHEMA_VERSION;
+#[derive(Debug, Clone)]
+pub struct CoreApiMetrics {
+    pub requests_count: IntCounterVec,
+    pub requests_duration: HistogramVec,
+    pub requests_pending: IntGaugeVec,
+    pub requests_not_found: IntCounter,
 }
 
-// Re-exports for handlers
-pub use hyper::StatusCode;
+impl CoreApiMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        CoreApiMetrics {
+            requests_count: IntCounterVec::new(
+                opts(
+                    "core_api_requests_count",
+                    "Count of total core api requests by endpoint and status.",
+                ),
+                &["endpoint", "status"],
+            )
+            .registered_at(registry),
+            requests_duration: new_timer_vec(
+                opts(
+                    "core_api_requests_duration",
+                    "Time spent by request and status.",
+                ),
+                &["endpoint", "status"],
+                vec![
+                    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+                ],
+            )
+            .registered_at(registry),
+            requests_pending: IntGaugeVec::new(
+                opts(
+                    "core_api_requests_pending",
+                    "Number of pending requests by endpoint.",
+                ),
+                &["endpoint"],
+            )
+            .registered_at(registry),
+            requests_not_found: IntCounter::new(
+                "core_api_requests_not_found",
+                "Number of total requests that did not match any configured route.",
+            )
+            .registered_at(registry),
+        }
+    }
+}

--- a/core-rust/core-api-server/src/core_api/metrics_layer.rs
+++ b/core-rust/core-api-server/src/core_api/metrics_layer.rs
@@ -122,7 +122,7 @@ where
         let endpoint: String = request.uri().path().into();
 
         let metrics = self.metrics.clone();
-        metrics.requests_pending.with_label(endpoint.clone()).inc();
+        metrics.requests_accepted.with_label(endpoint.clone()).inc();
 
         let future = self.inner.call(request);
 
@@ -133,14 +133,9 @@ where
             let status = response.status().as_u16().to_string();
 
             metrics
-                .requests_duration
+                .handle_request
                 .with_two_labels(endpoint.clone(), status.clone())
                 .observe(duration);
-            metrics
-                .requests_count
-                .with_two_labels(endpoint.clone(), status)
-                .inc();
-            metrics.requests_pending.with_label(endpoint).dec();
 
             Ok(response)
         })

--- a/core-rust/core-api-server/src/core_api/metrics_layer.rs
+++ b/core-rust/core-api-server/src/core_api/metrics_layer.rs
@@ -62,32 +62,87 @@
  * permissions under this License.
  */
 
-mod constants;
-mod conversions;
-mod errors;
-mod extractors;
-mod handlers;
-mod helpers;
-mod metrics;
-mod metrics_layer;
-mod server;
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+    time::Instant,
+};
 
-#[allow(unused)]
-#[rustfmt::skip]
-#[allow(clippy::all)]
-mod generated;
+use axum::{http::Request, response::Response};
+use futures_util::future::BoxFuture;
+use node_common::metrics::TakesMetricLabels;
+use tower::{Layer, Service};
 
-pub(crate) use constants::*;
-pub(crate) use conversions::*;
-pub(crate) use errors::*;
-pub(crate) use extractors::*;
-pub(crate) use helpers::*;
-pub(crate) use server::{create_server, CoreApiServerConfig, CoreApiState};
+use super::metrics::CoreApiMetrics;
 
-pub(crate) mod models {
-    pub(crate) use super::generated::models::*;
-    pub(crate) use super::generated::SCHEMA_VERSION;
+#[derive(Debug, Clone)]
+pub struct MetricsLayer {
+    metrics: Arc<CoreApiMetrics>,
 }
 
-// Re-exports for handlers
-pub use hyper::StatusCode;
+impl MetricsLayer {
+    pub fn new(metrics: Arc<CoreApiMetrics>) -> Self {
+        Self { metrics }
+    }
+}
+
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MetricsService {
+            inner,
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MetricsService<S> {
+    inner: S,
+    metrics: Arc<CoreApiMetrics>,
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for MetricsService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<ReqBody>) -> Self::Future {
+        let start = Instant::now();
+        let endpoint: String = request.uri().path().into();
+
+        let metrics = self.metrics.clone();
+        metrics.requests_pending.with_label(endpoint.clone()).inc();
+
+        let future = self.inner.call(request);
+
+        Box::pin(async move {
+            let response: Response = future.await?;
+
+            let duration = start.elapsed().as_secs_f64();
+            let status = response.status().as_u16().to_string();
+
+            metrics
+                .requests_duration
+                .with_two_labels(endpoint.clone(), status.clone())
+                .observe(duration);
+            metrics
+                .requests_count
+                .with_two_labels(endpoint.clone(), status)
+                .inc();
+            metrics.requests_pending.with_label(endpoint).dec();
+
+            Ok(response)
+        })
+    }
+}

--- a/core-rust/state-manager/src/jni/state_manager.rs
+++ b/core-rust/state-manager/src/jni/state_manager.rs
@@ -170,7 +170,7 @@ pub struct JNIStateManager {
     pub mempool_manager: Arc<MempoolManager>,
     pub committability_validator: Arc<CommittabilityValidator<StateManagerDatabase>>,
     pub transaction_previewer: Arc<TransactionPreviewer<StateManagerDatabase>>,
-    pub metric_registry: Registry,
+    pub metric_registry: Arc<Registry>,
 }
 
 impl JNIStateManager {
@@ -201,7 +201,7 @@ impl JNIStateManager {
                 config.database_flags,
             ),
         ));
-        let metric_registry = Registry::new();
+        let metric_registry = Arc::new(Registry::new());
         let mut fee_reserve_config = FeeReserveConfig::default();
         if config.no_fees {
             fee_reserve_config.cost_unit_price = Decimal::ZERO;


### PR DESCRIPTION
Added following metrics to Core API:

- Count of total core api requests by endpoint and status.
- Histogram of requests duration by endpoint and status.
- Gauge of pending requests by endpoint.
- Number of total 404 requests (exclusive with other metrics).