### PR TITLE
Metrics: a rate of ledger proposer timestamp during N most recent ledger updates

### DIFF
--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -124,7 +124,7 @@ pub struct StateComputer<S> {
     logging_config: StateComputerLoggingConfig,
 }
 
-impl<S: TransactionIdentifierLoader> StateComputer<S> {
+impl<S: QueryableProofStore> StateComputer<S> {
     // TODO: refactor and maybe make clippy happy too
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -138,7 +138,12 @@ impl<S: TransactionIdentifierLoader> StateComputer<S> {
         metrics_registry: &Registry,
         lock_factory: &LockFactory,
     ) -> StateComputer<S> {
-        let transaction_root = store.read().get_top_ledger_hashes().1.transaction_root;
+        let (current_transaction_root, current_ledger_proposer_timestamp_ms) = store
+            .read()
+            .get_last_proof()
+            .map(|proof| proof.ledger_header)
+            .map(|header| (header.hashes.transaction_root, header.proposer_timestamp_ms))
+            .unwrap_or_else(|| (LedgerHashes::pre_genesis().transaction_root, 0));
 
         let regular_execution_config = execution_configurator
             .execution_configs
@@ -155,7 +160,7 @@ impl<S: TransactionIdentifierLoader> StateComputer<S> {
             pending_transaction_result_cache,
             execution_cache: lock_factory
                 .named("execution_cache")
-                .new_mutex(ExecutionCache::new(transaction_root)),
+                .new_mutex(ExecutionCache::new(current_transaction_root)),
             ledger_transaction_validator: LedgerTransactionValidator::new(network),
             logging_config: logging_config.state_manager_config,
             vertex_prepare_metrics: VertexPrepareMetrics::new(metrics_registry),
@@ -164,6 +169,7 @@ impl<S: TransactionIdentifierLoader> StateComputer<S> {
                 network,
                 &lock_factory.named("ledger_metrics"),
                 metrics_registry,
+                current_ledger_proposer_timestamp_ms,
             ),
             committed_transactions_metrics,
         }


### PR DESCRIPTION
⚠️ This builds on top of https://github.com/radixdlt/babylon-node/pull/605 (re-uses the ring-buffer impl)

This PR adds a `rn_ledger_recent_proposer_timestamp_progress_rate` metric (as promised in the https://github.com/radixdlt/babylon-node/pull/582#issuecomment-1673254726). It will be needed for a computation of the "overall health" (see https://whimsical.com/node-status-and-health-metrics-QXjDREqeRDvGDu6xg3J8wx@2bsEvpTYSt1Hir2FvjaStZLhMXjmH9Prk7p).

The metric:
```
# HELP rn_ledger_recent_proposer_timestamp_progress_rate A rate of the proposer timestamp progress (against wall-clock) averaged over 10 most recent ledger updates.
# TYPE rn_ledger_recent_proposer_timestamp_progress_rate gauge
rn_ledger_recent_proposer_timestamp_progress_rate 0.9982936655602106
```
_(nicely oscillates around ~1.0 on a healthy Node)_