### PR TITLE
Including the epoch+round in the ledger summary of state responses

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -1442,9 +1442,12 @@ components:
     LedgerHeaderSummary:
       type: object
       required:
+        - epoch_round
         - ledger_hashes
         - proposer_timestamp
       properties:
+        epoch_round:
+          $ref: "#/components/schemas/EpochRound"
         ledger_hashes:
           $ref: "#/components/schemas/LedgerHashes"
         proposer_timestamp:
@@ -5976,8 +5979,12 @@ components:
     TransactionCallPreviewResponse:
       type: object
       required:
+        - at_ledger_state
         - status
       properties:
+        at_ledger_state:
+          $ref: "#/components/schemas/LedgerStateSummary"
+          description: A summarized state of the ledger on top of which the preview was performed.
         status:
           $ref: "#/components/schemas/TransactionStatus"
         output:
@@ -6066,11 +6073,15 @@ components:
     TransactionPreviewResponse:
       type: object
       required:
+        - at_ledger_state
         - encoded_receipt
         - receipt
         - instruction_resource_changes
         - logs
       properties:
+        at_ledger_state:
+          $ref: "#/components/schemas/LedgerStateSummary"
+          description: A summarized state of the ledger on top of which the preview was performed.
         encoded_receipt:
           type: string
           description: The hex-sbor-encoded receipt

--- a/core-rust/core-api-server/src/core_api/conversions/common.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/common.rs
@@ -3,6 +3,7 @@ use radix_engine::types::*;
 use sbor::representations::*;
 use state_manager::LedgerHeader;
 
+use crate::core_api::handlers::to_api_epoch_round;
 use crate::core_api::*;
 
 #[tracing::instrument(skip_all)]
