### PR TITLE
Mempool improvement: remove transactions on epoch change

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -893,6 +893,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,7 +1535,7 @@ version = "0.12.0"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=fig-715722bf65#715722bf65a5c18302894b7a9c6a823e67e1e22c"
 dependencies = [
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "paste",
  "radix-engine",
  "radix-engine-interface",
@@ -1542,7 +1551,7 @@ version = "0.12.0"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=fig-715722bf65#715722bf65a5c18302894b7a9c6a823e67e1e22c"
 dependencies = [
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "radix-engine-common",
  "radix-engine-derive",
  "radix-engine-interface",
@@ -1556,7 +1565,7 @@ version = "0.12.0"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=fig-715722bf65#715722bf65a5c18302894b7a9c6a823e67e1e22c"
 dependencies = [
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "radix-engine-common",
  "radix-engine-derive",
  "radix-engine-store-interface",
@@ -1768,7 +1777,7 @@ version = "0.12.0"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=fig-715722bf65#715722bf65a5c18302894b7a9c6a823e67e1e22c"
 dependencies = [
  "const-sha1",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2023,6 +2032,7 @@ dependencies = [
  "enum_dispatch",
  "hex",
  "im",
+ "itertools 0.11.0",
  "jni",
  "lru",
  "node-common",
@@ -2341,7 +2351,7 @@ version = "0.12.0"
 source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=fig-715722bf65#715722bf65a5c18302894b7a9c6a823e67e1e22c"
 dependencies = [
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "radix-engine",
  "radix-engine-interface",
  "radix-engine-store-interface",

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -32,6 +32,7 @@ radix-engine-store-interface = { git = "https://github.com/radixdlt/radixdlt-scr
 radix-engine-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "fig-715722bf65" }
 utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "fig-715722bf65", features = ["serde"] }
 
+itertools = { version = "0.11.0" }
 jni = { version = "0.19.0" }
 tracing = { version = "0.1" }
 tokio = { version = "1.21.0", features = ["rt-multi-thread"] }

--- a/core-rust/state-manager/Cargo.toml
+++ b/core-rust/state-manager/Cargo.toml
@@ -18,6 +18,7 @@ radix-engine-queries = { workspace = true }
 utils = { workspace = true }
 
 # Non-Radix Engine Dependencies:
+itertools = { workspace = true }
 jni = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -368,7 +368,7 @@ impl MempoolManager {
     }
 
     /// Removes transactions no longer valid at or after the given epoch.
-    pub fn remove_before_epoch(&self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
-        self.mempool.write().remove_before_epoch(epoch)
+    pub fn remove_txns_where_end_epoch_expired(&self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
+        self.mempool.write().remove_txns_where_end_epoch_expired(epoch)
     }
 }

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -366,4 +366,9 @@ impl MempoolManager {
                 write_mempool.remove_by_payload_hash(user_payload_hash);
             });
     }
+
+    /// Removes transactions no longer valid at or after the given epoch.
+    pub fn remove_before_epoch(&self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
+        self.mempool.write().remove_before_epoch(epoch)
+    }
 }

--- a/core-rust/state-manager/src/mempool/priority_mempool.rs
+++ b/core-rust/state-manager/src/mempool/priority_mempool.rs
@@ -432,15 +432,15 @@ impl PriorityMempool {
             .collect()
     }
 
-    pub fn remove_before_epoch(&mut self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
-        let mempool_data = self.get_transactions_before_epoch(epoch);
+    pub fn remove_txns_where_end_epoch_expired(&mut self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
+        let mempool_data = self.get_txns_where_end_epoch_expired(epoch);
         mempool_data
             .iter()
             .for_each(|data| self.remove_data(data.clone()));
         mempool_data
     }
 
-    pub fn get_transactions_before_epoch(&self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
+    pub fn get_txns_where_end_epoch_expired(&self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
         self.end_epoch_exclusive_index
             .iter()
             .take_while_ref(|&mempool_data_end_epoch_order| {

--- a/core-rust/state-manager/src/mempool/priority_mempool.rs
+++ b/core-rust/state-manager/src/mempool/priority_mempool.rs
@@ -71,6 +71,7 @@ use transaction::model::*;
 use utils::prelude::indexmap::IndexMap;
 
 use crate::mempool::*;
+use itertools::Itertools;
 
 use std::cmp::{max, min, Ordering};
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -111,6 +112,16 @@ impl MempoolTransaction {
             .header
             .inner
             .tip_percentage
+    }
+
+    pub fn end_epoch_exclusive(&self) -> Epoch {
+        self.validated
+            .prepared
+            .signed_intent
+            .intent
+            .header
+            .inner
+            .end_epoch_exclusive
     }
 }
 
@@ -173,19 +184,46 @@ impl PartialOrd for MempoolDataProposalPriorityOrdering {
     }
 }
 
+/// A wrapper around an [`Arc<MempoolData>`] which implements ordering traits by end epoch (exclusive).
+#[derive(Clone, Eq, PartialEq)]
+pub struct MempoolDataEndEpochExclusiveOrdering(pub Arc<MempoolData>);
+
+impl Ord for MempoolDataEndEpochExclusiveOrdering {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0
+            .transaction
+            .end_epoch_exclusive()
+            .cmp(&other.0.transaction.end_epoch_exclusive())
+            .then_with(|| {
+                self.0
+                    .transaction
+                    .notarized_transaction_hash()
+                    .cmp(&other.0.transaction.notarized_transaction_hash())
+            })
+    }
+}
+
+impl PartialOrd for MempoolDataEndEpochExclusiveOrdering {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 pub struct PriorityMempool {
     /// Max number of different (by [`NotarizedTransactionHash`]) transactions that can live at any moment of time in the mempool.
     remaining_transaction_count: u32,
     /// Max sum of transactions size that can live in [`self.data`].
     remaining_total_transactions_size: u64,
-    /// Keeps ordering of the transactions by proposal priority (best transaction is highest tip percentage and longest time in mempool)
-    proposal_priority_index: BTreeSet<MempoolDataProposalPriorityOrdering>,
     /// Mapping from [`NotarizedTransactionHash`] to [`Arc<MempoolData>`] containing [`MempoolTransaction`] with said payload hash.
     /// We use [`IndexMap`] for it's O(1) [`get_index`] needed for efficient random sampling.
     data: IndexMap<NotarizedTransactionHash, Arc<MempoolData>>,
     /// Mapping from [`IntentHash`] to all transactions ([`NotarizedTransactionHash`]) that submit said intent.
     intent_lookup: HashMap<IntentHash, HashSet<NotarizedTransactionHash>>,
-    /// Various metrics
+    /// Keeps ordering of the transactions by proposal priority (best transaction is highest tip percentage and longest time in mempool).
+    proposal_priority_index: BTreeSet<MempoolDataProposalPriorityOrdering>,
+    /// Keeps ordering of the transactions by end epoch.
+    end_epoch_exclusive_index: BTreeSet<MempoolDataEndEpochExclusiveOrdering>,
+    /// Various metrics.
     metrics: MempoolMetrics,
 }
 
@@ -194,9 +232,10 @@ impl PriorityMempool {
         PriorityMempool {
             remaining_transaction_count: config.max_transaction_count,
             remaining_total_transactions_size: config.max_total_transactions_size,
-            proposal_priority_index: BTreeSet::new(),
             data: IndexMap::new(),
             intent_lookup: HashMap::new(),
+            proposal_priority_index: BTreeSet::new(),
+            end_epoch_exclusive_index: BTreeSet::new(),
             metrics: MempoolMetrics::new(metric_registry),
         }
     }
@@ -286,12 +325,20 @@ impl PriorityMempool {
         self.metrics.submission_added.with_label(source).inc();
 
         // Add new MempoolData
-        if self.data.insert(payload_hash, transaction_data).is_some() {
+        if self
+            .data
+            .insert(payload_hash, transaction_data.clone())
+            .is_some()
+        {
             panic!("Broken precondition: Transaction already inside mempool");
         }
 
         // Add proposal priority index
         self.proposal_priority_index.insert(new_order_data);
+
+        // Add end epoch exclusive index
+        self.end_epoch_exclusive_index
+            .insert(MempoolDataEndEpochExclusiveOrdering(transaction_data));
 
         // Add intent lookup
         self.intent_lookup
@@ -339,9 +386,16 @@ impl PriorityMempool {
 
         if !self
             .proposal_priority_index
-            .remove(&MempoolDataProposalPriorityOrdering(data))
+            .remove(&MempoolDataProposalPriorityOrdering(data.clone()))
         {
             panic!("Mempool priority index out of sync on remove");
+        }
+
+        if !self
+            .end_epoch_exclusive_index
+            .remove(&MempoolDataEndEpochExclusiveOrdering(data))
+        {
+            panic!("Mempool end epoch index out of sync on remove");
         }
     }
 
@@ -375,6 +429,28 @@ impl PriorityMempool {
                 self.remove_data(data.clone());
                 data
             })
+            .collect()
+    }
+
+    pub fn remove_before_epoch(&mut self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
+        let mempool_data = self.get_transactions_before_epoch(epoch);
+        mempool_data
+            .iter()
+            .for_each(|data| self.remove_data(data.clone()));
+        mempool_data
+    }
+
+    pub fn get_transactions_before_epoch(&self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
+        self.end_epoch_exclusive_index
+            .iter()
+            .take_while_ref(|&mempool_data_end_epoch_order| {
+                mempool_data_end_epoch_order
+                    .0
+                    .transaction
+                    .end_epoch_exclusive()
+                    < epoch
+            })
+            .map(|mempool_data_end_epoch_order| mempool_data_end_epoch_order.0.clone())
             .collect()
     }
 

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -1108,6 +1108,10 @@ where
 
         let round_counters = leader_round_counters_builder.build(series_executor.epoch_header());
         let proposer_timestamp_ms = commit_ledger_header.proposer_timestamp_ms; // for metrics only
+        let next_epoch = commit_ledger_header
+            .next_epoch
+            .as_ref()
+            .map(|next_epoch| next_epoch.epoch);
 
         write_store.commit(CommitBundle {
             transactions: committed_transaction_bundles,
@@ -1125,6 +1129,9 @@ where
                 .iter()
                 .map(|txn| &txn.intent_hash),
         );
+        if let Some(epoch) = next_epoch {
+            self.mempool_manager.remove_before_epoch(epoch);
+        }
         self.pending_transaction_result_cache
             .write()
             .track_committed_transactions(SystemTime::now(), committed_user_transactions);

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -1130,7 +1130,7 @@ where
                 .map(|txn| &txn.intent_hash),
         );
         if let Some(epoch) = next_epoch {
-            self.mempool_manager.remove_before_epoch(epoch);
+            self.mempool_manager.remove_txns_where_end_epoch_expired(epoch);
         }
         self.pending_transaction_result_cache
             .write()


### PR DESCRIPTION
Add a new mempool index that keeps transactions sorted by `end_epoch_exclusive`. Use this index to remove transactions that are no longer valid after epoch change.