### PR TITLE
remove the setfattr line as it is not available in debian 12

### DIFF
--- a/docker/build_scripts/config_radixdlt.sh
+++ b/docker/build_scripts/config_radixdlt.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Sets USER_ID to LOCAL_USER_ID if provided, else set it to 999
-USER_ID=${LOCAL_USER_ID:-999}
+USER_ID=${LOCAL_USER_ID:-996}
 USER_NAME=radixdlt
 
 # Check and delete the user that is created in postinstall action of deb package

--- a/docker/build_scripts/config_radixdlt.sh
+++ b/docker/build_scripts/config_radixdlt.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# Need this to run on Alpine (grsec) kernels without crashing
-find /usr -type f -name java -exec setfattr -n user.pax.flags -v em {} \;
-
 # Sets USER_ID to LOCAL_USER_ID if provided, else set it to 999
 USER_ID=${LOCAL_USER_ID:-999}
 USER_NAME=radixdlt


### PR DESCRIPTION
This pr removes the setfattr line from the config script as it is only done for alpine kernels. we'll find a better approach to deal with that in the future 