@@ -139,19 +140,22 @@ pub fn to_api_sbor_data_from_bytes(
 }
 
 pub fn to_api_ledger_state_summary(
+    mapping_context: &MappingContext,
     header: &LedgerHeader,
 ) -> Result<models::LedgerStateSummary, MappingError> {
     Ok(models::LedgerStateSummary {
         state_version: to_api_state_version(header.state_version)?,
-        header_summary: Box::new(to_api_ledger_header_summary(header)?),
+        header_summary: Box::new(to_api_ledger_header_summary(mapping_context, header)?),
     })
 }
 
 pub fn to_api_ledger_header_summary(
+    mapping_context: &MappingContext,
     header: &LedgerHeader,
 ) -> Result<models::LedgerHeaderSummary, MappingError> {
     let hashes = &header.hashes;
     Ok(models::LedgerHeaderSummary {
+        epoch_round: Box::new(to_api_epoch_round(mapping_context, header)?),
         ledger_hashes: Box::new(models::LedgerHashes {
             state_tree_hash: to_api_state_tree_hash(&hashes.state_root),
             transaction_tree_hash: to_api_transaction_tree_hash(&hashes.transaction_root),

--- a/core-rust/core-api-server/src/core_api/generated/models/ledger_header_summary.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/ledger_header_summary.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct LedgerHeaderSummary {
+    #[serde(rename = "epoch_round")]
+    pub epoch_round: Box<crate::core_api::generated::models::EpochRound>,
     #[serde(rename = "ledger_hashes")]
     pub ledger_hashes: Box<crate::core_api::generated::models::LedgerHashes>,
     #[serde(rename = "proposer_timestamp")]
@@ -20,8 +22,9 @@ pub struct LedgerHeaderSummary {
 }
 
 impl LedgerHeaderSummary {
-    pub fn new(ledger_hashes: crate::core_api::generated::models::LedgerHashes, proposer_timestamp: crate::core_api::generated::models::Instant) -> LedgerHeaderSummary {
+    pub fn new(epoch_round: crate::core_api::generated::models::EpochRound, ledger_hashes: crate::core_api::generated::models::LedgerHashes, proposer_timestamp: crate::core_api::generated::models::Instant) -> LedgerHeaderSummary {
         LedgerHeaderSummary {
+            epoch_round: Box::new(epoch_round),
             ledger_hashes: Box::new(ledger_hashes),
             proposer_timestamp: Box::new(proposer_timestamp),
         }

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_call_preview_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_call_preview_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct TransactionCallPreviewResponse {
+    #[serde(rename = "at_ledger_state")]
+    pub at_ledger_state: Box<crate::core_api::generated::models::LedgerStateSummary>,
     #[serde(rename = "status")]
     pub status: crate::core_api::generated::models::TransactionStatus,
     #[serde(rename = "output", skip_serializing_if = "Option::is_none")]
@@ -23,8 +25,9 @@ pub struct TransactionCallPreviewResponse {
 }
 
 impl TransactionCallPreviewResponse {
-    pub fn new(status: crate::core_api::generated::models::TransactionStatus) -> TransactionCallPreviewResponse {
+    pub fn new(at_ledger_state: crate::core_api::generated::models::LedgerStateSummary, status: crate::core_api::generated::models::TransactionStatus) -> TransactionCallPreviewResponse {
         TransactionCallPreviewResponse {
+            at_ledger_state: Box::new(at_ledger_state),
             status,
             output: None,
             error_message: None,

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_preview_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_preview_response.rs
@@ -13,6 +13,8 @@
 
 #[derive(Clone, Debug, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub struct TransactionPreviewResponse {
+    #[serde(rename = "at_ledger_state")]
+    pub at_ledger_state: Box<crate::core_api::generated::models::LedgerStateSummary>,
     /// The hex-sbor-encoded receipt
     #[serde(rename = "encoded_receipt")]
     pub encoded_receipt: String,
@@ -25,8 +27,9 @@ pub struct TransactionPreviewResponse {
 }
 
 impl TransactionPreviewResponse {
-    pub fn new(encoded_receipt: String, receipt: crate::core_api::generated::models::TransactionReceipt, instruction_resource_changes: Vec<crate::core_api::generated::models::InstructionResourceChanges>, logs: Vec<crate::core_api::generated::models::TransactionPreviewResponseLogsInner>) -> TransactionPreviewResponse {
+    pub fn new(at_ledger_state: crate::core_api::generated::models::LedgerStateSummary, encoded_receipt: String, receipt: crate::core_api::generated::models::TransactionReceipt, instruction_resource_changes: Vec<crate::core_api::generated::models::InstructionResourceChanges>, logs: Vec<crate::core_api::generated::models::TransactionPreviewResponseLogsInner>) -> TransactionPreviewResponse {
         TransactionPreviewResponse {
+            at_ledger_state: Box::new(at_ledger_state),
             encoded_receipt,
             receipt: Box::new(receipt),
             instruction_resource_changes,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
@@ -48,7 +48,10 @@ pub(crate) async fn handle_lts_state_account_all_fungible_resource_balances(
         if component_address.as_node_id().is_global_virtual() {
             return Ok(models::LtsStateAccountAllFungibleResourceBalancesResponse {
                 state_version: to_api_state_version(header.state_version)?,
-                ledger_header_summary: Box::new(to_api_ledger_header_summary(&header)?),
+                ledger_header_summary: Box::new(to_api_ledger_header_summary(
+                    &mapping_context,
+                    &header,
+                )?),
                 account_address: to_api_component_address(&mapping_context, &component_address)?,
                 fungible_resource_balances: vec![],
             })
@@ -95,7 +98,7 @@ pub(crate) async fn handle_lts_state_account_all_fungible_resource_balances(
 
     Ok(models::LtsStateAccountAllFungibleResourceBalancesResponse {
         state_version: to_api_state_version(header.state_version)?,
-        ledger_header_summary: Box::new(to_api_ledger_header_summary(&header)?),
+        ledger_header_summary: Box::new(to_api_ledger_header_summary(&mapping_context, &header)?),
         account_address: to_api_component_address(&mapping_context, &component_address)?,
         fungible_resource_balances,
     })

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
@@ -123,7 +123,7 @@ fn response(
 ) -> Result<Json<models::LtsStateAccountFungibleResourceBalanceResponse>, ResponseError<()>> {
     Ok(models::LtsStateAccountFungibleResourceBalanceResponse {
         state_version: to_api_state_version(header.state_version)?,
-        ledger_header_summary: Box::new(to_api_ledger_header_summary(header)?),
+        ledger_header_summary: Box::new(to_api_ledger_header_summary(context, header)?),
         account_address: to_api_component_address(context, account_address)?,
         fungible_resource_balance: Box::new(models::LtsFungibleResourceBalance {
             fungible_resource_address: to_api_resource_address(context, resource_address)?,

--- a/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
@@ -50,7 +50,7 @@ pub(crate) async fn handle_state_access_controller(
         .ledger_header;
 
     Ok(models::StateAccessControllerResponse {
-        at_ledger_state: Box::new(to_api_ledger_state_summary(&header)?),
+        at_ledger_state: Box::new(to_api_ledger_state_summary(&mapping_context, &header)?),
         state: Some(to_api_access_controller_substate(
             &mapping_context,
             &access_controller_substate,

--- a/core-rust/core-api-server/src/core_api/handlers/state_account.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_account.rs
@@ -57,7 +57,7 @@ pub(crate) async fn handle_state_account(
         .ledger_header;
 
     Ok(models::StateAccountResponse {
-        at_ledger_state: Box::new(to_api_ledger_state_summary(&header)?),
+        at_ledger_state: Box::new(to_api_ledger_state_summary(&mapping_context, &header)?),
         info: Some(to_api_type_info_substate(&mapping_context, &type_info)?),
         owner_role: Some(to_api_owner_role_substate(
             &mapping_context,

--- a/core-rust/core-api-server/src/core_api/handlers/state_component.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_component.rs
@@ -66,7 +66,7 @@ pub(crate) async fn handle_state_component(
         .ledger_header;
 
     Ok(models::StateComponentResponse {
-        at_ledger_state: Box::new(to_api_ledger_state_summary(&header)?),
+        at_ledger_state: Box::new(to_api_ledger_state_summary(&mapping_context, &header)?),
         info: Some(to_api_type_info_substate(
             &mapping_context,
             &type_info_substate,

--- a/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
@@ -49,7 +49,7 @@ pub(crate) async fn handle_state_consensus_manager(
         .ledger_header;
 
     Ok(models::StateConsensusManagerResponse {
-        at_ledger_state: Box::new(to_api_ledger_state_summary(&header)?),
+        at_ledger_state: Box::new(to_api_ledger_state_summary(&mapping_context, &header)?),
         config: Some(to_api_consensus_manager_config_substate(&config_substate)?),
         state: Some(to_api_consensus_manager_state_substate(
             &mapping_context,

--- a/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
@@ -67,7 +67,7 @@ pub(crate) async fn handle_state_non_fungible(
         .ledger_header;
 
     Ok(StateNonFungibleResponse {
-        at_ledger_state: Box::new(to_api_ledger_state_summary(&header)?),
+        at_ledger_state: Box::new(to_api_ledger_state_summary(&mapping_context, &header)?),
         non_fungible: Some(to_api_non_fungible_resource_manager_data_substate(
             &mapping_context,
             &TypedSubstateKey::MainModule(TypedMainModuleSubstateKey::NonFungibleResourceData(

--- a/core-rust/core-api-server/src/core_api/handlers/state_package.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_package.rs
@@ -36,7 +36,7 @@ pub(crate) async fn handle_state_package(
         .ledger_header;
 
     Ok(models::StatePackageResponse {
-        at_ledger_state: Box::new(to_api_ledger_state_summary(&header)?),
+        at_ledger_state: Box::new(to_api_ledger_state_summary(&mapping_context, &header)?),
         owner_role: Some(to_api_owner_role_substate(
             &mapping_context,
             &owner_role_substate,

--- a/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
@@ -83,7 +83,7 @@ pub(crate) async fn handle_state_resource(
         .ledger_header;
 
     Ok(models::StateResourceResponse {
-        at_ledger_state: Box::new(to_api_ledger_state_summary(&header)?),
+        at_ledger_state: Box::new(to_api_ledger_state_summary(&mapping_context, &header)?),
         manager: Some(to_api_resource_manager(&mapping_context, &manager)?),
         owner_role: Some(to_api_owner_role_substate(
             &mapping_context,

--- a/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
@@ -53,7 +53,7 @@ pub(crate) async fn handle_state_validator(
         .ledger_header;
 
     Ok(models::StateValidatorResponse {
-        at_ledger_state: Box::new(to_api_ledger_state_summary(&header)?),
+        at_ledger_state: Box::new(to_api_ledger_state_summary(&mapping_context, &header)?),
         address: to_api_component_address(&mapping_context, &validator_address)?,
         state: Some(to_api_validator_substate(
             &mapping_context,

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -4,7 +4,7 @@ use radix_engine_interface::prelude::*;
 
 use state_manager::query::TransactionIdentifierLoader;
 use state_manager::store::traits::*;
-use state_manager::{LedgerHashes, LedgerProof, StateVersion};
+use state_manager::{LedgerHashes, LedgerHeader, LedgerProof, StateVersion};
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_status_network_status(
@@ -24,7 +24,10 @@ pub(crate) async fn handle_status_network_status(
         genesis_epoch_round: database
             .get_first_proof()
             .map(|proof| -> Result<_, MappingError> {
-                Ok(Box::new(to_api_epoch_round(&mapping_context, &proof)?))
+                Ok(Box::new(to_api_epoch_round(
+                    &mapping_context,
+                    &proof.ledger_header,
+                )?))
             })
             .transpose()?,
         post_genesis_state_identifier: database
@@ -65,7 +68,10 @@ pub(crate) async fn handle_status_network_status(
         current_epoch_round: database
             .get_last_proof()
             .map(|proof| -> Result<_, MappingError> {
-                Ok(Box::new(to_api_epoch_round(&mapping_context, &proof)?))
+                Ok(Box::new(to_api_epoch_round(
+                    &mapping_context,
+                    &proof.ledger_header,
+                )?))
             })
             .transpose()?,
         current_protocol_version: "babylon".to_string(),
@@ -75,11 +81,11 @@ pub(crate) async fn handle_status_network_status(
 
 pub fn to_api_epoch_round(
     context: &MappingContext,
-    ledger_proof: &LedgerProof,
+    ledger_header: &LedgerHeader,
 ) -> Result<models::EpochRound, MappingError> {
     Ok(models::EpochRound {
-        epoch: to_api_epoch(context, ledger_proof.ledger_header.epoch)?,
-        round: to_api_round(ledger_proof.ledger_header.round)?,
+        epoch: to_api_epoch(context, ledger_header.epoch)?,
+        round: to_api_round(ledger_header.round)?,
     })
 }
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -151,6 +151,10 @@ pub(crate) async fn handle_transaction_callpreview(
     };
 
     Ok(TransactionCallPreviewResponse {
+        at_ledger_state: Box::new(to_api_ledger_state_summary(
+            &mapping_context,
+            &result.base_ledger_header,
+        )?),
         error_message: error,
         output: output.map(Box::new),
         status,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
@@ -102,6 +102,11 @@ fn to_api_response(
     let receipt = result.receipt;
     let encoded_receipt = to_hex(scrypto_encode(&receipt).unwrap());
 
+    let at_ledger_state = Box::new(to_api_ledger_state_summary(
+        context,
+        &result.base_ledger_header,
+    )?);
+
     let response = match receipt.transaction_result {
         TransactionResult::Commit(commit_result) => {
             let mut instruction_resource_changes = Vec::new();
@@ -148,6 +153,7 @@ fn to_api_response(
                 LocalTransactionReceipt::from((commit_result, result.substate_changes));
 
             models::TransactionPreviewResponse {
+                at_ledger_state,
                 encoded_receipt,
                 receipt: Box::new(to_api_receipt(context, local_receipt)?),
                 instruction_resource_changes,
@@ -155,6 +161,7 @@ fn to_api_response(
             }
         }
         TransactionResult::Reject(reject_result) => models::TransactionPreviewResponse {
+            at_ledger_state,
             encoded_receipt,
             receipt: Box::new(models::TransactionReceipt {
                 status: models::TransactionStatus::Rejected,

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -8,7 +8,7 @@ use crate::query::{StateManagerSubstateQueries, TransactionIdentifierLoader};
 use crate::staging::ReadableStore;
 use crate::store::traits::QueryableProofStore;
 use crate::transaction::*;
-use crate::{PreviewRequest, ProcessedCommitResult, SubstateChange};
+use crate::{LedgerHeader, PreviewRequest, ProcessedCommitResult, SubstateChange};
 use radix_engine_common::prelude::*;
 use transaction::model::*;
 use transaction::signing::secp256k1::Secp256k1PrivateKey;
@@ -23,6 +23,7 @@ pub struct TransactionPreviewer<S> {
 }
 
 pub struct ProcessedPreviewResult {
+    pub base_ledger_header: LedgerHeader,
     pub receipt: TransactionReceipt,
     pub substate_changes: Vec<SubstateChange>,
 }
@@ -69,7 +70,13 @@ impl<S: ReadableStore + QueryableProofStore + TransactionIdentifierLoader> Trans
             _ => Vec::new(),
         };
 
+        let base_ledger_header = read_store
+            .get_last_proof()
+            .expect("proof for preview's base state")
+            .ledger_header;
+
         Ok(ProcessedPreviewResult {
+            base_ledger_header,
             receipt,
             substate_changes,
         })

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/LedgerHeaderSummary.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/LedgerHeaderSummary.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.radixdlt.api.core.generated.models.EpochRound;
 import com.radixdlt.api.core.generated.models.Instant;
 import com.radixdlt.api.core.generated.models.LedgerHashes;
 import io.swagger.annotations.ApiModel;
@@ -33,11 +34,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * LedgerHeaderSummary
  */
 @JsonPropertyOrder({
+  LedgerHeaderSummary.JSON_PROPERTY_EPOCH_ROUND,
   LedgerHeaderSummary.JSON_PROPERTY_LEDGER_HASHES,
   LedgerHeaderSummary.JSON_PROPERTY_PROPOSER_TIMESTAMP
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class LedgerHeaderSummary {
+  public static final String JSON_PROPERTY_EPOCH_ROUND = "epoch_round";
+  private EpochRound epochRound;
+
   public static final String JSON_PROPERTY_LEDGER_HASHES = "ledger_hashes";
   private LedgerHashes ledgerHashes;
 
@@ -46,6 +51,32 @@ public class LedgerHeaderSummary {
 
   public LedgerHeaderSummary() { 
   }
+
+  public LedgerHeaderSummary epochRound(EpochRound epochRound) {
+    this.epochRound = epochRound;
+    return this;
+  }
+
+   /**
+   * Get epochRound
+   * @return epochRound
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_EPOCH_ROUND)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public EpochRound getEpochRound() {
+    return epochRound;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EPOCH_ROUND)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setEpochRound(EpochRound epochRound) {
+    this.epochRound = epochRound;
+  }
+
 
   public LedgerHeaderSummary ledgerHashes(LedgerHashes ledgerHashes) {
     this.ledgerHashes = ledgerHashes;
@@ -111,19 +142,21 @@ public class LedgerHeaderSummary {
       return false;
     }
     LedgerHeaderSummary ledgerHeaderSummary = (LedgerHeaderSummary) o;
-    return Objects.equals(this.ledgerHashes, ledgerHeaderSummary.ledgerHashes) &&
+    return Objects.equals(this.epochRound, ledgerHeaderSummary.epochRound) &&
+        Objects.equals(this.ledgerHashes, ledgerHeaderSummary.ledgerHashes) &&
         Objects.equals(this.proposerTimestamp, ledgerHeaderSummary.proposerTimestamp);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(ledgerHashes, proposerTimestamp);
+    return Objects.hash(epochRound, ledgerHashes, proposerTimestamp);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LedgerHeaderSummary {\n");
+    sb.append("    epochRound: ").append(toIndentedString(epochRound)).append("\n");
     sb.append("    ledgerHashes: ").append(toIndentedString(ledgerHashes)).append("\n");
     sb.append("    proposerTimestamp: ").append(toIndentedString(proposerTimestamp)).append("\n");
     sb.append("}");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionCallPreviewResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionCallPreviewResponse.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.radixdlt.api.core.generated.models.LedgerStateSummary;
 import com.radixdlt.api.core.generated.models.SborData;
 import com.radixdlt.api.core.generated.models.TransactionStatus;
 import io.swagger.annotations.ApiModel;
@@ -33,12 +34,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * TransactionCallPreviewResponse
  */
 @JsonPropertyOrder({
+  TransactionCallPreviewResponse.JSON_PROPERTY_AT_LEDGER_STATE,
   TransactionCallPreviewResponse.JSON_PROPERTY_STATUS,
   TransactionCallPreviewResponse.JSON_PROPERTY_OUTPUT,
   TransactionCallPreviewResponse.JSON_PROPERTY_ERROR_MESSAGE
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class TransactionCallPreviewResponse {
+  public static final String JSON_PROPERTY_AT_LEDGER_STATE = "at_ledger_state";
+  private LedgerStateSummary atLedgerState;
+
   public static final String JSON_PROPERTY_STATUS = "status";
   private TransactionStatus status;
 
@@ -50,6 +55,32 @@ public class TransactionCallPreviewResponse {
 
   public TransactionCallPreviewResponse() { 
   }
+
+  public TransactionCallPreviewResponse atLedgerState(LedgerStateSummary atLedgerState) {
+    this.atLedgerState = atLedgerState;
+    return this;
+  }
+
+   /**
+   * Get atLedgerState
+   * @return atLedgerState
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_AT_LEDGER_STATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public LedgerStateSummary getAtLedgerState() {
+    return atLedgerState;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_AT_LEDGER_STATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setAtLedgerState(LedgerStateSummary atLedgerState) {
+    this.atLedgerState = atLedgerState;
+  }
+
 
   public TransactionCallPreviewResponse status(TransactionStatus status) {
     this.status = status;
@@ -141,20 +172,22 @@ public class TransactionCallPreviewResponse {
       return false;
     }
     TransactionCallPreviewResponse transactionCallPreviewResponse = (TransactionCallPreviewResponse) o;
-    return Objects.equals(this.status, transactionCallPreviewResponse.status) &&
+    return Objects.equals(this.atLedgerState, transactionCallPreviewResponse.atLedgerState) &&
+        Objects.equals(this.status, transactionCallPreviewResponse.status) &&
         Objects.equals(this.output, transactionCallPreviewResponse.output) &&
         Objects.equals(this.errorMessage, transactionCallPreviewResponse.errorMessage);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, output, errorMessage);
+    return Objects.hash(atLedgerState, status, output, errorMessage);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class TransactionCallPreviewResponse {\n");
+    sb.append("    atLedgerState: ").append(toIndentedString(atLedgerState)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    output: ").append(toIndentedString(output)).append("\n");
     sb.append("    errorMessage: ").append(toIndentedString(errorMessage)).append("\n");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionPreviewResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionPreviewResponse.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.radixdlt.api.core.generated.models.InstructionResourceChanges;
+import com.radixdlt.api.core.generated.models.LedgerStateSummary;
 import com.radixdlt.api.core.generated.models.TransactionPreviewResponseLogsInner;
 import com.radixdlt.api.core.generated.models.TransactionReceipt;
 import io.swagger.annotations.ApiModel;
@@ -36,6 +37,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * TransactionPreviewResponse
  */
 @JsonPropertyOrder({
+  TransactionPreviewResponse.JSON_PROPERTY_AT_LEDGER_STATE,
   TransactionPreviewResponse.JSON_PROPERTY_ENCODED_RECEIPT,
   TransactionPreviewResponse.JSON_PROPERTY_RECEIPT,
   TransactionPreviewResponse.JSON_PROPERTY_INSTRUCTION_RESOURCE_CHANGES,
@@ -43,6 +45,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class TransactionPreviewResponse {
+  public static final String JSON_PROPERTY_AT_LEDGER_STATE = "at_ledger_state";
+  private LedgerStateSummary atLedgerState;
+
   public static final String JSON_PROPERTY_ENCODED_RECEIPT = "encoded_receipt";
   private String encodedReceipt;
 
@@ -57,6 +62,32 @@ public class TransactionPreviewResponse {
 
   public TransactionPreviewResponse() { 
   }
+
+  public TransactionPreviewResponse atLedgerState(LedgerStateSummary atLedgerState) {
+    this.atLedgerState = atLedgerState;
+    return this;
+  }
+
+   /**
+   * Get atLedgerState
+   * @return atLedgerState
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_AT_LEDGER_STATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public LedgerStateSummary getAtLedgerState() {
+    return atLedgerState;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_AT_LEDGER_STATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setAtLedgerState(LedgerStateSummary atLedgerState) {
+    this.atLedgerState = atLedgerState;
+  }
+
 
   public TransactionPreviewResponse encodedReceipt(String encodedReceipt) {
     this.encodedReceipt = encodedReceipt;
@@ -184,7 +215,8 @@ public class TransactionPreviewResponse {
       return false;
     }
     TransactionPreviewResponse transactionPreviewResponse = (TransactionPreviewResponse) o;
-    return Objects.equals(this.encodedReceipt, transactionPreviewResponse.encodedReceipt) &&
+    return Objects.equals(this.atLedgerState, transactionPreviewResponse.atLedgerState) &&
+        Objects.equals(this.encodedReceipt, transactionPreviewResponse.encodedReceipt) &&
         Objects.equals(this.receipt, transactionPreviewResponse.receipt) &&
         Objects.equals(this.instructionResourceChanges, transactionPreviewResponse.instructionResourceChanges) &&
         Objects.equals(this.logs, transactionPreviewResponse.logs);
@@ -192,13 +224,14 @@ public class TransactionPreviewResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(encodedReceipt, receipt, instructionResourceChanges, logs);
+    return Objects.hash(atLedgerState, encodedReceipt, receipt, instructionResourceChanges, logs);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class TransactionPreviewResponse {\n");
+    sb.append("    atLedgerState: ").append(toIndentedString(atLedgerState)).append("\n");
     sb.append("    encodedReceipt: ").append(toIndentedString(encodedReceipt)).append("\n");
     sb.append("    receipt: ").append(toIndentedString(receipt)).append("\n");
     sb.append("    instructionResourceChanges: ").append(toIndentedString(instructionResourceChanges)).append("\n");


### PR DESCRIPTION
... also, this PR adds the entire ledger summary to preview responses.

This is a follow up to https://github.com/radixdlt/babylon-node/pull/586, as requested at https://rdxworks.slack.com/archives/C01M90Y2448/p1691450140878449?thread_ts=1691176138.574649&cid=C01M90Y2448.
