### PR TITLE
Metrics: Fixing a rendering of validator address in metric labels

### DIFF
--- a/core-rust/node-common/src/metrics.rs
+++ b/core-rust/node-common/src/metrics.rs
@@ -64,7 +64,6 @@
 
 use prometheus::core::*;
 use prometheus::*;
-use radix_engine_common::types::ComponentAddress;
 
 /// A syntactic sugar trait allowing for an inline "create + register" metric definition.
 pub trait AtDefaultRegistryExt<R> {
@@ -212,14 +211,6 @@ impl<T: MetricLabel> MetricLabel for &T {
 
     fn prometheus_label_name(&self) -> Self::StringReturnType {
         T::prometheus_label_name(self)
-    }
-}
-
-impl MetricLabel for ComponentAddress {
-    type StringReturnType = String;
-
-    fn prometheus_label_name(&self) -> Self::StringReturnType {
-        self.to_hex()
     }
 }
 

--- a/core-rust/state-manager/src/metrics.rs
+++ b/core-rust/state-manager/src/metrics.rs
@@ -74,6 +74,7 @@ use radix_engine::transaction::ExecutionConfig;
 use radix_engine_common::prelude::*;
 
 pub struct LedgerMetrics {
+    address_encoder: AddressBech32Encoder, // for label rendering only
     pub state_version: IntGauge,
     pub transactions_committed: IntCounter,
     pub consensus_rounds_committed: IntCounterVec,
@@ -99,8 +100,9 @@ pub struct VertexPrepareMetrics {
 }
 
 impl LedgerMetrics {
-    pub fn new(registry: &Registry) -> Self {
+    pub fn new(network: &NetworkDefinition, registry: &Registry) -> Self {
         Self {
+            address_encoder: AddressBech32Encoder::new(network),
             state_version: IntGauge::with_opts(opts(
                 "ledger_state_version",
                 "Version of the ledger state.",
@@ -143,6 +145,11 @@ impl LedgerMetrics {
         self.transactions_committed
             .inc_by(added_transactions as u64);
         for (validator_address, counter) in validator_proposal_counters {
+            let encoded_validator_address = self
+                .address_encoder
+                .encode(validator_address.as_ref())
+                // a fallback for an unlikely encoding error:
+                .unwrap_or_else(|_| validator_address.to_hex());
             for (round_resolution, count) in [
                 (ConsensusRoundResolution::Successful, counter.successful),
                 (
@@ -152,7 +159,7 @@ impl LedgerMetrics {
                 (ConsensusRoundResolution::MissedByGap, counter.missed_by_gap),
             ] {
                 self.consensus_rounds_committed
-                    .with_two_labels(validator_address, round_resolution)
+                    .with_two_labels(&encoded_validator_address, round_resolution)
                     .inc_by(count as u64);
             }
         }

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -160,7 +160,7 @@ impl<S: TransactionIdentifierLoader> StateComputer<S> {
             logging_config: logging_config.state_manager_config,
             vertex_prepare_metrics: VertexPrepareMetrics::new(metrics_registry),
             vertex_limits_config,
-            ledger_metrics: LedgerMetrics::new(metrics_registry),
+            ledger_metrics: LedgerMetrics::new(network, metrics_registry),
             committed_transactions_metrics,
         }
     }


### PR DESCRIPTION
Spotted randomly:

All other metrics are using Bech32m, apart from this one:
`rn_ledger_consensus_rounds_committed{leader_component_address="833d72e50885b684fb3d59e496d02c824da5a7ca3cdc3cc3c2ee4fa2d701", ...`

After this PR:
`rn_ledger_consensus_rounds_committed{leader_component_address="validator_loc1sv7h9eggskmgf7eat8jfd5pvsfx6tf728nwres7zae8694cp5xewdk", ...`