### PR TITLE
Include `state_version` in all Core API `/state/...` responses

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -6253,6 +6253,7 @@ components:
     StateConsensusManagerResponse:
       type: object
       required:
+        - state_version
         - config
         - state
         - current_proposal_statistic
@@ -6260,6 +6261,9 @@ components:
         - current_time
         - current_time_rounded_to_minutes
       properties:
+        state_version:
+          $ref: "#/components/schemas/StateVersion"
+          description: The state version at which the query was performed.
         config:
           $ref: "#/components/schemas/Substate"
         state:
@@ -6289,11 +6293,15 @@ components:
     StateAccountResponse:
       type: object
       required:
+        - state_version
         - info
         - owner_role
         - state
         - vaults
       properties:
+        state_version:
+          $ref: "#/components/schemas/StateVersion"
+          description: The state version at which the query was performed.
         info:
           $ref: "#/components/schemas/Substate"
         owner_role:
@@ -6332,6 +6340,7 @@ components:
     StateComponentResponse:
       type: object
       required:
+        - state_version
         - info
         - state
         - royalty_accumulator
@@ -6339,6 +6348,9 @@ components:
         - vaults
         - descendent_nodes
       properties:
+        state_version:
+          $ref: "#/components/schemas/StateVersion"
+          description: The state version at which the query was performed.
         info:
           $ref: "#/components/schemas/Substate"
         state:
@@ -6404,12 +6416,16 @@ components:
     StateValidatorResponse:
       type: object
       required:
+        - state_version
         - address
         - state
         - owner_role
         - vaults
         - descendent_nodes
       properties:
+        state_version:
+          $ref: "#/components/schemas/StateVersion"
+          description: The state version at which the query was performed.
         address:
           $ref: '#/components/schemas/ComponentAddress'
         state:
@@ -6442,11 +6458,15 @@ components:
     StateAccessControllerResponse:
       type: object
       required:
+        - state_version
         - state
         - owner_role
         - vaults
         - descendent_nodes
       properties:
+        state_version:
+          $ref: "#/components/schemas/StateVersion"
+          description: The state version at which the query was performed.
         state:
           $ref: "#/components/schemas/Substate"
         owner_role:
@@ -6478,9 +6498,13 @@ components:
     StateResourceResponse:
       type: object
       required:
+        - state_version
         - manager
         - owner_role
       properties:
+        state_version:
+          $ref: "#/components/schemas/StateVersion"
+          description: The state version at which the query was performed.
         manager:
           $ref: "#/components/schemas/StateResourceManager"
         owner_role:
@@ -6543,8 +6567,12 @@ components:
     StateNonFungibleResponse:
       type: object
       required:
+        - state_version
         - non_fungible
       properties:
+        state_version:
+          $ref: "#/components/schemas/StateVersion"
+          description: The state version at which the query was performed.
         non_fungible:
           $ref: "#/components/schemas/Substate"
 ###########################
@@ -6564,8 +6592,12 @@ components:
     StatePackageResponse:
       type: object
       required:
+        - state_version
         - owner_role
       properties:
+        state_version:
+          $ref: "#/components/schemas/StateVersion"
+          description: The state version at which the query was performed.
         owner_role:
           $ref: "#/components/schemas/Substate"
         royalty:

