### PR TITLE
Fixing a compile error (extra param needed) after scrypto update

### DIFF
--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -1302,9 +1302,12 @@ mod tests {
                 ManifestBuilder::new()
                     .lock_fee_from_faucet()
                     .get_free_xrd_from_faucet()
-                    .try_deposit_batch_or_abort(ComponentAddress::virtual_account_from_public_key(
-                        &sig_1_private_key.public_key(),
-                    ))
+                    .try_deposit_batch_or_abort(
+                        ComponentAddress::virtual_account_from_public_key(
+                            &sig_1_private_key.public_key(),
+                        ),
+                        None,
+                    )
                     .build(),
             )
             .sign(&sig_1_private_key)


### PR DESCRIPTION
An auto-merge after updating scrypto (https://github.com/radixdlt/babylon-node/pull/597) was unfortunate.
Our `develop` does not test-compile ATM.