### PR TITLE
Adding metric for other validators' proposal timestamp difference

### DIFF
--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -176,6 +176,7 @@ public record Metrics(
       LabelledCounter<RoundChange> roundChanges,
       Timer consensusEventsQueueWait,
       LabelledCounter<RejectedConsensusEvent> rejectedConsensusEvents,
+      LabelledGauge<Validator> proposalTimestampDifferenceSeconds,
       GetterGauge validatorCount,
       GetterGauge inValidatorSet,
       Pacemaker pacemaker,
@@ -340,6 +341,8 @@ public record Metrics(
       NOT_MONOTONIC
     }
   }
+
+  public record Validator(String key, String componentAddress) {}
 
   public record ChannelProperties(Direction direction) {
 

--- a/core/src/main/java/com/radixdlt/consensus/bft/BFTBuilder.java
+++ b/core/src/main/java/com/radixdlt/consensus/bft/BFTBuilder.java
@@ -64,6 +64,7 @@
 
 package com.radixdlt.consensus.bft;
 
+import com.radixdlt.addressing.Addressing;
 import com.radixdlt.consensus.*;
 import com.radixdlt.consensus.bft.processor.*;
 import com.radixdlt.consensus.bft.processor.BFTQuorumAssembler.TimeoutQuorumDelayedResolution;
@@ -102,6 +103,7 @@ public final class BFTBuilder {
 
   private TimeSupplier timeSupplier;
   private Metrics metrics;
+  private Addressing addressing;
 
   private BFTBuilder() {
     // Just making this inaccessible
@@ -196,6 +198,11 @@ public final class BFTBuilder {
     return this;
   }
 
+  public BFTBuilder addressing(Addressing addressing) {
+    this.addressing = addressing;
+    return this;
+  }
+
   public BFTEventProcessor build() {
     if (!validatorSet.containsValidator(self)) {
       return EmptyBFTEventProcessor.INSTANCE;
@@ -225,7 +232,7 @@ public final class BFTBuilder {
 
     final var proposalTimestampVerifier =
         new ProposalTimestampVerifier(
-            quorumAssembler, timeSupplier, metrics, proposalRejectedDispatcher);
+            quorumAssembler, timeSupplier, metrics, addressing, proposalRejectedDispatcher);
 
     final var postSyncUpVerifier =
         new BFTEventPostSyncUpVerifier(proposalTimestampVerifier, metrics, roundUpdate);

--- a/core/src/main/java/com/radixdlt/consensus/epoch/EpochsConsensusModule.java
+++ b/core/src/main/java/com/radixdlt/consensus/epoch/EpochsConsensusModule.java
@@ -359,6 +359,7 @@ public class EpochsConsensusModule extends AbstractModule {
       HashVerifier verifier,
       TimeSupplier timeSupplier,
       Metrics metrics,
+      Addressing addressing,
       EventDispatcher<RoundQuorumResolution> roundQuorumResolutionEventDispatcher,
       ScheduledEventDispatcher<Epoched<TimeoutQuorumDelayedResolution>>
           timeoutQuorumDelayedResolutionDispatcher,
@@ -403,6 +404,7 @@ public class EpochsConsensusModule extends AbstractModule {
             .timeSupplier(timeSupplier)
             .proposerElection(proposerElection)
             .metrics(metrics)
+            .addressing(addressing)
             .build();
   }
 

--- a/core/src/test-core/java/com/radixdlt/environment/NoEpochsConsensusModule.java
+++ b/core/src/test-core/java/com/radixdlt/environment/NoEpochsConsensusModule.java
@@ -69,6 +69,7 @@ import com.google.inject.*;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.multibindings.ProvidesIntoSet;
+import com.radixdlt.addressing.Addressing;
 import com.radixdlt.consensus.*;
 import com.radixdlt.consensus.bft.*;
 import com.radixdlt.consensus.bft.processor.BFTEventProcessor;
@@ -151,6 +152,7 @@ public class NoEpochsConsensusModule extends AbstractModule {
       TimeSupplier timeSupplier,
       ProposerElection proposerElection,
       Metrics metrics,
+      Addressing addressing,
       EventDispatcher<RoundQuorumResolution> roundQuorumResolutionEventDispatcher,
       ScheduledEventDispatcher<TimeoutQuorumDelayedResolution>
           timeoutQuorumDelayedResolutionDispatcher,
@@ -192,6 +194,7 @@ public class NoEpochsConsensusModule extends AbstractModule {
         .validatorSet(config.getValidatorSet())
         .timeSupplier(timeSupplier)
         .metrics(metrics)
+        .addressing(addressing)
         .proposerElection(proposerElection)
         .build();
   }


### PR DESCRIPTION
As part of https://whimsical.com/node-status-and-health-metrics-QXjDREqeRDvGDu6xg3J8wx, this PR adds:
```
# TYPE rn_bft_proposal_timestamp_difference_seconds gauge
rn_bft_proposal_timestamp_difference_seconds{key="03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556",component_address="validator_loc1sv7h9eggskmgf7eat8jfd5pvsfx6tf728nwres7zae8694cp5xewdk",} -0.001
```

The interpretation of the above is of course:
"When that validator was creating the proposal, its wallclock was `-0.001` seconds away from my current wallclock."
We are aware that this "clock skew" actually includes the network delay too - but that's all we care about, since we accept/reject proposals based on this clock difference.