### PR TITLE
tweak: Add zabanet for RCnet v3

### DIFF
--- a/cli-tools/src/main/java/com/radixdlt/cli/GenerateGenesis.java
+++ b/cli-tools/src/main/java/com/radixdlt/cli/GenerateGenesis.java
@@ -101,14 +101,17 @@ public final class GenerateGenesis {
           Network.NERGALNET,
           Network.NEBUNET,
           Network.KISHARNET,
-          Network.ANSHARNET);
+          Network.ANSHARNET,
+          Network.ZABANET,
+          Network.STOKENET);
 
   private static final Set<Network> PRODUCTION_NETWORKS = Set.of(Network.MAINNET);
   private static final Set<Network> NETWORKS_TO_DISABLE_FAUCET = PRODUCTION_NETWORKS;
   private static final Set<Network> NETWORKS_TO_DISABLE_SCENARIOS = NETWORKS_TO_DISABLE_FAUCET;
 
   private static final Set<Network> NETWORKS_TO_ENSURE_PRODUCTION_EMISSIONS =
-      Set.of(Network.KISHARNET, Network.ANSHARNET, Network.STOKENET, Network.MAINNET);
+      Set.of(
+          Network.KISHARNET, Network.ANSHARNET, Network.ZABANET, Network.STOKENET, Network.MAINNET);
 
   private static final Decimal GENESIS_POWERFUL_STAKING_ACCOUNT_INITIAL_XRD_BALANCE =
       Decimal.of(700_000_000_000L); // 70% XRD_MAX_SUPPLY

--- a/common/src/main/java/com/radixdlt/networks/Network.java
+++ b/common/src/main/java/com/radixdlt/networks/Network.java
@@ -90,12 +90,14 @@ public enum Network {
   /// Babylon Temporary Testnets (0x0a - 0x0f)
   // - adapanet = Babylon Alphanet, after Adapa
   // - nebunet = Babylon Betanet, after Nebuchadnezzar
-  // - kisharnet = Babylon RCnet-V1, after Kishar (from the Babylonian Creation Story)
-  // - ansharnet = Babylon RCnet-V2, after Anshar (from the Babylonian Creation Story)
+  // - kisharnet = Babylon RCnet v1, after Kishar (from the Babylonian Creation Story)
+  // - ansharnet = Babylon RCnet v2, after Anshar (from the Babylonian Creation Story)
+  // - zabanet = Babylon RCnet v3, after Zababa, a war god from the Mesopotamian city of Kish
   ADAPANET(10 /* 0x0a */, "adapanet", "tdx_a_"),
   NEBUNET(11 /* 0x0b */, "nebunet", "tdx_b_"),
   KISHARNET(12 /* 0x0c */, "kisharnet", "tdx_c_"),
   ANSHARNET(13 /* 0x0d */, "ansharnet", "tdx_d_"),
+  ZABANET(14 /* 0x0e */, "zabanet", "tdx_e_"),
 
   /// RDX Development - Semi-permanent Testnets (start with 0x2)
   // - gilganet = Node integration network, after Gilgamesh

--- a/core-rust/core-api-server/src/core_api/metrics_layer.rs
+++ b/core-rust/core-api-server/src/core_api/metrics_layer.rs
@@ -134,7 +134,7 @@ where
 
             metrics
                 .handle_request
-                .with_two_labels(endpoint.clone(), status.clone())
+                .with_two_labels(endpoint.clone(), status)
                 .observe(duration);
 
             Ok(response)

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -30,7 +30,7 @@ import { CoreApiClient } from "@radixdlt/babylon-core-api-sdk";
 
 const coreApiClient = await CoreApiClient.initialize({
     basePath: "http://127.0.0.1:3333/core", // Note: 127.0.0.1 works better than localhost on Node.JS
-    logicalNetworkName: "ansharnet",
+    logicalNetworkName: "zabanet",
     // Further options - explained below...
 });
 ```
@@ -92,7 +92,7 @@ const basicAuthPassword = "????"; // From your node set-up - provide this secure
 
 const coreApiClient = await CoreApiClient.initialize({
     basePath: "https://127.0.0.1/core",
-    logicalNetworkName: "ansharnet",
+    logicalNetworkName: "zabanet",
     advanced: {
         agent: new https.Agent({
             keepAlive: true,
@@ -121,7 +121,7 @@ const basicAuthPassword = "????"; // From your node set-up - provide this secure
 
 const coreApiClient = await CoreApiClient.initialize({
     basePath: "https://127.0.0.1/core",
-    logicalNetworkName: "ansharnet",
+    logicalNetworkName: "zabanet",
     advanced: {
         dispatcher: new Agent({
             connect: {

--- a/testnet-node/README.md
+++ b/testnet-node/README.md
@@ -4,8 +4,8 @@ This is the easiest way to get a Babylon fullnode up and running, for integratio
 
 This set-up is only intended for local running as a developer - it is not intended for running in production - see [our documentation site for information on running a production node](https://docs-babylon.radixdlt.com/main/node-and-gateway/node-setup-introduction.html).
 
-The node connects to the latest public testnet (as of July 2023, this is RCnet v2, known by its logical name `ansharnet`).
-If you previously ran a `kisharnet` node, you will need to wipe the ledger database as documented in the "Ledger Database" section below.
+The node connects to the latest public testnet (as of August 2023, this is RCnet v3, known by its logical name `zabanet`).
+If you previously ran a `kisharnet` or `ansharnet` node, you will need to wipe the ledger database as documented in the "Ledger Database" section below.
 
 Documentation for integrators is available [here](https://docs.google.com/document/d/1cjc7_alyzIb2QQIGGn1PEpJyjrMRZYHq3VwkOXRP8J0).
 
@@ -19,7 +19,7 @@ Documentation for integrators is available [here](https://docs.google.com/docume
 curl \
   'http://localhost:3333/core/lts/transaction/construction' \
   -H 'Content-Type: application/json' \
-  -d '{ "network": "ansharnet" }'
+  -d '{ "network": "zabanet" }'
 ```
 
 ## Node volumes


### PR DESCRIPTION
Also updated some of the parts of the docs where we previously had `ansharnet` in preparation for RCnet v3.