--- a/core-rust/core-api-server/src/core_api/generated/models/state_access_controller_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/state_access_controller_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct StateAccessControllerResponse {
+    #[serde(rename = "state_version")]
+    pub state_version: i64,
     #[serde(rename = "state")]
     pub state: Option<crate::core_api::generated::models::Substate>, // Using Option permits Default trait; Will always be Some in normal use
     #[serde(rename = "owner_role")]
@@ -26,8 +28,9 @@ pub struct StateAccessControllerResponse {
 }
 
 impl StateAccessControllerResponse {
-    pub fn new(state: crate::core_api::generated::models::Substate, owner_role: crate::core_api::generated::models::Substate, vaults: Vec<crate::core_api::generated::models::VaultBalance>, descendent_nodes: Vec<crate::core_api::generated::models::StateComponentDescendentNode>) -> StateAccessControllerResponse {
+    pub fn new(state_version: i64, state: crate::core_api::generated::models::Substate, owner_role: crate::core_api::generated::models::Substate, vaults: Vec<crate::core_api::generated::models::VaultBalance>, descendent_nodes: Vec<crate::core_api::generated::models::StateComponentDescendentNode>) -> StateAccessControllerResponse {
         StateAccessControllerResponse {
+            state_version,
             state: Option::Some(state),
             owner_role: Option::Some(owner_role),
             vaults,

--- a/core-rust/core-api-server/src/core_api/generated/models/state_account_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/state_account_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct StateAccountResponse {
+    #[serde(rename = "state_version")]
+    pub state_version: i64,
     #[serde(rename = "info")]
     pub info: Option<crate::core_api::generated::models::Substate>, // Using Option permits Default trait; Will always be Some in normal use
     #[serde(rename = "owner_role")]
@@ -25,8 +27,9 @@ pub struct StateAccountResponse {
 }
 
 impl StateAccountResponse {
-    pub fn new(info: crate::core_api::generated::models::Substate, owner_role: crate::core_api::generated::models::Substate, state: crate::core_api::generated::models::Substate, vaults: Vec<crate::core_api::generated::models::VaultBalance>) -> StateAccountResponse {
+    pub fn new(state_version: i64, info: crate::core_api::generated::models::Substate, owner_role: crate::core_api::generated::models::Substate, state: crate::core_api::generated::models::Substate, vaults: Vec<crate::core_api::generated::models::VaultBalance>) -> StateAccountResponse {
         StateAccountResponse {
+            state_version,
             info: Option::Some(info),
             owner_role: Option::Some(owner_role),
             state: Option::Some(state),

--- a/core-rust/core-api-server/src/core_api/generated/models/state_component_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/state_component_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct StateComponentResponse {
+    #[serde(rename = "state_version")]
+    pub state_version: i64,
     #[serde(rename = "info")]
     pub info: Option<crate::core_api::generated::models::Substate>, // Using Option permits Default trait; Will always be Some in normal use
     #[serde(rename = "state")]
@@ -30,8 +32,9 @@ pub struct StateComponentResponse {
 }
 
 impl StateComponentResponse {
-    pub fn new(info: crate::core_api::generated::models::Substate, state: crate::core_api::generated::models::Substate, royalty_accumulator: crate::core_api::generated::models::Substate, owner_role: crate::core_api::generated::models::Substate, vaults: Vec<crate::core_api::generated::models::VaultBalance>, descendent_nodes: Vec<crate::core_api::generated::models::StateComponentDescendentNode>) -> StateComponentResponse {
+    pub fn new(state_version: i64, info: crate::core_api::generated::models::Substate, state: crate::core_api::generated::models::Substate, royalty_accumulator: crate::core_api::generated::models::Substate, owner_role: crate::core_api::generated::models::Substate, vaults: Vec<crate::core_api::generated::models::VaultBalance>, descendent_nodes: Vec<crate::core_api::generated::models::StateComponentDescendentNode>) -> StateComponentResponse {
         StateComponentResponse {
+            state_version,
             info: Option::Some(info),
             state: Option::Some(state),
             royalty_accumulator: Option::Some(royalty_accumulator),

--- a/core-rust/core-api-server/src/core_api/generated/models/state_consensus_manager_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/state_consensus_manager_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct StateConsensusManagerResponse {
+    #[serde(rename = "state_version")]
+    pub state_version: i64,
     #[serde(rename = "config")]
     pub config: Option<crate::core_api::generated::models::Substate>, // Using Option permits Default trait; Will always be Some in normal use
     #[serde(rename = "state")]
@@ -28,8 +30,9 @@ pub struct StateConsensusManagerResponse {
 }
 
 impl StateConsensusManagerResponse {
-    pub fn new(config: crate::core_api::generated::models::Substate, state: crate::core_api::generated::models::Substate, current_proposal_statistic: crate::core_api::generated::models::Substate, current_validator_set: crate::core_api::generated::models::Substate, current_time: crate::core_api::generated::models::Substate, current_time_rounded_to_minutes: crate::core_api::generated::models::Substate) -> StateConsensusManagerResponse {
+    pub fn new(state_version: i64, config: crate::core_api::generated::models::Substate, state: crate::core_api::generated::models::Substate, current_proposal_statistic: crate::core_api::generated::models::Substate, current_validator_set: crate::core_api::generated::models::Substate, current_time: crate::core_api::generated::models::Substate, current_time_rounded_to_minutes: crate::core_api::generated::models::Substate) -> StateConsensusManagerResponse {
         StateConsensusManagerResponse {
+            state_version,
             config: Option::Some(config),
             state: Option::Some(state),
             current_proposal_statistic: Option::Some(current_proposal_statistic),

--- a/core-rust/core-api-server/src/core_api/generated/models/state_non_fungible_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/state_non_fungible_response.rs
@@ -13,13 +13,16 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct StateNonFungibleResponse {
+    #[serde(rename = "state_version")]
+    pub state_version: i64,
     #[serde(rename = "non_fungible")]
     pub non_fungible: Option<crate::core_api::generated::models::Substate>, // Using Option permits Default trait; Will always be Some in normal use
 }
 
 impl StateNonFungibleResponse {
-    pub fn new(non_fungible: crate::core_api::generated::models::Substate) -> StateNonFungibleResponse {
+    pub fn new(state_version: i64, non_fungible: crate::core_api::generated::models::Substate) -> StateNonFungibleResponse {
         StateNonFungibleResponse {
+            state_version,
             non_fungible: Option::Some(non_fungible),
         }
     }

--- a/core-rust/core-api-server/src/core_api/generated/models/state_package_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/state_package_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct StatePackageResponse {
+    #[serde(rename = "state_version")]
+    pub state_version: i64,
     #[serde(rename = "owner_role")]
     pub owner_role: Option<crate::core_api::generated::models::Substate>, // Using Option permits Default trait; Will always be Some in normal use
     #[serde(rename = "royalty", skip_serializing_if = "Option::is_none")]
@@ -20,8 +22,9 @@ pub struct StatePackageResponse {
 }
 
 impl StatePackageResponse {
-    pub fn new(owner_role: crate::core_api::generated::models::Substate) -> StatePackageResponse {
+    pub fn new(state_version: i64, owner_role: crate::core_api::generated::models::Substate) -> StatePackageResponse {
         StatePackageResponse {
+            state_version,
             owner_role: Option::Some(owner_role),
             royalty: None,
         }

--- a/core-rust/core-api-server/src/core_api/generated/models/state_resource_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/state_resource_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct StateResourceResponse {
+    #[serde(rename = "state_version")]
+    pub state_version: i64,
     #[serde(rename = "manager")]
     pub manager: Option<crate::core_api::generated::models::StateResourceManager>, // Using Option permits Default trait; Will always be Some in normal use
     #[serde(rename = "owner_role")]
@@ -20,8 +22,9 @@ pub struct StateResourceResponse {
 }
 
 impl StateResourceResponse {
-    pub fn new(manager: crate::core_api::generated::models::StateResourceManager, owner_role: crate::core_api::generated::models::Substate) -> StateResourceResponse {
+    pub fn new(state_version: i64, manager: crate::core_api::generated::models::StateResourceManager, owner_role: crate::core_api::generated::models::Substate) -> StateResourceResponse {
         StateResourceResponse {
+            state_version,
             manager: Option::Some(manager),
             owner_role: Option::Some(owner_role),
         }

--- a/core-rust/core-api-server/src/core_api/generated/models/state_validator_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/state_validator_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct StateValidatorResponse {
+    #[serde(rename = "state_version")]
+    pub state_version: i64,
     /// The Bech32m-encoded human readable version of the component address
     #[serde(rename = "address")]
     pub address: String,
@@ -29,8 +31,9 @@ pub struct StateValidatorResponse {
 }
 
 impl StateValidatorResponse {
-    pub fn new(address: String, state: crate::core_api::generated::models::Substate, owner_role: crate::core_api::generated::models::Substate, vaults: Vec<crate::core_api::generated::models::VaultBalance>, descendent_nodes: Vec<crate::core_api::generated::models::StateComponentDescendentNode>) -> StateValidatorResponse {
+    pub fn new(state_version: i64, address: String, state: crate::core_api::generated::models::Substate, owner_role: crate::core_api::generated::models::Substate, vaults: Vec<crate::core_api::generated::models::VaultBalance>, descendent_nodes: Vec<crate::core_api::generated::models::StateComponentDescendentNode>) -> StateValidatorResponse {
         StateValidatorResponse {
+            state_version,
             address,
             state: Option::Some(state),
             owner_role: Option::Some(owner_role),

--- a/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
@@ -2,6 +2,7 @@ use crate::core_api::*;
 
 use radix_engine::types::*;
 use state_manager::query::dump_component_state;
+use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
 use super::component_dump_to_vaults_and_nodes;
@@ -44,6 +45,7 @@ pub(crate) async fn handle_state_access_controller(
         component_dump_to_vaults_and_nodes(&mapping_context, component_dump)?;
 
     Ok(models::StateAccessControllerResponse {
+        state_version: to_api_state_version(database.max_state_version())?,
         state: Some(to_api_access_controller_substate(
             &mapping_context,
             &access_controller_substate,

--- a/core-rust/core-api-server/src/core_api/handlers/state_account.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_account.rs
@@ -1,6 +1,7 @@
 use crate::core_api::*;
 use radix_engine::types::*;
 use state_manager::query::{dump_component_state, VaultData};
+use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
 pub(crate) async fn handle_state_account(
@@ -51,6 +52,7 @@ pub(crate) async fn handle_state_account(
         .collect::<Result<Vec<_>, MappingError>>()?;
 
     Ok(models::StateAccountResponse {
+        state_version: to_api_state_version(database.max_state_version())?,
         info: Some(to_api_type_info_substate(&mapping_context, &type_info)?),
         owner_role: Some(to_api_owner_role_substate(
             &mapping_context,

--- a/core-rust/core-api-server/src/core_api/handlers/state_component.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_component.rs
@@ -2,6 +2,7 @@ use crate::core_api::*;
 use radix_engine::types::*;
 use radix_engine_store_interface::db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper};
 use state_manager::query::{dump_component_state, ComponentStateDump, DescendantParentOpt};
+use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
 use super::map_to_vault_balance;
@@ -60,6 +61,7 @@ pub(crate) async fn handle_state_component(
         component_dump_to_vaults_and_nodes(&mapping_context, component_dump)?;
 
     Ok(models::StateComponentResponse {
+        state_version: to_api_state_version(database.max_state_version())?,
         info: Some(to_api_type_info_substate(
             &mapping_context,
             &type_info_substate,

--- a/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
@@ -1,5 +1,6 @@
 use crate::core_api::*;
 use radix_engine::types::*;
+use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
 #[tracing::instrument(skip(state))]
@@ -43,6 +44,7 @@ pub(crate) async fn handle_state_consensus_manager(
     )?;
 
     Ok(models::StateConsensusManagerResponse {
+        state_version: to_api_state_version(database.max_state_version())?,
         config: Some(to_api_consensus_manager_config_substate(&config_substate)?),
         state: Some(to_api_consensus_manager_state_substate(
             &mapping_context,

--- a/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
@@ -2,6 +2,7 @@ use radix_engine::blueprints::resource::*;
 use radix_engine::system::system::KeyValueEntrySubstate;
 use radix_engine::types::*;
 use radix_engine_queries::typed_substate_layout::{TypedMainModuleSubstateKey, TypedSubstateKey};
+use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
 use crate::core_api::*;
@@ -61,6 +62,7 @@ pub(crate) async fn handle_state_non_fungible(
     })?;
 
     Ok(StateNonFungibleResponse {
+        state_version: to_api_state_version(database.max_state_version())?,
         non_fungible: Some(to_api_non_fungible_resource_manager_data_substate(
             &mapping_context,
             &TypedSubstateKey::MainModule(TypedMainModuleSubstateKey::NonFungibleResourceData(

--- a/core-rust/core-api-server/src/core_api/handlers/state_package.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_package.rs
@@ -1,5 +1,6 @@
 use crate::core_api::*;
 use radix_engine::types::*;
+use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
 pub(crate) async fn handle_state_package(
@@ -30,6 +31,7 @@ pub(crate) async fn handle_state_package(
     );
 
     Ok(models::StatePackageResponse {
+        state_version: to_api_state_version(database.max_state_version())?,
         owner_role: Some(to_api_owner_role_substate(
             &mapping_context,
             &owner_role_substate,

--- a/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
@@ -2,6 +2,7 @@ use crate::core_api::*;
 
 use radix_engine::types::*;
 use radix_engine_queries::typed_substate_layout::*;
+use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
 use radix_engine_common::types::EntityType;
@@ -77,6 +78,7 @@ pub(crate) async fn handle_state_resource(
     )?;
 
     Ok(models::StateResourceResponse {
+        state_version: to_api_state_version(database.max_state_version())?,
         manager: Some(to_api_resource_manager(&mapping_context, &manager)?),
         owner_role: Some(to_api_owner_role_substate(
             &mapping_context,

--- a/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
@@ -2,6 +2,7 @@ use crate::core_api::*;
 use radix_engine::types::*;
 
 use state_manager::query::dump_component_state;
+use state_manager::store::traits::QueryableProofStore;
 use std::ops::Deref;
 
 use super::component_dump_to_vaults_and_nodes;
@@ -47,6 +48,7 @@ pub(crate) async fn handle_state_validator(
         component_dump_to_vaults_and_nodes(&mapping_context, component_dump)?;
 
     Ok(models::StateValidatorResponse {
+        state_version: to_api_state_version(database.max_state_version())?,
         address: to_api_component_address(&mapping_context, &validator_address)?,
         state: Some(to_api_validator_substate(
             &mapping_context,

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateAccessControllerResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateAccessControllerResponse.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * StateAccessControllerResponse
  */
 @JsonPropertyOrder({
+  StateAccessControllerResponse.JSON_PROPERTY_STATE_VERSION,
   StateAccessControllerResponse.JSON_PROPERTY_STATE,
   StateAccessControllerResponse.JSON_PROPERTY_OWNER_ROLE,
   StateAccessControllerResponse.JSON_PROPERTY_VAULTS,
@@ -43,6 +44,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StateAccessControllerResponse {
+  public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
+  private Long stateVersion;
+
   public static final String JSON_PROPERTY_STATE = "state";
   private Substate state;
 
@@ -57,6 +61,34 @@ public class StateAccessControllerResponse {
 
   public StateAccessControllerResponse() { 
   }
+
+  public StateAccessControllerResponse stateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+    return this;
+  }
+
+   /**
+   * Get stateVersion
+   * minimum: 1
+   * maximum: 100000000000000
+   * @return stateVersion
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getStateVersion() {
+    return stateVersion;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setStateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+  }
+
 
   public StateAccessControllerResponse state(Substate state) {
     this.state = state;
@@ -184,7 +216,8 @@ public class StateAccessControllerResponse {
       return false;
     }
     StateAccessControllerResponse stateAccessControllerResponse = (StateAccessControllerResponse) o;
-    return Objects.equals(this.state, stateAccessControllerResponse.state) &&
+    return Objects.equals(this.stateVersion, stateAccessControllerResponse.stateVersion) &&
+        Objects.equals(this.state, stateAccessControllerResponse.state) &&
         Objects.equals(this.ownerRole, stateAccessControllerResponse.ownerRole) &&
         Objects.equals(this.vaults, stateAccessControllerResponse.vaults) &&
         Objects.equals(this.descendentNodes, stateAccessControllerResponse.descendentNodes);
@@ -192,13 +225,14 @@ public class StateAccessControllerResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(state, ownerRole, vaults, descendentNodes);
+    return Objects.hash(stateVersion, state, ownerRole, vaults, descendentNodes);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class StateAccessControllerResponse {\n");
+    sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    ownerRole: ").append(toIndentedString(ownerRole)).append("\n");
     sb.append("    vaults: ").append(toIndentedString(vaults)).append("\n");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateAccountResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateAccountResponse.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * StateAccountResponse
  */
 @JsonPropertyOrder({
+  StateAccountResponse.JSON_PROPERTY_STATE_VERSION,
   StateAccountResponse.JSON_PROPERTY_INFO,
   StateAccountResponse.JSON_PROPERTY_OWNER_ROLE,
   StateAccountResponse.JSON_PROPERTY_STATE,
@@ -42,6 +43,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StateAccountResponse {
+  public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
+  private Long stateVersion;
+
   public static final String JSON_PROPERTY_INFO = "info";
   private Substate info;
 
@@ -56,6 +60,34 @@ public class StateAccountResponse {
 
   public StateAccountResponse() { 
   }
+
+  public StateAccountResponse stateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+    return this;
+  }
+
+   /**
+   * Get stateVersion
+   * minimum: 1
+   * maximum: 100000000000000
+   * @return stateVersion
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getStateVersion() {
+    return stateVersion;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setStateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+  }
+
 
   public StateAccountResponse info(Substate info) {
     this.info = info;
@@ -178,7 +210,8 @@ public class StateAccountResponse {
       return false;
     }
     StateAccountResponse stateAccountResponse = (StateAccountResponse) o;
-    return Objects.equals(this.info, stateAccountResponse.info) &&
+    return Objects.equals(this.stateVersion, stateAccountResponse.stateVersion) &&
+        Objects.equals(this.info, stateAccountResponse.info) &&
         Objects.equals(this.ownerRole, stateAccountResponse.ownerRole) &&
         Objects.equals(this.state, stateAccountResponse.state) &&
         Objects.equals(this.vaults, stateAccountResponse.vaults);
@@ -186,13 +219,14 @@ public class StateAccountResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(info, ownerRole, state, vaults);
+    return Objects.hash(stateVersion, info, ownerRole, state, vaults);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class StateAccountResponse {\n");
+    sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    info: ").append(toIndentedString(info)).append("\n");
     sb.append("    ownerRole: ").append(toIndentedString(ownerRole)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateComponentResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateComponentResponse.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * StateComponentResponse
  */
 @JsonPropertyOrder({
+  StateComponentResponse.JSON_PROPERTY_STATE_VERSION,
   StateComponentResponse.JSON_PROPERTY_INFO,
   StateComponentResponse.JSON_PROPERTY_STATE,
   StateComponentResponse.JSON_PROPERTY_ROYALTY_ACCUMULATOR,
@@ -45,6 +46,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StateComponentResponse {
+  public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
+  private Long stateVersion;
+
   public static final String JSON_PROPERTY_INFO = "info";
   private Substate info;
 
@@ -65,6 +69,34 @@ public class StateComponentResponse {
 
   public StateComponentResponse() { 
   }
+
+  public StateComponentResponse stateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+    return this;
+  }
+
+   /**
+   * Get stateVersion
+   * minimum: 1
+   * maximum: 100000000000000
+   * @return stateVersion
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getStateVersion() {
+    return stateVersion;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setStateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+  }
+
 
   public StateComponentResponse info(Substate info) {
     this.info = info;
@@ -244,7 +276,8 @@ public class StateComponentResponse {
       return false;
     }
     StateComponentResponse stateComponentResponse = (StateComponentResponse) o;
-    return Objects.equals(this.info, stateComponentResponse.info) &&
+    return Objects.equals(this.stateVersion, stateComponentResponse.stateVersion) &&
+        Objects.equals(this.info, stateComponentResponse.info) &&
         Objects.equals(this.state, stateComponentResponse.state) &&
         Objects.equals(this.royaltyAccumulator, stateComponentResponse.royaltyAccumulator) &&
         Objects.equals(this.ownerRole, stateComponentResponse.ownerRole) &&
@@ -254,13 +287,14 @@ public class StateComponentResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(info, state, royaltyAccumulator, ownerRole, vaults, descendentNodes);
+    return Objects.hash(stateVersion, info, state, royaltyAccumulator, ownerRole, vaults, descendentNodes);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class StateComponentResponse {\n");
+    sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    info: ").append(toIndentedString(info)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    royaltyAccumulator: ").append(toIndentedString(royaltyAccumulator)).append("\n");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateConsensusManagerResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateConsensusManagerResponse.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * StateConsensusManagerResponse
  */
 @JsonPropertyOrder({
+  StateConsensusManagerResponse.JSON_PROPERTY_STATE_VERSION,
   StateConsensusManagerResponse.JSON_PROPERTY_CONFIG,
   StateConsensusManagerResponse.JSON_PROPERTY_STATE,
   StateConsensusManagerResponse.JSON_PROPERTY_CURRENT_PROPOSAL_STATISTIC,
@@ -41,6 +42,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StateConsensusManagerResponse {
+  public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
+  private Long stateVersion;
+
   public static final String JSON_PROPERTY_CONFIG = "config";
   private Substate config;
 
@@ -61,6 +65,34 @@ public class StateConsensusManagerResponse {
 
   public StateConsensusManagerResponse() { 
   }
+
+  public StateConsensusManagerResponse stateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+    return this;
+  }
+
+   /**
+   * Get stateVersion
+   * minimum: 1
+   * maximum: 100000000000000
+   * @return stateVersion
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getStateVersion() {
+    return stateVersion;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setStateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+  }
+
 
   public StateConsensusManagerResponse config(Substate config) {
     this.config = config;
@@ -230,7 +262,8 @@ public class StateConsensusManagerResponse {
       return false;
     }
     StateConsensusManagerResponse stateConsensusManagerResponse = (StateConsensusManagerResponse) o;
-    return Objects.equals(this.config, stateConsensusManagerResponse.config) &&
+    return Objects.equals(this.stateVersion, stateConsensusManagerResponse.stateVersion) &&
+        Objects.equals(this.config, stateConsensusManagerResponse.config) &&
         Objects.equals(this.state, stateConsensusManagerResponse.state) &&
         Objects.equals(this.currentProposalStatistic, stateConsensusManagerResponse.currentProposalStatistic) &&
         Objects.equals(this.currentValidatorSet, stateConsensusManagerResponse.currentValidatorSet) &&
@@ -240,13 +273,14 @@ public class StateConsensusManagerResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(config, state, currentProposalStatistic, currentValidatorSet, currentTime, currentTimeRoundedToMinutes);
+    return Objects.hash(stateVersion, config, state, currentProposalStatistic, currentValidatorSet, currentTime, currentTimeRoundedToMinutes);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class StateConsensusManagerResponse {\n");
+    sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    config: ").append(toIndentedString(config)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    currentProposalStatistic: ").append(toIndentedString(currentProposalStatistic)).append("\n");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateNonFungibleResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateNonFungibleResponse.java
@@ -32,15 +32,47 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * StateNonFungibleResponse
  */
 @JsonPropertyOrder({
+  StateNonFungibleResponse.JSON_PROPERTY_STATE_VERSION,
   StateNonFungibleResponse.JSON_PROPERTY_NON_FUNGIBLE
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StateNonFungibleResponse {
+  public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
+  private Long stateVersion;
+
   public static final String JSON_PROPERTY_NON_FUNGIBLE = "non_fungible";
   private Substate nonFungible;
 
   public StateNonFungibleResponse() { 
   }
+
+  public StateNonFungibleResponse stateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+    return this;
+  }
+
+   /**
+   * Get stateVersion
+   * minimum: 1
+   * maximum: 100000000000000
+   * @return stateVersion
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getStateVersion() {
+    return stateVersion;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setStateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+  }
+
 
   public StateNonFungibleResponse nonFungible(Substate nonFungible) {
     this.nonFungible = nonFungible;
@@ -80,18 +112,20 @@ public class StateNonFungibleResponse {
       return false;
     }
     StateNonFungibleResponse stateNonFungibleResponse = (StateNonFungibleResponse) o;
-    return Objects.equals(this.nonFungible, stateNonFungibleResponse.nonFungible);
+    return Objects.equals(this.stateVersion, stateNonFungibleResponse.stateVersion) &&
+        Objects.equals(this.nonFungible, stateNonFungibleResponse.nonFungible);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(nonFungible);
+    return Objects.hash(stateVersion, nonFungible);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class StateNonFungibleResponse {\n");
+    sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    nonFungible: ").append(toIndentedString(nonFungible)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/StatePackageResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/StatePackageResponse.java
@@ -32,11 +32,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * StatePackageResponse
  */
 @JsonPropertyOrder({
+  StatePackageResponse.JSON_PROPERTY_STATE_VERSION,
   StatePackageResponse.JSON_PROPERTY_OWNER_ROLE,
   StatePackageResponse.JSON_PROPERTY_ROYALTY
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StatePackageResponse {
+  public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
+  private Long stateVersion;
+
   public static final String JSON_PROPERTY_OWNER_ROLE = "owner_role";
   private Substate ownerRole;
 
@@ -45,6 +49,34 @@ public class StatePackageResponse {
 
   public StatePackageResponse() { 
   }
+
+  public StatePackageResponse stateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+    return this;
+  }
+
+   /**
+   * Get stateVersion
+   * minimum: 1
+   * maximum: 100000000000000
+   * @return stateVersion
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getStateVersion() {
+    return stateVersion;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setStateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+  }
+
 
   public StatePackageResponse ownerRole(Substate ownerRole) {
     this.ownerRole = ownerRole;
@@ -110,19 +142,21 @@ public class StatePackageResponse {
       return false;
     }
     StatePackageResponse statePackageResponse = (StatePackageResponse) o;
-    return Objects.equals(this.ownerRole, statePackageResponse.ownerRole) &&
+    return Objects.equals(this.stateVersion, statePackageResponse.stateVersion) &&
+        Objects.equals(this.ownerRole, statePackageResponse.ownerRole) &&
         Objects.equals(this.royalty, statePackageResponse.royalty);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ownerRole, royalty);
+    return Objects.hash(stateVersion, ownerRole, royalty);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class StatePackageResponse {\n");
+    sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    ownerRole: ").append(toIndentedString(ownerRole)).append("\n");
     sb.append("    royalty: ").append(toIndentedString(royalty)).append("\n");
     sb.append("}");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateResourceResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateResourceResponse.java
@@ -33,11 +33,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * StateResourceResponse
  */
 @JsonPropertyOrder({
+  StateResourceResponse.JSON_PROPERTY_STATE_VERSION,
   StateResourceResponse.JSON_PROPERTY_MANAGER,
   StateResourceResponse.JSON_PROPERTY_OWNER_ROLE
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StateResourceResponse {
+  public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
+  private Long stateVersion;
+
   public static final String JSON_PROPERTY_MANAGER = "manager";
   private StateResourceManager manager;
 
@@ -46,6 +50,34 @@ public class StateResourceResponse {
 
   public StateResourceResponse() { 
   }
+
+  public StateResourceResponse stateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+    return this;
+  }
+
+   /**
+   * Get stateVersion
+   * minimum: 1
+   * maximum: 100000000000000
+   * @return stateVersion
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getStateVersion() {
+    return stateVersion;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setStateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+  }
+
 
   public StateResourceResponse manager(StateResourceManager manager) {
     this.manager = manager;
@@ -111,19 +143,21 @@ public class StateResourceResponse {
       return false;
     }
     StateResourceResponse stateResourceResponse = (StateResourceResponse) o;
-    return Objects.equals(this.manager, stateResourceResponse.manager) &&
+    return Objects.equals(this.stateVersion, stateResourceResponse.stateVersion) &&
+        Objects.equals(this.manager, stateResourceResponse.manager) &&
         Objects.equals(this.ownerRole, stateResourceResponse.ownerRole);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(manager, ownerRole);
+    return Objects.hash(stateVersion, manager, ownerRole);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class StateResourceResponse {\n");
+    sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    manager: ").append(toIndentedString(manager)).append("\n");
     sb.append("    ownerRole: ").append(toIndentedString(ownerRole)).append("\n");
     sb.append("}");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateValidatorResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/StateValidatorResponse.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * StateValidatorResponse
  */
 @JsonPropertyOrder({
+  StateValidatorResponse.JSON_PROPERTY_STATE_VERSION,
   StateValidatorResponse.JSON_PROPERTY_ADDRESS,
   StateValidatorResponse.JSON_PROPERTY_STATE,
   StateValidatorResponse.JSON_PROPERTY_OWNER_ROLE,
@@ -44,6 +45,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class StateValidatorResponse {
+  public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
+  private Long stateVersion;
+
   public static final String JSON_PROPERTY_ADDRESS = "address";
   private String address;
 
@@ -61,6 +65,34 @@ public class StateValidatorResponse {
 
   public StateValidatorResponse() { 
   }
+
+  public StateValidatorResponse stateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+    return this;
+  }
+
+   /**
+   * Get stateVersion
+   * minimum: 1
+   * maximum: 100000000000000
+   * @return stateVersion
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public Long getStateVersion() {
+    return stateVersion;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_STATE_VERSION)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setStateVersion(Long stateVersion) {
+    this.stateVersion = stateVersion;
+  }
+
 
   public StateValidatorResponse address(String address) {
     this.address = address;
@@ -214,7 +246,8 @@ public class StateValidatorResponse {
       return false;
     }
     StateValidatorResponse stateValidatorResponse = (StateValidatorResponse) o;
-    return Objects.equals(this.address, stateValidatorResponse.address) &&
+    return Objects.equals(this.stateVersion, stateValidatorResponse.stateVersion) &&
+        Objects.equals(this.address, stateValidatorResponse.address) &&
         Objects.equals(this.state, stateValidatorResponse.state) &&
         Objects.equals(this.ownerRole, stateValidatorResponse.ownerRole) &&
         Objects.equals(this.vaults, stateValidatorResponse.vaults) &&
@@ -223,13 +256,14 @@ public class StateValidatorResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(address, state, ownerRole, vaults, descendentNodes);
+    return Objects.hash(stateVersion, address, state, ownerRole, vaults, descendentNodes);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class StateValidatorResponse {\n");
+    sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    address: ").append(toIndentedString(address)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    ownerRole: ").append(toIndentedString(ownerRole)).append("\n");


### PR DESCRIPTION
The easy part of https://radixdlt.atlassian.net/browse/NODE-563.