### PR TITLE
Support for accepting and outputting both hex and bech32 encodings for all transaction hashes

### DIFF
--- a/common/src/main/java/com/radixdlt/networks/Network.java
+++ b/common/src/main/java/com/radixdlt/networks/Network.java
@@ -142,6 +142,8 @@ public enum Network {
   private final String validatorHrp;
   private final String resourceHrp;
   private final String nodeHrp;
+  private final String intentHashHrp;
+  private final String notarizedTransactionHashHrp;
   private final Optional<FixedNetworkGenesis> maybeFixedGenesis;
 
   Network(
@@ -165,6 +167,8 @@ public enum Network {
     this.validatorHrp = "validator_" + hrpSuffix;
     this.resourceHrp = "resource_" + hrpSuffix;
     this.nodeHrp = "node_" + hrpSuffix;
+    this.intentHashHrp = "txid_" + hrpSuffix;
+    this.notarizedTransactionHashHrp = "notarizedtransaction_" + hrpSuffix;
     this.maybeFixedGenesis = maybeFixedGenesis;
   }
 
@@ -202,6 +206,14 @@ public enum Network {
 
   public String getNodeHrp() {
     return nodeHrp;
+  }
+
+  public String getIntentHashHrp() {
+    return intentHashHrp;
+  }
+
+  public String getNotarizedTransactionHashHrp() {
+    return notarizedTransactionHashHrp;
   }
 
   public int getId() {

--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -1199,11 +1199,14 @@ components:
       type: object
       required:
         - hash
+        - hash_bech32m
         - signed_intent
         - notary_signature
       properties:
         hash:
           $ref: "#/components/schemas/NotarizedTransactionHash"
+        hash_bech32m:
+          $ref: "#/components/schemas/NotarizedTransactionHashBech32m"
         payload_hex:
           type: string
           description: The hex-encoded full notarized transaction payload. Returning this can be disabled in TransactionFormatOptions on your request (default true).
@@ -1215,11 +1218,14 @@ components:
       type: object
       required:
         - hash
+        - hash_bech32m
         - intent
         - intent_signatures
       properties:
         hash:
           $ref: "#/components/schemas/SignedIntentHash"
+        hash_bech32m:
+          $ref: "#/components/schemas/SignedIntentHashBech32m"
         intent:
           $ref: "#/components/schemas/TransactionIntent"
         intent_signatures:
@@ -1230,10 +1236,13 @@ components:
       type: object
       required:
         - hash
+        - hash_bech32m
         - header
       properties:
         hash:
           $ref: "#/components/schemas/IntentHash"
+        hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
         header:
           $ref: "#/components/schemas/TransactionHeader"
         instructions:
@@ -1486,15 +1495,24 @@ components:
       type: object
       required:
         - intent_hash
+        - intent_hash_bech32m
         - signed_intent_hash
+        - signed_intent_hash_bech32m
         - payload_hash
+        - payload_hash_bech32m
       properties:
         intent_hash:
           $ref: "#/components/schemas/IntentHash"
+        intent_hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
         signed_intent_hash:
           $ref: "#/components/schemas/SignedIntentHash"
+        signed_intent_hash_bech32m:
+          $ref: "#/components/schemas/SignedIntentHashBech32m"
         payload_hash:
           $ref: "#/components/schemas/NotarizedTransactionHash"
+        payload_hash_bech32m:
+          $ref: "#/components/schemas/NotarizedTransactionHashBech32m"
     IntentHash:
       type: string
       minLength: 64
@@ -1503,6 +1521,9 @@ components:
         The hex-encoded intent hash for a user transaction, also known as the transaction id.
         This hash identifies the core content "intent" of the transaction. Each intent can only be committed once.
         This hash gets signed by any signatories on the transaction, to create the signed intent.
+    IntentHashBech32m:
+      type: string
+      description: The Bech32m-encoded human readable `IntentHash`.
     SignedIntentHash:
       type: string
       minLength: 64
@@ -1511,6 +1532,9 @@ components:
         The hex-encoded signed intent hash for a user transaction.
         This hash identifies the transaction intent, plus additional signatures.
         This hash is signed by the notary, to create the submittable NotarizedTransaction.
+    SignedIntentHashBech32m:
+      type: string
+      description: The Bech32m-encoded human readable `SignedIntentHash`.
     NotarizedTransactionHash:
       type: string
       minLength: 64
@@ -1518,6 +1542,9 @@ components:
       description: |
         The hex-encoded notarized transaction hash for a user transaction.
         This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature.
+    NotarizedTransactionHashBech32m:
+      type: string
+      description: The Bech32m-encoded human readable `NotarizedTransactionHash`.
     LedgerPayloadHash:
       type: string
       minLength: 64
@@ -1525,11 +1552,15 @@ components:
       description: |
         The hex-encoded ledger payload transaction hash.
         This is a wrapper for both user transactions, and system transactions such as genesis and round changes.
+    LedgerPayloadHashBech32m:
+      type: string
+      description: The Bech32m-encoded human readable `LedgerPayloadHash`.
     CommittedIntentMetadata:
       type: object
       required:
         - state_version
         - payload_hash
+        - payload_hash_bech32m
         - is_same_transaction
       properties:
         state_version:
@@ -1537,7 +1568,8 @@ components:
           description: State version of a committed transaction which had the same intent.
         payload_hash:
           $ref: "#/components/schemas/NotarizedTransactionHash"
-          description: Payload hash of a committed transaction which had the same intent.
+        payload_hash_bech32m:
+          $ref: "#/components/schemas/NotarizedTransactionHashBech32m"
         is_same_transaction:
           type: boolean
           description: |
@@ -3486,9 +3518,12 @@ components:
       type: object
       required:
         - intent_hash
+        - intent_hash_bech32m
       properties:
         intent_hash:
           $ref: "#/components/schemas/IntentHash"
+        intent_hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
     GenericKey:
       type: object
       properties:
@@ -4825,10 +4860,13 @@ components:
       type: object
       required:
         - payload_hash
+        - payload_hash_bech32m
         - status
       properties:
         payload_hash:
           $ref: "#/components/schemas/NotarizedTransactionHash"
+        payload_hash_bech32m:
+          $ref: "#/components/schemas/NotarizedTransactionHashBech32m"
         state_version:
           $ref: "#/components/schemas/StateVersion"
           description: |
@@ -5617,6 +5655,7 @@ components:
         - logical_name
         - state_version
         - intent_hash
+        - intent_hash_bech32m
       properties:
         logical_name:
           type: string
@@ -5624,6 +5663,8 @@ components:
           $ref: "#/components/schemas/StateVersion"
         intent_hash:
           $ref: "#/components/schemas/IntentHash"
+        intent_hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
     DescribedAddress:
       type: string
       description: An arbitrary Bech32m-encoded human readable address (its type should be inferred from `logical_name`).
@@ -5650,12 +5691,18 @@ components:
       type: object
       required:
         - intent_hash
+        - intent_hash_bech32m
         - payload_hash
+        - payload_hash_bech32m
       properties:
         intent_hash:
           $ref: "#/components/schemas/IntentHash"
+        intent_hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
         payload_hash:
           $ref: "#/components/schemas/NotarizedTransactionHash"
+        payload_hash_bech32m:
+          $ref: "#/components/schemas/NotarizedTransactionHashBech32m"
 #################################
 # REQUEST: /mempool/transaction #
 #################################
@@ -5791,18 +5838,30 @@ components:
       type: object
       required:
         - intent_hash
+        - intent_hash_bech32m
         - signed_intent_hash
+        - signed_intent_hash_bech32m
         - payload_hash
+        - payload_hash_bech32m
         - ledger_hash
+        - ledger_hash_bech32m
       properties:
         intent_hash:
           $ref: "#/components/schemas/IntentHash"
+        intent_hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
         signed_intent_hash:
           $ref: "#/components/schemas/SignedIntentHash"
+        signed_intent_hash_bech32m:
+          $ref: "#/components/schemas/SignedIntentHashBech32m"
         payload_hash:
           $ref: "#/components/schemas/NotarizedTransactionHash"
+        payload_hash_bech32m:
+          $ref: "#/components/schemas/NotarizedTransactionHashBech32m"
         ledger_hash:
           $ref: "#/components/schemas/LedgerPayloadHash"
+        ledger_hash_bech32m:
+          $ref: "#/components/schemas/LedgerPayloadHashBech32m"
     ParsedSignedTransactionIntent:
       allOf:
         - $ref: "#/components/schemas/ParsedTransaction"
@@ -5818,12 +5877,18 @@ components:
       type: object
       required:
         - intent_hash
+        - intent_hash_bech32m
         - signed_intent_hash
+        - signed_intent_hash_bech32m
       properties:
         intent_hash:
           $ref: "#/components/schemas/IntentHash"
+        intent_hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
         signed_intent_hash:
           $ref: "#/components/schemas/SignedIntentHash"
+        signed_intent_hash_bech32m:
+          $ref: "#/components/schemas/SignedIntentHashBech32m"
     ParsedTransactionIntent:
       allOf:
         - $ref: "#/components/schemas/ParsedTransaction"
@@ -5839,9 +5904,12 @@ components:
       type: object
       required:
         - intent_hash
+        - intent_hash_bech32m
       properties:
         intent_hash:
           $ref: "#/components/schemas/IntentHash"
+        intent_hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
     ParsedLedgerTransaction:
       allOf:
         - $ref: "#/components/schemas/ParsedTransaction"
@@ -5857,15 +5925,24 @@ components:
       type: object
       required:
         - ledger_hash
+        - ledger_hash_bech32m
       properties:
         intent_hash:
           $ref: "#/components/schemas/IntentHash"
+        intent_hash_bech32m:
+          $ref: "#/components/schemas/IntentHashBech32m"
         signed_intent_hash:
           $ref: "#/components/schemas/SignedIntentHash"
+        signed_intent_hash_bech32m:
+          $ref: "#/components/schemas/SignedIntentHashBech32m"
         payload_hash:
           $ref: "#/components/schemas/NotarizedTransactionHash"
+        payload_hash_bech32m:
+          $ref: "#/components/schemas/NotarizedTransactionHashBech32m"
         ledger_hash:
           $ref: "#/components/schemas/LedgerPayloadHash"
+        ledger_hash_bech32m:
+          $ref: "#/components/schemas/LedgerPayloadHashBech32m"
 ################################
 # REQUEST: /transaction/submit #
 ################################
@@ -6039,10 +6116,13 @@ components:
       type: object
       required:
         - payload_hash
+        - payload_hash_bech32m
         - status
       properties:
         payload_hash:
           $ref: "#/components/schemas/NotarizedTransactionHash"
+        payload_hash_bech32m:
+          $ref: "#/components/schemas/NotarizedTransactionHashBech32m"
         state_version:
           $ref: "#/components/schemas/StateVersion"
           description: |

--- a/core-rust/core-api-server/src/core_api/conversions/addressing.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/addressing.rs
@@ -39,7 +39,7 @@ pub fn to_api_entity_address(
     node_id: &NodeId,
 ) -> Result<String, MappingError> {
     context
-        .bech32_encoder
+        .address_encoder
         .encode(node_id.as_ref())
         .map_err(|err| MappingError::InvalidEntityAddress { encode_error: err })
 }
@@ -424,7 +424,7 @@ pub fn extract_global_address(
     extraction_context: &ExtractionContext,
     package_address: &str,
 ) -> Result<GlobalAddress, ExtractionError> {
-    GlobalAddress::try_from_bech32(&extraction_context.bech32_decoder, package_address)
+    GlobalAddress::try_from_bech32(&extraction_context.address_decoder, package_address)
         .ok_or(ExtractionError::InvalidAddress)
 }
 
@@ -432,7 +432,7 @@ pub fn extract_package_address(
     extraction_context: &ExtractionContext,
     package_address: &str,
 ) -> Result<PackageAddress, ExtractionError> {
-    PackageAddress::try_from_bech32(&extraction_context.bech32_decoder, package_address)
+    PackageAddress::try_from_bech32(&extraction_context.address_decoder, package_address)
         .ok_or(ExtractionError::InvalidAddress)
 }
 
@@ -440,7 +440,7 @@ pub fn extract_component_address(
     extraction_context: &ExtractionContext,
     component_address: &str,
 ) -> Result<ComponentAddress, ExtractionError> {
-    ComponentAddress::try_from_bech32(&extraction_context.bech32_decoder, component_address)
+    ComponentAddress::try_from_bech32(&extraction_context.address_decoder, component_address)
         .ok_or(ExtractionError::InvalidAddress)
 }
 
@@ -448,7 +448,7 @@ pub fn extract_resource_address(
     extraction_context: &ExtractionContext,
     resource_address: &str,
 ) -> Result<ResourceAddress, ExtractionError> {
-    ResourceAddress::try_from_bech32(&extraction_context.bech32_decoder, resource_address)
+    ResourceAddress::try_from_bech32(&extraction_context.address_decoder, resource_address)
         .ok_or(ExtractionError::InvalidAddress)
 }
 

--- a/core-rust/core-api-server/src/core_api/conversions/common.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/common.rs
@@ -123,7 +123,7 @@ pub fn to_api_sbor_data_from_bytes(
                             .serializable(SerializationParameters::Schemaless {
                                 mode: SerializationMode::Programmatic,
                                 custom_context: ScryptoValueDisplayContext::with_optional_bech32(
-                                    Some(&context.bech32_encoder),
+                                    Some(&context.address_encoder),
                                 ),
                             }),
                     )

--- a/core-rust/core-api-server/src/core_api/conversions/context.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/context.rs
@@ -1,11 +1,13 @@
 use radix_engine::types::{AddressBech32Decoder, AddressBech32Encoder};
 use radix_engine_interface::network::NetworkDefinition;
+use transaction::model::{TransactionHashBech32Decoder, TransactionHashBech32Encoder};
 
 use crate::core_api::models;
 
 pub struct MappingContext {
     pub network_definition: NetworkDefinition,
-    pub bech32_encoder: AddressBech32Encoder,
+    pub address_encoder: AddressBech32Encoder,
+    pub transaction_hash_encoder: TransactionHashBech32Encoder,
     /// If this is true, then the data (eg transaction data) being mapped can be trusted less, so we need to be more lenient about invalid data
     pub uncommitted_data: bool,
     pub sbor_options: SborOptions,
@@ -17,7 +19,8 @@ impl MappingContext {
     pub fn new(network_definition: &NetworkDefinition) -> Self {
         Self {
             network_definition: network_definition.clone(),
-            bech32_encoder: AddressBech32Encoder::new(network_definition),
+            address_encoder: AddressBech32Encoder::new(network_definition),
+            transaction_hash_encoder: TransactionHashBech32Encoder::new(network_definition),
             uncommitted_data: false,
             sbor_options: Default::default(),
             transaction_options: Default::default(),
@@ -28,7 +31,8 @@ impl MappingContext {
     pub fn new_for_uncommitted_data(network_definition: &NetworkDefinition) -> Self {
         Self {
             network_definition: network_definition.clone(),
-            bech32_encoder: AddressBech32Encoder::new(network_definition),
+            address_encoder: AddressBech32Encoder::new(network_definition),
+            transaction_hash_encoder: TransactionHashBech32Encoder::new(network_definition),
             uncommitted_data: true,
             sbor_options: Default::default(),
             transaction_options: Default::default(),
@@ -158,13 +162,15 @@ impl Default for SubstateOptions {
 }
 
 pub struct ExtractionContext {
-    pub bech32_decoder: AddressBech32Decoder,
+    pub address_decoder: AddressBech32Decoder,
+    pub transaction_hash_decoder: TransactionHashBech32Decoder,
 }
 
 impl ExtractionContext {
     pub fn new(network_definition: &NetworkDefinition) -> Self {
         Self {
-            bech32_decoder: AddressBech32Decoder::new(network_definition),
+            address_decoder: AddressBech32Decoder::new(network_definition),
+            transaction_hash_decoder: TransactionHashBech32Decoder::new(network_definition),
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/conversions/errors.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/errors.rs
@@ -5,6 +5,7 @@ use sbor::{DecodeError, EncodeError};
 use state_manager::StateVersion;
 use tracing::warn;
 use transaction::errors::TransactionValidationError;
+use transaction::model::TransactionHashBech32EncodeError;
 
 use crate::core_api::*;
 
@@ -42,6 +43,9 @@ pub enum MappingError {
     },
     InvalidEntityAddress {
         encode_error: AddressBech32EncodeError,
+    },
+    InvalidTransactionHash {
+        encode_error: TransactionHashBech32EncodeError,
     },
     MismatchedSubstateId {
         message: String,

--- a/core-rust/core-api-server/src/core_api/conversions/lts.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/lts.rs
@@ -40,13 +40,29 @@ pub fn to_api_lts_committed_transaction_outcome(
         accumulator_hash: to_lts_api_accumulator_hash(
             &identifiers.resultant_ledger_hashes.transaction_root,
         ),
-        user_transaction_identifiers: identifiers.payload.typed.user().map(|hashes| {
-            Box::new(models::TransactionIdentifiers {
-                intent_hash: to_api_intent_hash(hashes.intent_hash),
-                signed_intent_hash: to_api_signed_intent_hash(hashes.signed_intent_hash),
-                payload_hash: to_api_notarized_transaction_hash(hashes.notarized_transaction_hash),
+        user_transaction_identifiers: identifiers
+            .payload
+            .typed
+            .user()
+            .map(|hashes| {
+                Ok(Box::new(models::TransactionIdentifiers {
+                    intent_hash: to_api_intent_hash(hashes.intent_hash),
+                    intent_hash_bech32m: to_api_hash_bech32m(context, hashes.intent_hash)?,
+                    signed_intent_hash: to_api_signed_intent_hash(hashes.signed_intent_hash),
+                    signed_intent_hash_bech32m: to_api_hash_bech32m(
+                        context,
+                        hashes.signed_intent_hash,
+                    )?,
+                    payload_hash: to_api_notarized_transaction_hash(
+                        hashes.notarized_transaction_hash,
+                    ),
+                    payload_hash_bech32m: to_api_hash_bech32m(
+                        context,
+                        hashes.notarized_transaction_hash,
+                    )?,
+                }))
             })
-        }),
+            .transpose()?,
         status,
         fungible_entity_balance_changes: to_api_lts_fungible_balance_changes(
             database,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/transaction_tracker.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/transaction_tracker.rs
@@ -30,7 +30,7 @@ pub fn to_api_transaction_tracker_substate(
 }
 
 pub fn to_api_transaction_tracker_collection_entry(
-    _context: &MappingContext,
+    context: &MappingContext,
     typed_key: &TypedSubstateKey,
     substate: &KeyValueEntrySubstate<TransactionStatus>,
 ) -> Result<models::Substate, MappingError> {
@@ -41,7 +41,8 @@ pub fn to_api_transaction_tracker_collection_entry(
         substate,
         TransactionTrackerCollectionEntry,
         models::TransactionIdKey {
-            intent_hash: to_api_hash(intent_hash.as_hash()),
+            intent_hash: to_api_intent_hash(intent_hash),
+            intent_hash_bech32m: to_api_hash_bech32m(context, intent_hash)?,
         },
         value => {
             status: match value {

--- a/core-rust/core-api-server/src/core_api/generated/models/committed_intent_metadata.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/committed_intent_metadata.rs
@@ -18,16 +18,20 @@ pub struct CommittedIntentMetadata {
     /// The hex-encoded notarized transaction hash for a user transaction. This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature. 
     #[serde(rename = "payload_hash")]
     pub payload_hash: String,
+    /// The Bech32m-encoded human readable `NotarizedTransactionHash`.
+    #[serde(rename = "payload_hash_bech32m")]
+    pub payload_hash_bech32m: String,
     /// Whether the intent was committed in a transaction with the same payload. This is a convenience field, which can also be computed using `payload_hash` by a client knowing the payload of the submitted transaction. 
     #[serde(rename = "is_same_transaction")]
     pub is_same_transaction: bool,
 }
 
 impl CommittedIntentMetadata {
-    pub fn new(state_version: i64, payload_hash: String, is_same_transaction: bool) -> CommittedIntentMetadata {
+    pub fn new(state_version: i64, payload_hash: String, payload_hash_bech32m: String, is_same_transaction: bool) -> CommittedIntentMetadata {
         CommittedIntentMetadata {
             state_version,
             payload_hash,
+            payload_hash_bech32m,
             is_same_transaction,
         }
     }

--- a/core-rust/core-api-server/src/core_api/generated/models/executed_scenario_transaction.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/executed_scenario_transaction.rs
@@ -20,14 +20,18 @@ pub struct ExecutedScenarioTransaction {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "intent_hash")]
     pub intent_hash: String,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "intent_hash_bech32m")]
+    pub intent_hash_bech32m: String,
 }
 
 impl ExecutedScenarioTransaction {
-    pub fn new(logical_name: String, state_version: i64, intent_hash: String) -> ExecutedScenarioTransaction {
+    pub fn new(logical_name: String, state_version: i64, intent_hash: String, intent_hash_bech32m: String) -> ExecutedScenarioTransaction {
         ExecutedScenarioTransaction {
             logical_name,
             state_version,
             intent_hash,
+            intent_hash_bech32m,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/lts_transaction_payload_details.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/lts_transaction_payload_details.rs
@@ -16,6 +16,9 @@ pub struct LtsTransactionPayloadDetails {
     /// The hex-encoded notarized transaction hash for a user transaction. This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature. 
     #[serde(rename = "payload_hash")]
     pub payload_hash: String,
+    /// The Bech32m-encoded human readable `NotarizedTransactionHash`.
+    #[serde(rename = "payload_hash_bech32m")]
+    pub payload_hash_bech32m: String,
     #[serde(rename = "state_version", skip_serializing_if = "Option::is_none")]
     pub state_version: Option<i64>,
     #[serde(rename = "status")]
@@ -26,9 +29,10 @@ pub struct LtsTransactionPayloadDetails {
 }
 
 impl LtsTransactionPayloadDetails {
-    pub fn new(payload_hash: String, status: crate::core_api::generated::models::LtsTransactionPayloadStatus) -> LtsTransactionPayloadDetails {
+    pub fn new(payload_hash: String, payload_hash_bech32m: String, status: crate::core_api::generated::models::LtsTransactionPayloadStatus) -> LtsTransactionPayloadDetails {
         LtsTransactionPayloadDetails {
             payload_hash,
+            payload_hash_bech32m,
             state_version: None,
             status,
             error_message: None,

--- a/core-rust/core-api-server/src/core_api/generated/models/mempool_transaction_hashes.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/mempool_transaction_hashes.rs
@@ -16,16 +16,24 @@ pub struct MempoolTransactionHashes {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "intent_hash")]
     pub intent_hash: String,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "intent_hash_bech32m")]
+    pub intent_hash_bech32m: String,
     /// The hex-encoded notarized transaction hash for a user transaction. This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature. 
     #[serde(rename = "payload_hash")]
     pub payload_hash: String,
+    /// The Bech32m-encoded human readable `NotarizedTransactionHash`.
+    #[serde(rename = "payload_hash_bech32m")]
+    pub payload_hash_bech32m: String,
 }
 
 impl MempoolTransactionHashes {
-    pub fn new(intent_hash: String, payload_hash: String) -> MempoolTransactionHashes {
+    pub fn new(intent_hash: String, intent_hash_bech32m: String, payload_hash: String, payload_hash_bech32m: String) -> MempoolTransactionHashes {
         MempoolTransactionHashes {
             intent_hash,
+            intent_hash_bech32m,
             payload_hash,
+            payload_hash_bech32m,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/notarized_transaction.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/notarized_transaction.rs
@@ -16,6 +16,9 @@ pub struct NotarizedTransaction {
     /// The hex-encoded notarized transaction hash for a user transaction. This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature. 
     #[serde(rename = "hash")]
     pub hash: String,
+    /// The Bech32m-encoded human readable `NotarizedTransactionHash`.
+    #[serde(rename = "hash_bech32m")]
+    pub hash_bech32m: String,
     /// The hex-encoded full notarized transaction payload. Returning this can be disabled in TransactionFormatOptions on your request (default true).
     #[serde(rename = "payload_hex", skip_serializing_if = "Option::is_none")]
     pub payload_hex: Option<String>,
@@ -26,9 +29,10 @@ pub struct NotarizedTransaction {
 }
 
 impl NotarizedTransaction {
-    pub fn new(hash: String, signed_intent: crate::core_api::generated::models::SignedTransactionIntent, notary_signature: crate::core_api::generated::models::Signature) -> NotarizedTransaction {
+    pub fn new(hash: String, hash_bech32m: String, signed_intent: crate::core_api::generated::models::SignedTransactionIntent, notary_signature: crate::core_api::generated::models::Signature) -> NotarizedTransaction {
         NotarizedTransaction {
             hash,
+            hash_bech32m,
             payload_hex: None,
             signed_intent: Box::new(signed_intent),
             notary_signature: Option::Some(notary_signature),

--- a/core-rust/core-api-server/src/core_api/generated/models/parsed_ledger_transaction_identifiers.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/parsed_ledger_transaction_identifiers.rs
@@ -16,24 +16,40 @@ pub struct ParsedLedgerTransactionIdentifiers {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "intent_hash", skip_serializing_if = "Option::is_none")]
     pub intent_hash: Option<String>,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "intent_hash_bech32m", skip_serializing_if = "Option::is_none")]
+    pub intent_hash_bech32m: Option<String>,
     /// The hex-encoded signed intent hash for a user transaction. This hash identifies the transaction intent, plus additional signatures. This hash is signed by the notary, to create the submittable NotarizedTransaction. 
     #[serde(rename = "signed_intent_hash", skip_serializing_if = "Option::is_none")]
     pub signed_intent_hash: Option<String>,
+    /// The Bech32m-encoded human readable `SignedIntentHash`.
+    #[serde(rename = "signed_intent_hash_bech32m", skip_serializing_if = "Option::is_none")]
+    pub signed_intent_hash_bech32m: Option<String>,
     /// The hex-encoded notarized transaction hash for a user transaction. This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature. 
     #[serde(rename = "payload_hash", skip_serializing_if = "Option::is_none")]
     pub payload_hash: Option<String>,
+    /// The Bech32m-encoded human readable `NotarizedTransactionHash`.
+    #[serde(rename = "payload_hash_bech32m", skip_serializing_if = "Option::is_none")]
+    pub payload_hash_bech32m: Option<String>,
     /// The hex-encoded ledger payload transaction hash. This is a wrapper for both user transactions, and system transactions such as genesis and round changes. 
     #[serde(rename = "ledger_hash")]
     pub ledger_hash: String,
+    /// The Bech32m-encoded human readable `LedgerPayloadHash`.
+    #[serde(rename = "ledger_hash_bech32m")]
+    pub ledger_hash_bech32m: String,
 }
 
 impl ParsedLedgerTransactionIdentifiers {
-    pub fn new(ledger_hash: String) -> ParsedLedgerTransactionIdentifiers {
+    pub fn new(ledger_hash: String, ledger_hash_bech32m: String) -> ParsedLedgerTransactionIdentifiers {
         ParsedLedgerTransactionIdentifiers {
             intent_hash: None,
+            intent_hash_bech32m: None,
             signed_intent_hash: None,
+            signed_intent_hash_bech32m: None,
             payload_hash: None,
+            payload_hash_bech32m: None,
             ledger_hash,
+            ledger_hash_bech32m,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/parsed_notarized_transaction_identifiers.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/parsed_notarized_transaction_identifiers.rs
@@ -16,24 +16,40 @@ pub struct ParsedNotarizedTransactionIdentifiers {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "intent_hash")]
     pub intent_hash: String,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "intent_hash_bech32m")]
+    pub intent_hash_bech32m: String,
     /// The hex-encoded signed intent hash for a user transaction. This hash identifies the transaction intent, plus additional signatures. This hash is signed by the notary, to create the submittable NotarizedTransaction. 
     #[serde(rename = "signed_intent_hash")]
     pub signed_intent_hash: String,
+    /// The Bech32m-encoded human readable `SignedIntentHash`.
+    #[serde(rename = "signed_intent_hash_bech32m")]
+    pub signed_intent_hash_bech32m: String,
     /// The hex-encoded notarized transaction hash for a user transaction. This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature. 
     #[serde(rename = "payload_hash")]
     pub payload_hash: String,
+    /// The Bech32m-encoded human readable `NotarizedTransactionHash`.
+    #[serde(rename = "payload_hash_bech32m")]
+    pub payload_hash_bech32m: String,
     /// The hex-encoded ledger payload transaction hash. This is a wrapper for both user transactions, and system transactions such as genesis and round changes. 
     #[serde(rename = "ledger_hash")]
     pub ledger_hash: String,
+    /// The Bech32m-encoded human readable `LedgerPayloadHash`.
+    #[serde(rename = "ledger_hash_bech32m")]
+    pub ledger_hash_bech32m: String,
 }
 
 impl ParsedNotarizedTransactionIdentifiers {
-    pub fn new(intent_hash: String, signed_intent_hash: String, payload_hash: String, ledger_hash: String) -> ParsedNotarizedTransactionIdentifiers {
+    pub fn new(intent_hash: String, intent_hash_bech32m: String, signed_intent_hash: String, signed_intent_hash_bech32m: String, payload_hash: String, payload_hash_bech32m: String, ledger_hash: String, ledger_hash_bech32m: String) -> ParsedNotarizedTransactionIdentifiers {
         ParsedNotarizedTransactionIdentifiers {
             intent_hash,
+            intent_hash_bech32m,
             signed_intent_hash,
+            signed_intent_hash_bech32m,
             payload_hash,
+            payload_hash_bech32m,
             ledger_hash,
+            ledger_hash_bech32m,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/parsed_signed_transaction_intent_identifiers.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/parsed_signed_transaction_intent_identifiers.rs
@@ -16,16 +16,24 @@ pub struct ParsedSignedTransactionIntentIdentifiers {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "intent_hash")]
     pub intent_hash: String,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "intent_hash_bech32m")]
+    pub intent_hash_bech32m: String,
     /// The hex-encoded signed intent hash for a user transaction. This hash identifies the transaction intent, plus additional signatures. This hash is signed by the notary, to create the submittable NotarizedTransaction. 
     #[serde(rename = "signed_intent_hash")]
     pub signed_intent_hash: String,
+    /// The Bech32m-encoded human readable `SignedIntentHash`.
+    #[serde(rename = "signed_intent_hash_bech32m")]
+    pub signed_intent_hash_bech32m: String,
 }
 
 impl ParsedSignedTransactionIntentIdentifiers {
-    pub fn new(intent_hash: String, signed_intent_hash: String) -> ParsedSignedTransactionIntentIdentifiers {
+    pub fn new(intent_hash: String, intent_hash_bech32m: String, signed_intent_hash: String, signed_intent_hash_bech32m: String) -> ParsedSignedTransactionIntentIdentifiers {
         ParsedSignedTransactionIntentIdentifiers {
             intent_hash,
+            intent_hash_bech32m,
             signed_intent_hash,
+            signed_intent_hash_bech32m,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/parsed_transaction_intent_identifiers.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/parsed_transaction_intent_identifiers.rs
@@ -16,12 +16,16 @@ pub struct ParsedTransactionIntentIdentifiers {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "intent_hash")]
     pub intent_hash: String,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "intent_hash_bech32m")]
+    pub intent_hash_bech32m: String,
 }
 
 impl ParsedTransactionIntentIdentifiers {
-    pub fn new(intent_hash: String) -> ParsedTransactionIntentIdentifiers {
+    pub fn new(intent_hash: String, intent_hash_bech32m: String) -> ParsedTransactionIntentIdentifiers {
         ParsedTransactionIntentIdentifiers {
             intent_hash,
+            intent_hash_bech32m,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/signed_transaction_intent.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/signed_transaction_intent.rs
@@ -16,6 +16,9 @@ pub struct SignedTransactionIntent {
     /// The hex-encoded signed intent hash for a user transaction. This hash identifies the transaction intent, plus additional signatures. This hash is signed by the notary, to create the submittable NotarizedTransaction. 
     #[serde(rename = "hash")]
     pub hash: String,
+    /// The Bech32m-encoded human readable `SignedIntentHash`.
+    #[serde(rename = "hash_bech32m")]
+    pub hash_bech32m: String,
     #[serde(rename = "intent")]
     pub intent: Box<crate::core_api::generated::models::TransactionIntent>,
     #[serde(rename = "intent_signatures")]
@@ -23,9 +26,10 @@ pub struct SignedTransactionIntent {
 }
 
 impl SignedTransactionIntent {
-    pub fn new(hash: String, intent: crate::core_api::generated::models::TransactionIntent, intent_signatures: Vec<crate::core_api::generated::models::SignatureWithPublicKey>) -> SignedTransactionIntent {
+    pub fn new(hash: String, hash_bech32m: String, intent: crate::core_api::generated::models::TransactionIntent, intent_signatures: Vec<crate::core_api::generated::models::SignatureWithPublicKey>) -> SignedTransactionIntent {
         SignedTransactionIntent {
             hash,
+            hash_bech32m,
             intent: Box::new(intent),
             intent_signatures,
         }

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_id_key.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_id_key.rs
@@ -16,12 +16,16 @@ pub struct TransactionIdKey {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "intent_hash")]
     pub intent_hash: String,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "intent_hash_bech32m")]
+    pub intent_hash_bech32m: String,
 }
 
 impl TransactionIdKey {
-    pub fn new(intent_hash: String) -> TransactionIdKey {
+    pub fn new(intent_hash: String, intent_hash_bech32m: String) -> TransactionIdKey {
         TransactionIdKey {
             intent_hash,
+            intent_hash_bech32m,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_identifiers.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_identifiers.rs
@@ -16,20 +16,32 @@ pub struct TransactionIdentifiers {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "intent_hash")]
     pub intent_hash: String,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "intent_hash_bech32m")]
+    pub intent_hash_bech32m: String,
     /// The hex-encoded signed intent hash for a user transaction. This hash identifies the transaction intent, plus additional signatures. This hash is signed by the notary, to create the submittable NotarizedTransaction. 
     #[serde(rename = "signed_intent_hash")]
     pub signed_intent_hash: String,
+    /// The Bech32m-encoded human readable `SignedIntentHash`.
+    #[serde(rename = "signed_intent_hash_bech32m")]
+    pub signed_intent_hash_bech32m: String,
     /// The hex-encoded notarized transaction hash for a user transaction. This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature. 
     #[serde(rename = "payload_hash")]
     pub payload_hash: String,
+    /// The Bech32m-encoded human readable `NotarizedTransactionHash`.
+    #[serde(rename = "payload_hash_bech32m")]
+    pub payload_hash_bech32m: String,
 }
 
 impl TransactionIdentifiers {
-    pub fn new(intent_hash: String, signed_intent_hash: String, payload_hash: String) -> TransactionIdentifiers {
+    pub fn new(intent_hash: String, intent_hash_bech32m: String, signed_intent_hash: String, signed_intent_hash_bech32m: String, payload_hash: String, payload_hash_bech32m: String) -> TransactionIdentifiers {
         TransactionIdentifiers {
             intent_hash,
+            intent_hash_bech32m,
             signed_intent_hash,
+            signed_intent_hash_bech32m,
             payload_hash,
+            payload_hash_bech32m,
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_intent.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_intent.rs
@@ -16,6 +16,9 @@ pub struct TransactionIntent {
     /// The hex-encoded intent hash for a user transaction, also known as the transaction id. This hash identifies the core content \"intent\" of the transaction. Each intent can only be committed once. This hash gets signed by any signatories on the transaction, to create the signed intent. 
     #[serde(rename = "hash")]
     pub hash: String,
+    /// The Bech32m-encoded human readable `IntentHash`.
+    #[serde(rename = "hash_bech32m")]
+    pub hash_bech32m: String,
     #[serde(rename = "header")]
     pub header: Box<crate::core_api::generated::models::TransactionHeader>,
     /// The decompiled transaction manifest instructions. Only returned if enabled in `TransactionFormatOptions` on your request.
@@ -29,9 +32,10 @@ pub struct TransactionIntent {
 }
 
 impl TransactionIntent {
-    pub fn new(hash: String, header: crate::core_api::generated::models::TransactionHeader) -> TransactionIntent {
+    pub fn new(hash: String, hash_bech32m: String, header: crate::core_api::generated::models::TransactionHeader) -> TransactionIntent {
         TransactionIntent {
             hash,
+            hash_bech32m,
             header: Box::new(header),
             instructions: None,
             blobs_hex: None,

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_payload_details.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_payload_details.rs
@@ -16,6 +16,9 @@ pub struct TransactionPayloadDetails {
     /// The hex-encoded notarized transaction hash for a user transaction. This hash identifies the full submittable notarized transaction - ie the signed intent, plus the notary signature. 
     #[serde(rename = "payload_hash")]
     pub payload_hash: String,
+    /// The Bech32m-encoded human readable `NotarizedTransactionHash`.
+    #[serde(rename = "payload_hash_bech32m")]
+    pub payload_hash_bech32m: String,
     #[serde(rename = "state_version", skip_serializing_if = "Option::is_none")]
     pub state_version: Option<i64>,
     #[serde(rename = "status")]
@@ -26,9 +29,10 @@ pub struct TransactionPayloadDetails {
 }
 
 impl TransactionPayloadDetails {
-    pub fn new(payload_hash: String, status: crate::core_api::generated::models::TransactionPayloadStatus) -> TransactionPayloadDetails {
+    pub fn new(payload_hash: String, payload_hash_bech32m: String, status: crate::core_api::generated::models::TransactionPayloadStatus) -> TransactionPayloadDetails {
         TransactionPayloadDetails {
             payload_hash,
+            payload_hash_bech32m,
             state_version: None,
             status,
             error_message: None,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
@@ -52,7 +52,7 @@ pub(crate) async fn handle_lts_transaction_submit(
                 intent_already_committed_as: rejection
                     .reason
                     .already_committed_error()
-                    .map(to_api_committed_intent_metadata)
+                    .map(|err| to_api_committed_intent_metadata(&mapping_context, err))
                     .transpose()?
                     .map(Box::new),
                 // TODO - Add `result_validity_substate_criteria` once track / mempool is improved

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
@@ -6,17 +6,21 @@ pub(crate) async fn handle_mempool_list(
     Json(request): Json<models::MempoolListRequest>,
 ) -> Result<Json<models::MempoolListResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
+    let mapping_context = MappingContext::new(&state.network);
+
     let mempool = state.state_manager.mempool.read();
     Ok(models::MempoolListResponse {
         contents: mempool
             .all_hashes_iter()
-            .map(
-                |(intent_hash, payload_hash)| models::MempoolTransactionHashes {
+            .map(|(intent_hash, payload_hash)| {
+                Ok(models::MempoolTransactionHashes {
                     intent_hash: to_api_intent_hash(intent_hash),
+                    intent_hash_bech32m: to_api_hash_bech32m(&mapping_context, intent_hash)?,
                     payload_hash: to_api_notarized_transaction_hash(payload_hash),
-                },
-            )
-            .collect(),
+                    payload_hash_bech32m: to_api_hash_bech32m(&mapping_context, payload_hash)?,
+                })
+            })
+            .collect::<Result<Vec<_>, MappingError>>()?,
     })
     .map(Json)
 }

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_transaction.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_transaction.rs
@@ -5,8 +5,11 @@ pub(crate) async fn handle_mempool_transaction(
     Json(request): Json<models::MempoolTransactionRequest>,
 ) -> Result<Json<models::MempoolTransactionResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
-    let payload_hash = extract_notarized_transaction_hash(request.payload_hash)
-        .map_err(|err| err.into_response_error("payload_hash"))?;
+
+    let extraction_context = ExtractionContext::new(&state.network);
+    let payload_hash =
+        extract_notarized_transaction_hash(&extraction_context, request.payload_hash)
+            .map_err(|err| err.into_response_error("payload_hash"))?;
 
     let mempool = state.state_manager.mempool.read();
     match mempool.get_payload(&payload_hash) {

--- a/core-rust/core-api-server/src/core_api/handlers/status_scenarios.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_scenarios.rs
@@ -54,12 +54,13 @@ pub fn to_api_executed_scenario(
 }
 
 pub fn to_api_scenario_transaction(
-    _context: &MappingContext,
+    context: &MappingContext,
     transaction: &ExecutedScenarioTransaction,
 ) -> Result<models::ExecutedScenarioTransaction, MappingError> {
     Ok(models::ExecutedScenarioTransaction {
         logical_name: transaction.logical_name.clone(),
         state_version: to_api_state_version(transaction.state_version)?,
         intent_hash: to_api_intent_hash(&transaction.intent_hash),
+        intent_hash_bech32m: to_api_hash_bech32m(context, &transaction.intent_hash)?,
     })
 }

--- a/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
@@ -214,6 +214,7 @@ pub fn to_api_notarized_transaction(
 
     Ok(models::NotarizedTransaction {
         hash: to_api_notarized_transaction_hash(notarized_transaction_hash),
+        hash_bech32m: to_api_hash_bech32m(context, notarized_transaction_hash)?,
         payload_hex,
         signed_intent: Box::new(to_api_signed_intent(
             context,
@@ -234,6 +235,7 @@ pub fn to_api_signed_intent(
 ) -> Result<models::SignedTransactionIntent, MappingError> {
     Ok(models::SignedTransactionIntent {
         hash: to_api_signed_intent_hash(signed_intent_hash),
+        hash_bech32m: to_api_hash_bech32m(context, signed_intent_hash)?,
         intent: Box::new(to_api_intent(context, &signed_intent.intent, intent_hash)?),
         intent_signatures: signed_intent
             .intent_signatures
@@ -307,6 +309,7 @@ pub fn to_api_intent(
 
     Ok(models::TransactionIntent {
         hash: to_api_intent_hash(intent_hash),
+        hash_bech32m: to_api_hash_bech32m(context, intent_hash)?,
         header,
         instructions,
         blobs_hex,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_parse.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_parse.rs
@@ -217,9 +217,19 @@ fn to_api_parsed_notarized_transaction(
         notarized_transaction: model,
         identifiers: Box::new(models::ParsedNotarizedTransactionIdentifiers {
             intent_hash: to_api_intent_hash(&intent_hash),
+            intent_hash_bech32m: to_api_hash_bech32m(&context.mapping_context, &intent_hash)?,
             signed_intent_hash: to_api_signed_intent_hash(&signed_intent_hash),
+            signed_intent_hash_bech32m: to_api_hash_bech32m(
+                &context.mapping_context,
+                &signed_intent_hash,
+            )?,
             payload_hash: to_api_notarized_transaction_hash(&notarized_transaction_hash),
+            payload_hash_bech32m: to_api_hash_bech32m(
+                &context.mapping_context,
+                &notarized_transaction_hash,
+            )?,
             ledger_hash: to_api_ledger_hash(&ledger_hash),
+            ledger_hash_bech32m: to_api_hash_bech32m(&context.mapping_context, &ledger_hash)?,
         }),
         validation_error,
     })
@@ -250,7 +260,15 @@ fn to_api_parsed_signed_intent(
         signed_intent: model,
         identifiers: Box::new(models::ParsedSignedTransactionIntentIdentifiers {
             intent_hash: to_api_intent_hash(&prepared.intent_hash()),
+            intent_hash_bech32m: to_api_hash_bech32m(
+                &context.mapping_context,
+                &prepared.intent_hash(),
+            )?,
             signed_intent_hash: to_api_signed_intent_hash(&prepared.signed_intent_hash()),
+            signed_intent_hash_bech32m: to_api_hash_bech32m(
+                &context.mapping_context,
+                &prepared.signed_intent_hash(),
+            )?,
         }),
     })
 }
@@ -265,18 +283,20 @@ fn to_api_parsed_intent(
     context: &ParseContext,
     (model, prepared): (IntentV1, PreparedIntentV1),
 ) -> Result<models::ParsedTransaction, ResponseError<()>> {
+    let intent_hash = &prepared.intent_hash();
     let model = match context.response_mode {
         ResponseMode::Basic => None,
         ResponseMode::Full => Some(Box::new(to_api_intent(
             &context.mapping_context,
             &model,
-            &prepared.intent_hash(),
+            intent_hash,
         )?)),
     };
     Ok(models::ParsedTransaction::ParsedTransactionIntent {
         intent: model,
         identifiers: Box::new(models::ParsedTransactionIntentIdentifiers {
-            intent_hash: to_api_intent_hash(&prepared.intent_hash()),
+            intent_hash: to_api_intent_hash(intent_hash),
+            intent_hash_bech32m: to_api_hash_bech32m(&context.mapping_context, intent_hash)?,
         }),
     })
 }
@@ -321,13 +341,33 @@ fn to_api_parsed_ledger_transaction(
             intent_hash: user_identifiers
                 .as_ref()
                 .map(|hashes| to_api_intent_hash(hashes.intent_hash)),
+            intent_hash_bech32m: user_identifiers
+                .as_ref()
+                .map(|hashes| to_api_hash_bech32m(&context.mapping_context, hashes.intent_hash))
+                .transpose()?,
             signed_intent_hash: user_identifiers
                 .as_ref()
                 .map(|hashes| to_api_signed_intent_hash(hashes.signed_intent_hash)),
+            signed_intent_hash_bech32m: user_identifiers
+                .as_ref()
+                .map(|hashes| {
+                    to_api_hash_bech32m(&context.mapping_context, hashes.signed_intent_hash)
+                })
+                .transpose()?,
             payload_hash: user_identifiers
                 .as_ref()
                 .map(|hashes| to_api_notarized_transaction_hash(hashes.notarized_transaction_hash)),
+            payload_hash_bech32m: user_identifiers
+                .as_ref()
+                .map(|hashes| {
+                    to_api_hash_bech32m(&context.mapping_context, hashes.notarized_transaction_hash)
+                })
+                .transpose()?,
             ledger_hash: to_api_ledger_hash(&prepared.ledger_transaction_hash()),
+            ledger_hash_bech32m: to_api_hash_bech32m(
+                &context.mapping_context,
+                &prepared.ledger_transaction_hash(),
+            )?,
         }),
     })
 }

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_receipt.rs
@@ -12,8 +12,9 @@ pub(crate) async fn handle_transaction_receipt(
     assert_matching_network(&request.network, &state.network)?;
 
     let mapping_context = MappingContext::new(&state.network);
+    let extraction_context = ExtractionContext::new(&state.network);
 
-    let intent_hash = extract_intent_hash(request.intent_hash)
+    let intent_hash = extract_intent_hash(&extraction_context, request.intent_hash)
         .map_err(|err| err.into_response_error("intent_hash"))?;
 
     let database = state.state_manager.database.read();

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
@@ -51,7 +51,7 @@ pub(crate) async fn handle_transaction_submit(
                 intent_already_committed_as: rejection
                     .reason
                     .already_committed_error()
-                    .map(to_api_committed_intent_metadata)
+                    .map(|err| to_api_committed_intent_metadata(&mapping_context, err))
                     .transpose()?
                     .map(Box::new),
                 // TODO - Add `result_validity_substate_criteria` once track / mempool is improved
@@ -88,6 +88,7 @@ pub(crate) async fn handle_transaction_submit(
 }
 
 pub fn to_api_committed_intent_metadata(
+    context: &MappingContext,
     error: &AlreadyCommittedError,
 ) -> Result<models::CommittedIntentMetadata, MappingError> {
     Ok(models::CommittedIntentMetadata {
@@ -95,6 +96,10 @@ pub fn to_api_committed_intent_metadata(
         payload_hash: to_api_notarized_transaction_hash(
             &error.committed_notarized_transaction_hash,
         ),
+        payload_hash_bech32m: to_api_hash_bech32m(
+            context,
+            &error.committed_notarized_transaction_hash,
+        )?,
         is_same_transaction: error.committed_notarized_transaction_hash
             == error.notarized_transaction_hash,
     })

--- a/core-rust/state-manager/src/transaction/ledger_transaction.rs
+++ b/core-rust/state-manager/src/transaction/ledger_transaction.rs
@@ -419,6 +419,12 @@ impl LedgerTransactionHash {
     }
 }
 
+impl HashHasHrp for LedgerTransactionHash {
+    fn hrp(hrp_set: &HrpSet) -> &str {
+        &hrp_set.ledger_transaction
+    }
+}
+
 pub trait HasLedgerTransactionHash {
     fn ledger_transaction_hash(&self) -> LedgerTransactionHash;
 }

--- a/core/src/main/java/com/radixdlt/addressing/Addressing.java
+++ b/core/src/main/java/com/radixdlt/addressing/Addressing.java
@@ -72,6 +72,8 @@ import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.*;
 import com.radixdlt.serialization.DeserializeException;
 import com.radixdlt.testutil.InternalAddress;
+import com.radixdlt.transactions.IntentHash;
+import com.radixdlt.transactions.NotarizedTransactionHash;
 import com.radixdlt.utils.Pair;
 
 /** Performs Bech32m encoding/decoding. */
@@ -106,6 +108,14 @@ public final class Addressing {
 
   public String encode(ResourceAddress address) {
     return address.encode(this.networkDefinition);
+  }
+
+  public String encode(IntentHash hash) {
+    return Bech32mCoder.encode(network.getIntentHashHrp(), hash.inner().asBytes());
+  }
+
+  public String encode(NotarizedTransactionHash hash) {
+    return Bech32mCoder.encode(network.getNotarizedTransactionHashHrp(), hash.inner().asBytes());
   }
 
   public PackageAddress decodePackageAddress(String address) {

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/CommittedIntentMetadata.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/CommittedIntentMetadata.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({
   CommittedIntentMetadata.JSON_PROPERTY_STATE_VERSION,
   CommittedIntentMetadata.JSON_PROPERTY_PAYLOAD_HASH,
+  CommittedIntentMetadata.JSON_PROPERTY_PAYLOAD_HASH_BECH32M,
   CommittedIntentMetadata.JSON_PROPERTY_IS_SAME_TRANSACTION
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -42,6 +43,9 @@ public class CommittedIntentMetadata {
 
   public static final String JSON_PROPERTY_PAYLOAD_HASH = "payload_hash";
   private String payloadHash;
+
+  public static final String JSON_PROPERTY_PAYLOAD_HASH_BECH32M = "payload_hash_bech32m";
+  private String payloadHashBech32m;
 
   public static final String JSON_PROPERTY_IS_SAME_TRANSACTION = "is_same_transaction";
   private Boolean isSameTransaction;
@@ -103,6 +107,32 @@ public class CommittedIntentMetadata {
   }
 
 
+  public CommittedIntentMetadata payloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;NotarizedTransactionHash&#x60;.
+   * @return payloadHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `NotarizedTransactionHash`.")
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getPayloadHashBech32m() {
+    return payloadHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setPayloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+  }
+
+
   public CommittedIntentMetadata isSameTransaction(Boolean isSameTransaction) {
     this.isSameTransaction = isSameTransaction;
     return this;
@@ -143,12 +173,13 @@ public class CommittedIntentMetadata {
     CommittedIntentMetadata committedIntentMetadata = (CommittedIntentMetadata) o;
     return Objects.equals(this.stateVersion, committedIntentMetadata.stateVersion) &&
         Objects.equals(this.payloadHash, committedIntentMetadata.payloadHash) &&
+        Objects.equals(this.payloadHashBech32m, committedIntentMetadata.payloadHashBech32m) &&
         Objects.equals(this.isSameTransaction, committedIntentMetadata.isSameTransaction);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(stateVersion, payloadHash, isSameTransaction);
+    return Objects.hash(stateVersion, payloadHash, payloadHashBech32m, isSameTransaction);
   }
 
   @Override
@@ -157,6 +188,7 @@ public class CommittedIntentMetadata {
     sb.append("class CommittedIntentMetadata {\n");
     sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    payloadHash: ").append(toIndentedString(payloadHash)).append("\n");
+    sb.append("    payloadHashBech32m: ").append(toIndentedString(payloadHashBech32m)).append("\n");
     sb.append("    isSameTransaction: ").append(toIndentedString(isSameTransaction)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/ExecutedScenarioTransaction.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/ExecutedScenarioTransaction.java
@@ -33,7 +33,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({
   ExecutedScenarioTransaction.JSON_PROPERTY_LOGICAL_NAME,
   ExecutedScenarioTransaction.JSON_PROPERTY_STATE_VERSION,
-  ExecutedScenarioTransaction.JSON_PROPERTY_INTENT_HASH
+  ExecutedScenarioTransaction.JSON_PROPERTY_INTENT_HASH,
+  ExecutedScenarioTransaction.JSON_PROPERTY_INTENT_HASH_BECH32M
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ExecutedScenarioTransaction {
@@ -45,6 +46,9 @@ public class ExecutedScenarioTransaction {
 
   public static final String JSON_PROPERTY_INTENT_HASH = "intent_hash";
   private String intentHash;
+
+  public static final String JSON_PROPERTY_INTENT_HASH_BECH32M = "intent_hash_bech32m";
+  private String intentHashBech32m;
 
   public ExecutedScenarioTransaction() { 
   }
@@ -129,6 +133,32 @@ public class ExecutedScenarioTransaction {
   }
 
 
+  public ExecutedScenarioTransaction intentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return intentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getIntentHashBech32m() {
+    return intentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setIntentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+  }
+
+
   /**
    * Return true if this ExecutedScenarioTransaction object is equal to o.
    */
@@ -143,12 +173,13 @@ public class ExecutedScenarioTransaction {
     ExecutedScenarioTransaction executedScenarioTransaction = (ExecutedScenarioTransaction) o;
     return Objects.equals(this.logicalName, executedScenarioTransaction.logicalName) &&
         Objects.equals(this.stateVersion, executedScenarioTransaction.stateVersion) &&
-        Objects.equals(this.intentHash, executedScenarioTransaction.intentHash);
+        Objects.equals(this.intentHash, executedScenarioTransaction.intentHash) &&
+        Objects.equals(this.intentHashBech32m, executedScenarioTransaction.intentHashBech32m);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(logicalName, stateVersion, intentHash);
+    return Objects.hash(logicalName, stateVersion, intentHash, intentHashBech32m);
   }
 
   @Override
@@ -158,6 +189,7 @@ public class ExecutedScenarioTransaction {
     sb.append("    logicalName: ").append(toIndentedString(logicalName)).append("\n");
     sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    intentHash: ").append(toIndentedString(intentHash)).append("\n");
+    sb.append("    intentHashBech32m: ").append(toIndentedString(intentHashBech32m)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/LtsTransactionPayloadDetails.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/LtsTransactionPayloadDetails.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   LtsTransactionPayloadDetails.JSON_PROPERTY_PAYLOAD_HASH,
+  LtsTransactionPayloadDetails.JSON_PROPERTY_PAYLOAD_HASH_BECH32M,
   LtsTransactionPayloadDetails.JSON_PROPERTY_STATE_VERSION,
   LtsTransactionPayloadDetails.JSON_PROPERTY_STATUS,
   LtsTransactionPayloadDetails.JSON_PROPERTY_ERROR_MESSAGE
@@ -41,6 +42,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class LtsTransactionPayloadDetails {
   public static final String JSON_PROPERTY_PAYLOAD_HASH = "payload_hash";
   private String payloadHash;
+
+  public static final String JSON_PROPERTY_PAYLOAD_HASH_BECH32M = "payload_hash_bech32m";
+  private String payloadHashBech32m;
 
   public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
   private Long stateVersion;
@@ -77,6 +81,32 @@ public class LtsTransactionPayloadDetails {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPayloadHash(String payloadHash) {
     this.payloadHash = payloadHash;
+  }
+
+
+  public LtsTransactionPayloadDetails payloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;NotarizedTransactionHash&#x60;.
+   * @return payloadHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `NotarizedTransactionHash`.")
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getPayloadHashBech32m() {
+    return payloadHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setPayloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
   }
 
 
@@ -173,6 +203,7 @@ public class LtsTransactionPayloadDetails {
     }
     LtsTransactionPayloadDetails ltsTransactionPayloadDetails = (LtsTransactionPayloadDetails) o;
     return Objects.equals(this.payloadHash, ltsTransactionPayloadDetails.payloadHash) &&
+        Objects.equals(this.payloadHashBech32m, ltsTransactionPayloadDetails.payloadHashBech32m) &&
         Objects.equals(this.stateVersion, ltsTransactionPayloadDetails.stateVersion) &&
         Objects.equals(this.status, ltsTransactionPayloadDetails.status) &&
         Objects.equals(this.errorMessage, ltsTransactionPayloadDetails.errorMessage);
@@ -180,7 +211,7 @@ public class LtsTransactionPayloadDetails {
 
   @Override
   public int hashCode() {
-    return Objects.hash(payloadHash, stateVersion, status, errorMessage);
+    return Objects.hash(payloadHash, payloadHashBech32m, stateVersion, status, errorMessage);
   }
 
   @Override
@@ -188,6 +219,7 @@ public class LtsTransactionPayloadDetails {
     StringBuilder sb = new StringBuilder();
     sb.append("class LtsTransactionPayloadDetails {\n");
     sb.append("    payloadHash: ").append(toIndentedString(payloadHash)).append("\n");
+    sb.append("    payloadHashBech32m: ").append(toIndentedString(payloadHashBech32m)).append("\n");
     sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    errorMessage: ").append(toIndentedString(errorMessage)).append("\n");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/MempoolTransactionHashes.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/MempoolTransactionHashes.java
@@ -32,15 +32,23 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   MempoolTransactionHashes.JSON_PROPERTY_INTENT_HASH,
-  MempoolTransactionHashes.JSON_PROPERTY_PAYLOAD_HASH
+  MempoolTransactionHashes.JSON_PROPERTY_INTENT_HASH_BECH32M,
+  MempoolTransactionHashes.JSON_PROPERTY_PAYLOAD_HASH,
+  MempoolTransactionHashes.JSON_PROPERTY_PAYLOAD_HASH_BECH32M
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class MempoolTransactionHashes {
   public static final String JSON_PROPERTY_INTENT_HASH = "intent_hash";
   private String intentHash;
 
+  public static final String JSON_PROPERTY_INTENT_HASH_BECH32M = "intent_hash_bech32m";
+  private String intentHashBech32m;
+
   public static final String JSON_PROPERTY_PAYLOAD_HASH = "payload_hash";
   private String payloadHash;
+
+  public static final String JSON_PROPERTY_PAYLOAD_HASH_BECH32M = "payload_hash_bech32m";
+  private String payloadHashBech32m;
 
   public MempoolTransactionHashes() { 
   }
@@ -71,6 +79,32 @@ public class MempoolTransactionHashes {
   }
 
 
+  public MempoolTransactionHashes intentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return intentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getIntentHashBech32m() {
+    return intentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setIntentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+  }
+
+
   public MempoolTransactionHashes payloadHash(String payloadHash) {
     this.payloadHash = payloadHash;
     return this;
@@ -97,6 +131,32 @@ public class MempoolTransactionHashes {
   }
 
 
+  public MempoolTransactionHashes payloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;NotarizedTransactionHash&#x60;.
+   * @return payloadHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `NotarizedTransactionHash`.")
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getPayloadHashBech32m() {
+    return payloadHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setPayloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+  }
+
+
   /**
    * Return true if this MempoolTransactionHashes object is equal to o.
    */
@@ -110,12 +170,14 @@ public class MempoolTransactionHashes {
     }
     MempoolTransactionHashes mempoolTransactionHashes = (MempoolTransactionHashes) o;
     return Objects.equals(this.intentHash, mempoolTransactionHashes.intentHash) &&
-        Objects.equals(this.payloadHash, mempoolTransactionHashes.payloadHash);
+        Objects.equals(this.intentHashBech32m, mempoolTransactionHashes.intentHashBech32m) &&
+        Objects.equals(this.payloadHash, mempoolTransactionHashes.payloadHash) &&
+        Objects.equals(this.payloadHashBech32m, mempoolTransactionHashes.payloadHashBech32m);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(intentHash, payloadHash);
+    return Objects.hash(intentHash, intentHashBech32m, payloadHash, payloadHashBech32m);
   }
 
   @Override
@@ -123,7 +185,9 @@ public class MempoolTransactionHashes {
     StringBuilder sb = new StringBuilder();
     sb.append("class MempoolTransactionHashes {\n");
     sb.append("    intentHash: ").append(toIndentedString(intentHash)).append("\n");
+    sb.append("    intentHashBech32m: ").append(toIndentedString(intentHashBech32m)).append("\n");
     sb.append("    payloadHash: ").append(toIndentedString(payloadHash)).append("\n");
+    sb.append("    payloadHashBech32m: ").append(toIndentedString(payloadHashBech32m)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/NotarizedTransaction.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/NotarizedTransaction.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   NotarizedTransaction.JSON_PROPERTY_HASH,
+  NotarizedTransaction.JSON_PROPERTY_HASH_BECH32M,
   NotarizedTransaction.JSON_PROPERTY_PAYLOAD_HEX,
   NotarizedTransaction.JSON_PROPERTY_SIGNED_INTENT,
   NotarizedTransaction.JSON_PROPERTY_NOTARY_SIGNATURE
@@ -42,6 +43,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class NotarizedTransaction {
   public static final String JSON_PROPERTY_HASH = "hash";
   private String hash;
+
+  public static final String JSON_PROPERTY_HASH_BECH32M = "hash_bech32m";
+  private String hashBech32m;
 
   public static final String JSON_PROPERTY_PAYLOAD_HEX = "payload_hex";
   private String payloadHex;
@@ -78,6 +82,32 @@ public class NotarizedTransaction {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setHash(String hash) {
     this.hash = hash;
+  }
+
+
+  public NotarizedTransaction hashBech32m(String hashBech32m) {
+    this.hashBech32m = hashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;NotarizedTransactionHash&#x60;.
+   * @return hashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `NotarizedTransactionHash`.")
+  @JsonProperty(JSON_PROPERTY_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getHashBech32m() {
+    return hashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setHashBech32m(String hashBech32m) {
+    this.hashBech32m = hashBech32m;
   }
 
 
@@ -172,6 +202,7 @@ public class NotarizedTransaction {
     }
     NotarizedTransaction notarizedTransaction = (NotarizedTransaction) o;
     return Objects.equals(this.hash, notarizedTransaction.hash) &&
+        Objects.equals(this.hashBech32m, notarizedTransaction.hashBech32m) &&
         Objects.equals(this.payloadHex, notarizedTransaction.payloadHex) &&
         Objects.equals(this.signedIntent, notarizedTransaction.signedIntent) &&
         Objects.equals(this.notarySignature, notarizedTransaction.notarySignature);
@@ -179,7 +210,7 @@ public class NotarizedTransaction {
 
   @Override
   public int hashCode() {
-    return Objects.hash(hash, payloadHex, signedIntent, notarySignature);
+    return Objects.hash(hash, hashBech32m, payloadHex, signedIntent, notarySignature);
   }
 
   @Override
@@ -187,6 +218,7 @@ public class NotarizedTransaction {
     StringBuilder sb = new StringBuilder();
     sb.append("class NotarizedTransaction {\n");
     sb.append("    hash: ").append(toIndentedString(hash)).append("\n");
+    sb.append("    hashBech32m: ").append(toIndentedString(hashBech32m)).append("\n");
     sb.append("    payloadHex: ").append(toIndentedString(payloadHex)).append("\n");
     sb.append("    signedIntent: ").append(toIndentedString(signedIntent)).append("\n");
     sb.append("    notarySignature: ").append(toIndentedString(notarySignature)).append("\n");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/ParsedLedgerTransactionIdentifiers.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/ParsedLedgerTransactionIdentifiers.java
@@ -32,23 +32,39 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_INTENT_HASH,
+  ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_INTENT_HASH_BECH32M,
   ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH,
+  ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M,
   ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_PAYLOAD_HASH,
-  ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_LEDGER_HASH
+  ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_PAYLOAD_HASH_BECH32M,
+  ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_LEDGER_HASH,
+  ParsedLedgerTransactionIdentifiers.JSON_PROPERTY_LEDGER_HASH_BECH32M
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ParsedLedgerTransactionIdentifiers {
   public static final String JSON_PROPERTY_INTENT_HASH = "intent_hash";
   private String intentHash;
 
+  public static final String JSON_PROPERTY_INTENT_HASH_BECH32M = "intent_hash_bech32m";
+  private String intentHashBech32m;
+
   public static final String JSON_PROPERTY_SIGNED_INTENT_HASH = "signed_intent_hash";
   private String signedIntentHash;
+
+  public static final String JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M = "signed_intent_hash_bech32m";
+  private String signedIntentHashBech32m;
 
   public static final String JSON_PROPERTY_PAYLOAD_HASH = "payload_hash";
   private String payloadHash;
 
+  public static final String JSON_PROPERTY_PAYLOAD_HASH_BECH32M = "payload_hash_bech32m";
+  private String payloadHashBech32m;
+
   public static final String JSON_PROPERTY_LEDGER_HASH = "ledger_hash";
   private String ledgerHash;
+
+  public static final String JSON_PROPERTY_LEDGER_HASH_BECH32M = "ledger_hash_bech32m";
+  private String ledgerHashBech32m;
 
   public ParsedLedgerTransactionIdentifiers() { 
   }
@@ -79,6 +95,32 @@ public class ParsedLedgerTransactionIdentifiers {
   }
 
 
+  public ParsedLedgerTransactionIdentifiers intentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return intentHashBech32m
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getIntentHashBech32m() {
+    return intentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIntentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+  }
+
+
   public ParsedLedgerTransactionIdentifiers signedIntentHash(String signedIntentHash) {
     this.signedIntentHash = signedIntentHash;
     return this;
@@ -102,6 +144,32 @@ public class ParsedLedgerTransactionIdentifiers {
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setSignedIntentHash(String signedIntentHash) {
     this.signedIntentHash = signedIntentHash;
+  }
+
+
+  public ParsedLedgerTransactionIdentifiers signedIntentHashBech32m(String signedIntentHashBech32m) {
+    this.signedIntentHashBech32m = signedIntentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;SignedIntentHash&#x60;.
+   * @return signedIntentHashBech32m
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The Bech32m-encoded human readable `SignedIntentHash`.")
+  @JsonProperty(JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getSignedIntentHashBech32m() {
+    return signedIntentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setSignedIntentHashBech32m(String signedIntentHashBech32m) {
+    this.signedIntentHashBech32m = signedIntentHashBech32m;
   }
 
 
@@ -131,6 +199,32 @@ public class ParsedLedgerTransactionIdentifiers {
   }
 
 
+  public ParsedLedgerTransactionIdentifiers payloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;NotarizedTransactionHash&#x60;.
+   * @return payloadHashBech32m
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The Bech32m-encoded human readable `NotarizedTransactionHash`.")
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public String getPayloadHashBech32m() {
+    return payloadHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setPayloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+  }
+
+
   public ParsedLedgerTransactionIdentifiers ledgerHash(String ledgerHash) {
     this.ledgerHash = ledgerHash;
     return this;
@@ -157,6 +251,32 @@ public class ParsedLedgerTransactionIdentifiers {
   }
 
 
+  public ParsedLedgerTransactionIdentifiers ledgerHashBech32m(String ledgerHashBech32m) {
+    this.ledgerHashBech32m = ledgerHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;LedgerPayloadHash&#x60;.
+   * @return ledgerHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `LedgerPayloadHash`.")
+  @JsonProperty(JSON_PROPERTY_LEDGER_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getLedgerHashBech32m() {
+    return ledgerHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_LEDGER_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setLedgerHashBech32m(String ledgerHashBech32m) {
+    this.ledgerHashBech32m = ledgerHashBech32m;
+  }
+
+
   /**
    * Return true if this ParsedLedgerTransactionIdentifiers object is equal to o.
    */
@@ -170,14 +290,18 @@ public class ParsedLedgerTransactionIdentifiers {
     }
     ParsedLedgerTransactionIdentifiers parsedLedgerTransactionIdentifiers = (ParsedLedgerTransactionIdentifiers) o;
     return Objects.equals(this.intentHash, parsedLedgerTransactionIdentifiers.intentHash) &&
+        Objects.equals(this.intentHashBech32m, parsedLedgerTransactionIdentifiers.intentHashBech32m) &&
         Objects.equals(this.signedIntentHash, parsedLedgerTransactionIdentifiers.signedIntentHash) &&
+        Objects.equals(this.signedIntentHashBech32m, parsedLedgerTransactionIdentifiers.signedIntentHashBech32m) &&
         Objects.equals(this.payloadHash, parsedLedgerTransactionIdentifiers.payloadHash) &&
-        Objects.equals(this.ledgerHash, parsedLedgerTransactionIdentifiers.ledgerHash);
+        Objects.equals(this.payloadHashBech32m, parsedLedgerTransactionIdentifiers.payloadHashBech32m) &&
+        Objects.equals(this.ledgerHash, parsedLedgerTransactionIdentifiers.ledgerHash) &&
+        Objects.equals(this.ledgerHashBech32m, parsedLedgerTransactionIdentifiers.ledgerHashBech32m);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(intentHash, signedIntentHash, payloadHash, ledgerHash);
+    return Objects.hash(intentHash, intentHashBech32m, signedIntentHash, signedIntentHashBech32m, payloadHash, payloadHashBech32m, ledgerHash, ledgerHashBech32m);
   }
 
   @Override
@@ -185,9 +309,13 @@ public class ParsedLedgerTransactionIdentifiers {
     StringBuilder sb = new StringBuilder();
     sb.append("class ParsedLedgerTransactionIdentifiers {\n");
     sb.append("    intentHash: ").append(toIndentedString(intentHash)).append("\n");
+    sb.append("    intentHashBech32m: ").append(toIndentedString(intentHashBech32m)).append("\n");
     sb.append("    signedIntentHash: ").append(toIndentedString(signedIntentHash)).append("\n");
+    sb.append("    signedIntentHashBech32m: ").append(toIndentedString(signedIntentHashBech32m)).append("\n");
     sb.append("    payloadHash: ").append(toIndentedString(payloadHash)).append("\n");
+    sb.append("    payloadHashBech32m: ").append(toIndentedString(payloadHashBech32m)).append("\n");
     sb.append("    ledgerHash: ").append(toIndentedString(ledgerHash)).append("\n");
+    sb.append("    ledgerHashBech32m: ").append(toIndentedString(ledgerHashBech32m)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/ParsedNotarizedTransactionIdentifiers.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/ParsedNotarizedTransactionIdentifiers.java
@@ -32,23 +32,39 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_INTENT_HASH,
+  ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_INTENT_HASH_BECH32M,
   ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH,
+  ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M,
   ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_PAYLOAD_HASH,
-  ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_LEDGER_HASH
+  ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_PAYLOAD_HASH_BECH32M,
+  ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_LEDGER_HASH,
+  ParsedNotarizedTransactionIdentifiers.JSON_PROPERTY_LEDGER_HASH_BECH32M
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ParsedNotarizedTransactionIdentifiers {
   public static final String JSON_PROPERTY_INTENT_HASH = "intent_hash";
   private String intentHash;
 
+  public static final String JSON_PROPERTY_INTENT_HASH_BECH32M = "intent_hash_bech32m";
+  private String intentHashBech32m;
+
   public static final String JSON_PROPERTY_SIGNED_INTENT_HASH = "signed_intent_hash";
   private String signedIntentHash;
+
+  public static final String JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M = "signed_intent_hash_bech32m";
+  private String signedIntentHashBech32m;
 
   public static final String JSON_PROPERTY_PAYLOAD_HASH = "payload_hash";
   private String payloadHash;
 
+  public static final String JSON_PROPERTY_PAYLOAD_HASH_BECH32M = "payload_hash_bech32m";
+  private String payloadHashBech32m;
+
   public static final String JSON_PROPERTY_LEDGER_HASH = "ledger_hash";
   private String ledgerHash;
+
+  public static final String JSON_PROPERTY_LEDGER_HASH_BECH32M = "ledger_hash_bech32m";
+  private String ledgerHashBech32m;
 
   public ParsedNotarizedTransactionIdentifiers() { 
   }
@@ -79,6 +95,32 @@ public class ParsedNotarizedTransactionIdentifiers {
   }
 
 
+  public ParsedNotarizedTransactionIdentifiers intentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return intentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getIntentHashBech32m() {
+    return intentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setIntentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+  }
+
+
   public ParsedNotarizedTransactionIdentifiers signedIntentHash(String signedIntentHash) {
     this.signedIntentHash = signedIntentHash;
     return this;
@@ -102,6 +144,32 @@ public class ParsedNotarizedTransactionIdentifiers {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setSignedIntentHash(String signedIntentHash) {
     this.signedIntentHash = signedIntentHash;
+  }
+
+
+  public ParsedNotarizedTransactionIdentifiers signedIntentHashBech32m(String signedIntentHashBech32m) {
+    this.signedIntentHashBech32m = signedIntentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;SignedIntentHash&#x60;.
+   * @return signedIntentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `SignedIntentHash`.")
+  @JsonProperty(JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getSignedIntentHashBech32m() {
+    return signedIntentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setSignedIntentHashBech32m(String signedIntentHashBech32m) {
+    this.signedIntentHashBech32m = signedIntentHashBech32m;
   }
 
 
@@ -131,6 +199,32 @@ public class ParsedNotarizedTransactionIdentifiers {
   }
 
 
+  public ParsedNotarizedTransactionIdentifiers payloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;NotarizedTransactionHash&#x60;.
+   * @return payloadHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `NotarizedTransactionHash`.")
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getPayloadHashBech32m() {
+    return payloadHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setPayloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+  }
+
+
   public ParsedNotarizedTransactionIdentifiers ledgerHash(String ledgerHash) {
     this.ledgerHash = ledgerHash;
     return this;
@@ -157,6 +251,32 @@ public class ParsedNotarizedTransactionIdentifiers {
   }
 
 
+  public ParsedNotarizedTransactionIdentifiers ledgerHashBech32m(String ledgerHashBech32m) {
+    this.ledgerHashBech32m = ledgerHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;LedgerPayloadHash&#x60;.
+   * @return ledgerHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `LedgerPayloadHash`.")
+  @JsonProperty(JSON_PROPERTY_LEDGER_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getLedgerHashBech32m() {
+    return ledgerHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_LEDGER_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setLedgerHashBech32m(String ledgerHashBech32m) {
+    this.ledgerHashBech32m = ledgerHashBech32m;
+  }
+
+
   /**
    * Return true if this ParsedNotarizedTransactionIdentifiers object is equal to o.
    */
@@ -170,14 +290,18 @@ public class ParsedNotarizedTransactionIdentifiers {
     }
     ParsedNotarizedTransactionIdentifiers parsedNotarizedTransactionIdentifiers = (ParsedNotarizedTransactionIdentifiers) o;
     return Objects.equals(this.intentHash, parsedNotarizedTransactionIdentifiers.intentHash) &&
+        Objects.equals(this.intentHashBech32m, parsedNotarizedTransactionIdentifiers.intentHashBech32m) &&
         Objects.equals(this.signedIntentHash, parsedNotarizedTransactionIdentifiers.signedIntentHash) &&
+        Objects.equals(this.signedIntentHashBech32m, parsedNotarizedTransactionIdentifiers.signedIntentHashBech32m) &&
         Objects.equals(this.payloadHash, parsedNotarizedTransactionIdentifiers.payloadHash) &&
-        Objects.equals(this.ledgerHash, parsedNotarizedTransactionIdentifiers.ledgerHash);
+        Objects.equals(this.payloadHashBech32m, parsedNotarizedTransactionIdentifiers.payloadHashBech32m) &&
+        Objects.equals(this.ledgerHash, parsedNotarizedTransactionIdentifiers.ledgerHash) &&
+        Objects.equals(this.ledgerHashBech32m, parsedNotarizedTransactionIdentifiers.ledgerHashBech32m);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(intentHash, signedIntentHash, payloadHash, ledgerHash);
+    return Objects.hash(intentHash, intentHashBech32m, signedIntentHash, signedIntentHashBech32m, payloadHash, payloadHashBech32m, ledgerHash, ledgerHashBech32m);
   }
 
   @Override
@@ -185,9 +309,13 @@ public class ParsedNotarizedTransactionIdentifiers {
     StringBuilder sb = new StringBuilder();
     sb.append("class ParsedNotarizedTransactionIdentifiers {\n");
     sb.append("    intentHash: ").append(toIndentedString(intentHash)).append("\n");
+    sb.append("    intentHashBech32m: ").append(toIndentedString(intentHashBech32m)).append("\n");
     sb.append("    signedIntentHash: ").append(toIndentedString(signedIntentHash)).append("\n");
+    sb.append("    signedIntentHashBech32m: ").append(toIndentedString(signedIntentHashBech32m)).append("\n");
     sb.append("    payloadHash: ").append(toIndentedString(payloadHash)).append("\n");
+    sb.append("    payloadHashBech32m: ").append(toIndentedString(payloadHashBech32m)).append("\n");
     sb.append("    ledgerHash: ").append(toIndentedString(ledgerHash)).append("\n");
+    sb.append("    ledgerHashBech32m: ").append(toIndentedString(ledgerHashBech32m)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/ParsedSignedTransactionIntentIdentifiers.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/ParsedSignedTransactionIntentIdentifiers.java
@@ -32,15 +32,23 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   ParsedSignedTransactionIntentIdentifiers.JSON_PROPERTY_INTENT_HASH,
-  ParsedSignedTransactionIntentIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH
+  ParsedSignedTransactionIntentIdentifiers.JSON_PROPERTY_INTENT_HASH_BECH32M,
+  ParsedSignedTransactionIntentIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH,
+  ParsedSignedTransactionIntentIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ParsedSignedTransactionIntentIdentifiers {
   public static final String JSON_PROPERTY_INTENT_HASH = "intent_hash";
   private String intentHash;
 
+  public static final String JSON_PROPERTY_INTENT_HASH_BECH32M = "intent_hash_bech32m";
+  private String intentHashBech32m;
+
   public static final String JSON_PROPERTY_SIGNED_INTENT_HASH = "signed_intent_hash";
   private String signedIntentHash;
+
+  public static final String JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M = "signed_intent_hash_bech32m";
+  private String signedIntentHashBech32m;
 
   public ParsedSignedTransactionIntentIdentifiers() { 
   }
@@ -71,6 +79,32 @@ public class ParsedSignedTransactionIntentIdentifiers {
   }
 
 
+  public ParsedSignedTransactionIntentIdentifiers intentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return intentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getIntentHashBech32m() {
+    return intentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setIntentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+  }
+
+
   public ParsedSignedTransactionIntentIdentifiers signedIntentHash(String signedIntentHash) {
     this.signedIntentHash = signedIntentHash;
     return this;
@@ -97,6 +131,32 @@ public class ParsedSignedTransactionIntentIdentifiers {
   }
 
 
+  public ParsedSignedTransactionIntentIdentifiers signedIntentHashBech32m(String signedIntentHashBech32m) {
+    this.signedIntentHashBech32m = signedIntentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;SignedIntentHash&#x60;.
+   * @return signedIntentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `SignedIntentHash`.")
+  @JsonProperty(JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getSignedIntentHashBech32m() {
+    return signedIntentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setSignedIntentHashBech32m(String signedIntentHashBech32m) {
+    this.signedIntentHashBech32m = signedIntentHashBech32m;
+  }
+
+
   /**
    * Return true if this ParsedSignedTransactionIntentIdentifiers object is equal to o.
    */
@@ -110,12 +170,14 @@ public class ParsedSignedTransactionIntentIdentifiers {
     }
     ParsedSignedTransactionIntentIdentifiers parsedSignedTransactionIntentIdentifiers = (ParsedSignedTransactionIntentIdentifiers) o;
     return Objects.equals(this.intentHash, parsedSignedTransactionIntentIdentifiers.intentHash) &&
-        Objects.equals(this.signedIntentHash, parsedSignedTransactionIntentIdentifiers.signedIntentHash);
+        Objects.equals(this.intentHashBech32m, parsedSignedTransactionIntentIdentifiers.intentHashBech32m) &&
+        Objects.equals(this.signedIntentHash, parsedSignedTransactionIntentIdentifiers.signedIntentHash) &&
+        Objects.equals(this.signedIntentHashBech32m, parsedSignedTransactionIntentIdentifiers.signedIntentHashBech32m);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(intentHash, signedIntentHash);
+    return Objects.hash(intentHash, intentHashBech32m, signedIntentHash, signedIntentHashBech32m);
   }
 
   @Override
@@ -123,7 +185,9 @@ public class ParsedSignedTransactionIntentIdentifiers {
     StringBuilder sb = new StringBuilder();
     sb.append("class ParsedSignedTransactionIntentIdentifiers {\n");
     sb.append("    intentHash: ").append(toIndentedString(intentHash)).append("\n");
+    sb.append("    intentHashBech32m: ").append(toIndentedString(intentHashBech32m)).append("\n");
     sb.append("    signedIntentHash: ").append(toIndentedString(signedIntentHash)).append("\n");
+    sb.append("    signedIntentHashBech32m: ").append(toIndentedString(signedIntentHashBech32m)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/ParsedTransactionIntentIdentifiers.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/ParsedTransactionIntentIdentifiers.java
@@ -31,12 +31,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * ParsedTransactionIntentIdentifiers
  */
 @JsonPropertyOrder({
-  ParsedTransactionIntentIdentifiers.JSON_PROPERTY_INTENT_HASH
+  ParsedTransactionIntentIdentifiers.JSON_PROPERTY_INTENT_HASH,
+  ParsedTransactionIntentIdentifiers.JSON_PROPERTY_INTENT_HASH_BECH32M
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ParsedTransactionIntentIdentifiers {
   public static final String JSON_PROPERTY_INTENT_HASH = "intent_hash";
   private String intentHash;
+
+  public static final String JSON_PROPERTY_INTENT_HASH_BECH32M = "intent_hash_bech32m";
+  private String intentHashBech32m;
 
   public ParsedTransactionIntentIdentifiers() { 
   }
@@ -67,6 +71,32 @@ public class ParsedTransactionIntentIdentifiers {
   }
 
 
+  public ParsedTransactionIntentIdentifiers intentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return intentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getIntentHashBech32m() {
+    return intentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setIntentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+  }
+
+
   /**
    * Return true if this ParsedTransactionIntentIdentifiers object is equal to o.
    */
@@ -79,12 +109,13 @@ public class ParsedTransactionIntentIdentifiers {
       return false;
     }
     ParsedTransactionIntentIdentifiers parsedTransactionIntentIdentifiers = (ParsedTransactionIntentIdentifiers) o;
-    return Objects.equals(this.intentHash, parsedTransactionIntentIdentifiers.intentHash);
+    return Objects.equals(this.intentHash, parsedTransactionIntentIdentifiers.intentHash) &&
+        Objects.equals(this.intentHashBech32m, parsedTransactionIntentIdentifiers.intentHashBech32m);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(intentHash);
+    return Objects.hash(intentHash, intentHashBech32m);
   }
 
   @Override
@@ -92,6 +123,7 @@ public class ParsedTransactionIntentIdentifiers {
     StringBuilder sb = new StringBuilder();
     sb.append("class ParsedTransactionIntentIdentifiers {\n");
     sb.append("    intentHash: ").append(toIndentedString(intentHash)).append("\n");
+    sb.append("    intentHashBech32m: ").append(toIndentedString(intentHashBech32m)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/SignedTransactionIntent.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/SignedTransactionIntent.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   SignedTransactionIntent.JSON_PROPERTY_HASH,
+  SignedTransactionIntent.JSON_PROPERTY_HASH_BECH32M,
   SignedTransactionIntent.JSON_PROPERTY_INTENT,
   SignedTransactionIntent.JSON_PROPERTY_INTENT_SIGNATURES
 })
@@ -43,6 +44,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class SignedTransactionIntent {
   public static final String JSON_PROPERTY_HASH = "hash";
   private String hash;
+
+  public static final String JSON_PROPERTY_HASH_BECH32M = "hash_bech32m";
+  private String hashBech32m;
 
   public static final String JSON_PROPERTY_INTENT = "intent";
   private TransactionIntent intent;
@@ -76,6 +80,32 @@ public class SignedTransactionIntent {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setHash(String hash) {
     this.hash = hash;
+  }
+
+
+  public SignedTransactionIntent hashBech32m(String hashBech32m) {
+    this.hashBech32m = hashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;SignedIntentHash&#x60;.
+   * @return hashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `SignedIntentHash`.")
+  @JsonProperty(JSON_PROPERTY_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getHashBech32m() {
+    return hashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setHashBech32m(String hashBech32m) {
+    this.hashBech32m = hashBech32m;
   }
 
 
@@ -149,13 +179,14 @@ public class SignedTransactionIntent {
     }
     SignedTransactionIntent signedTransactionIntent = (SignedTransactionIntent) o;
     return Objects.equals(this.hash, signedTransactionIntent.hash) &&
+        Objects.equals(this.hashBech32m, signedTransactionIntent.hashBech32m) &&
         Objects.equals(this.intent, signedTransactionIntent.intent) &&
         Objects.equals(this.intentSignatures, signedTransactionIntent.intentSignatures);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(hash, intent, intentSignatures);
+    return Objects.hash(hash, hashBech32m, intent, intentSignatures);
   }
 
   @Override
@@ -163,6 +194,7 @@ public class SignedTransactionIntent {
     StringBuilder sb = new StringBuilder();
     sb.append("class SignedTransactionIntent {\n");
     sb.append("    hash: ").append(toIndentedString(hash)).append("\n");
+    sb.append("    hashBech32m: ").append(toIndentedString(hashBech32m)).append("\n");
     sb.append("    intent: ").append(toIndentedString(intent)).append("\n");
     sb.append("    intentSignatures: ").append(toIndentedString(intentSignatures)).append("\n");
     sb.append("}");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionIdKey.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionIdKey.java
@@ -31,12 +31,16 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * TransactionIdKey
  */
 @JsonPropertyOrder({
-  TransactionIdKey.JSON_PROPERTY_INTENT_HASH
+  TransactionIdKey.JSON_PROPERTY_INTENT_HASH,
+  TransactionIdKey.JSON_PROPERTY_INTENT_HASH_BECH32M
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class TransactionIdKey {
   public static final String JSON_PROPERTY_INTENT_HASH = "intent_hash";
   private String intentHash;
+
+  public static final String JSON_PROPERTY_INTENT_HASH_BECH32M = "intent_hash_bech32m";
+  private String intentHashBech32m;
 
   public TransactionIdKey() { 
   }
@@ -67,6 +71,32 @@ public class TransactionIdKey {
   }
 
 
+  public TransactionIdKey intentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return intentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getIntentHashBech32m() {
+    return intentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setIntentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+  }
+
+
   /**
    * Return true if this TransactionIdKey object is equal to o.
    */
@@ -79,12 +109,13 @@ public class TransactionIdKey {
       return false;
     }
     TransactionIdKey transactionIdKey = (TransactionIdKey) o;
-    return Objects.equals(this.intentHash, transactionIdKey.intentHash);
+    return Objects.equals(this.intentHash, transactionIdKey.intentHash) &&
+        Objects.equals(this.intentHashBech32m, transactionIdKey.intentHashBech32m);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(intentHash);
+    return Objects.hash(intentHash, intentHashBech32m);
   }
 
   @Override
@@ -92,6 +123,7 @@ public class TransactionIdKey {
     StringBuilder sb = new StringBuilder();
     sb.append("class TransactionIdKey {\n");
     sb.append("    intentHash: ").append(toIndentedString(intentHash)).append("\n");
+    sb.append("    intentHashBech32m: ").append(toIndentedString(intentHashBech32m)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionIdentifiers.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionIdentifiers.java
@@ -32,19 +32,31 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   TransactionIdentifiers.JSON_PROPERTY_INTENT_HASH,
+  TransactionIdentifiers.JSON_PROPERTY_INTENT_HASH_BECH32M,
   TransactionIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH,
-  TransactionIdentifiers.JSON_PROPERTY_PAYLOAD_HASH
+  TransactionIdentifiers.JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M,
+  TransactionIdentifiers.JSON_PROPERTY_PAYLOAD_HASH,
+  TransactionIdentifiers.JSON_PROPERTY_PAYLOAD_HASH_BECH32M
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class TransactionIdentifiers {
   public static final String JSON_PROPERTY_INTENT_HASH = "intent_hash";
   private String intentHash;
 
+  public static final String JSON_PROPERTY_INTENT_HASH_BECH32M = "intent_hash_bech32m";
+  private String intentHashBech32m;
+
   public static final String JSON_PROPERTY_SIGNED_INTENT_HASH = "signed_intent_hash";
   private String signedIntentHash;
 
+  public static final String JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M = "signed_intent_hash_bech32m";
+  private String signedIntentHashBech32m;
+
   public static final String JSON_PROPERTY_PAYLOAD_HASH = "payload_hash";
   private String payloadHash;
+
+  public static final String JSON_PROPERTY_PAYLOAD_HASH_BECH32M = "payload_hash_bech32m";
+  private String payloadHashBech32m;
 
   public TransactionIdentifiers() { 
   }
@@ -75,6 +87,32 @@ public class TransactionIdentifiers {
   }
 
 
+  public TransactionIdentifiers intentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return intentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getIntentHashBech32m() {
+    return intentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setIntentHashBech32m(String intentHashBech32m) {
+    this.intentHashBech32m = intentHashBech32m;
+  }
+
+
   public TransactionIdentifiers signedIntentHash(String signedIntentHash) {
     this.signedIntentHash = signedIntentHash;
     return this;
@@ -98,6 +136,32 @@ public class TransactionIdentifiers {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setSignedIntentHash(String signedIntentHash) {
     this.signedIntentHash = signedIntentHash;
+  }
+
+
+  public TransactionIdentifiers signedIntentHashBech32m(String signedIntentHashBech32m) {
+    this.signedIntentHashBech32m = signedIntentHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;SignedIntentHash&#x60;.
+   * @return signedIntentHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `SignedIntentHash`.")
+  @JsonProperty(JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getSignedIntentHashBech32m() {
+    return signedIntentHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SIGNED_INTENT_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setSignedIntentHashBech32m(String signedIntentHashBech32m) {
+    this.signedIntentHashBech32m = signedIntentHashBech32m;
   }
 
 
@@ -127,6 +191,32 @@ public class TransactionIdentifiers {
   }
 
 
+  public TransactionIdentifiers payloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;NotarizedTransactionHash&#x60;.
+   * @return payloadHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `NotarizedTransactionHash`.")
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getPayloadHashBech32m() {
+    return payloadHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setPayloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+  }
+
+
   /**
    * Return true if this TransactionIdentifiers object is equal to o.
    */
@@ -140,13 +230,16 @@ public class TransactionIdentifiers {
     }
     TransactionIdentifiers transactionIdentifiers = (TransactionIdentifiers) o;
     return Objects.equals(this.intentHash, transactionIdentifiers.intentHash) &&
+        Objects.equals(this.intentHashBech32m, transactionIdentifiers.intentHashBech32m) &&
         Objects.equals(this.signedIntentHash, transactionIdentifiers.signedIntentHash) &&
-        Objects.equals(this.payloadHash, transactionIdentifiers.payloadHash);
+        Objects.equals(this.signedIntentHashBech32m, transactionIdentifiers.signedIntentHashBech32m) &&
+        Objects.equals(this.payloadHash, transactionIdentifiers.payloadHash) &&
+        Objects.equals(this.payloadHashBech32m, transactionIdentifiers.payloadHashBech32m);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(intentHash, signedIntentHash, payloadHash);
+    return Objects.hash(intentHash, intentHashBech32m, signedIntentHash, signedIntentHashBech32m, payloadHash, payloadHashBech32m);
   }
 
   @Override
@@ -154,8 +247,11 @@ public class TransactionIdentifiers {
     StringBuilder sb = new StringBuilder();
     sb.append("class TransactionIdentifiers {\n");
     sb.append("    intentHash: ").append(toIndentedString(intentHash)).append("\n");
+    sb.append("    intentHashBech32m: ").append(toIndentedString(intentHashBech32m)).append("\n");
     sb.append("    signedIntentHash: ").append(toIndentedString(signedIntentHash)).append("\n");
+    sb.append("    signedIntentHashBech32m: ").append(toIndentedString(signedIntentHashBech32m)).append("\n");
     sb.append("    payloadHash: ").append(toIndentedString(payloadHash)).append("\n");
+    sb.append("    payloadHashBech32m: ").append(toIndentedString(payloadHashBech32m)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionIntent.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionIntent.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   TransactionIntent.JSON_PROPERTY_HASH,
+  TransactionIntent.JSON_PROPERTY_HASH_BECH32M,
   TransactionIntent.JSON_PROPERTY_HEADER,
   TransactionIntent.JSON_PROPERTY_INSTRUCTIONS,
   TransactionIntent.JSON_PROPERTY_BLOBS_HEX,
@@ -46,6 +47,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class TransactionIntent {
   public static final String JSON_PROPERTY_HASH = "hash";
   private String hash;
+
+  public static final String JSON_PROPERTY_HASH_BECH32M = "hash_bech32m";
+  private String hashBech32m;
 
   public static final String JSON_PROPERTY_HEADER = "header";
   private TransactionHeader header;
@@ -85,6 +89,32 @@ public class TransactionIntent {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setHash(String hash) {
     this.hash = hash;
+  }
+
+
+  public TransactionIntent hashBech32m(String hashBech32m) {
+    this.hashBech32m = hashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;IntentHash&#x60;.
+   * @return hashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `IntentHash`.")
+  @JsonProperty(JSON_PROPERTY_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getHashBech32m() {
+    return hashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setHashBech32m(String hashBech32m) {
+    this.hashBech32m = hashBech32m;
   }
 
 
@@ -213,6 +243,7 @@ public class TransactionIntent {
     }
     TransactionIntent transactionIntent = (TransactionIntent) o;
     return Objects.equals(this.hash, transactionIntent.hash) &&
+        Objects.equals(this.hashBech32m, transactionIntent.hashBech32m) &&
         Objects.equals(this.header, transactionIntent.header) &&
         Objects.equals(this.instructions, transactionIntent.instructions) &&
         Objects.equals(this.blobsHex, transactionIntent.blobsHex) &&
@@ -221,7 +252,7 @@ public class TransactionIntent {
 
   @Override
   public int hashCode() {
-    return Objects.hash(hash, header, instructions, blobsHex, message);
+    return Objects.hash(hash, hashBech32m, header, instructions, blobsHex, message);
   }
 
   @Override
@@ -229,6 +260,7 @@ public class TransactionIntent {
     StringBuilder sb = new StringBuilder();
     sb.append("class TransactionIntent {\n");
     sb.append("    hash: ").append(toIndentedString(hash)).append("\n");
+    sb.append("    hashBech32m: ").append(toIndentedString(hashBech32m)).append("\n");
     sb.append("    header: ").append(toIndentedString(header)).append("\n");
     sb.append("    instructions: ").append(toIndentedString(instructions)).append("\n");
     sb.append("    blobsHex: ").append(toIndentedString(blobsHex)).append("\n");

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionPayloadDetails.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionPayloadDetails.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   TransactionPayloadDetails.JSON_PROPERTY_PAYLOAD_HASH,
+  TransactionPayloadDetails.JSON_PROPERTY_PAYLOAD_HASH_BECH32M,
   TransactionPayloadDetails.JSON_PROPERTY_STATE_VERSION,
   TransactionPayloadDetails.JSON_PROPERTY_STATUS,
   TransactionPayloadDetails.JSON_PROPERTY_ERROR_MESSAGE
@@ -41,6 +42,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class TransactionPayloadDetails {
   public static final String JSON_PROPERTY_PAYLOAD_HASH = "payload_hash";
   private String payloadHash;
+
+  public static final String JSON_PROPERTY_PAYLOAD_HASH_BECH32M = "payload_hash_bech32m";
+  private String payloadHashBech32m;
 
   public static final String JSON_PROPERTY_STATE_VERSION = "state_version";
   private Long stateVersion;
@@ -77,6 +81,32 @@ public class TransactionPayloadDetails {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setPayloadHash(String payloadHash) {
     this.payloadHash = payloadHash;
+  }
+
+
+  public TransactionPayloadDetails payloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
+    return this;
+  }
+
+   /**
+   * The Bech32m-encoded human readable &#x60;NotarizedTransactionHash&#x60;.
+   * @return payloadHashBech32m
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The Bech32m-encoded human readable `NotarizedTransactionHash`.")
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getPayloadHashBech32m() {
+    return payloadHashBech32m;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_PAYLOAD_HASH_BECH32M)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setPayloadHashBech32m(String payloadHashBech32m) {
+    this.payloadHashBech32m = payloadHashBech32m;
   }
 
 
@@ -173,6 +203,7 @@ public class TransactionPayloadDetails {
     }
     TransactionPayloadDetails transactionPayloadDetails = (TransactionPayloadDetails) o;
     return Objects.equals(this.payloadHash, transactionPayloadDetails.payloadHash) &&
+        Objects.equals(this.payloadHashBech32m, transactionPayloadDetails.payloadHashBech32m) &&
         Objects.equals(this.stateVersion, transactionPayloadDetails.stateVersion) &&
         Objects.equals(this.status, transactionPayloadDetails.status) &&
         Objects.equals(this.errorMessage, transactionPayloadDetails.errorMessage);
@@ -180,7 +211,7 @@ public class TransactionPayloadDetails {
 
   @Override
   public int hashCode() {
-    return Objects.hash(payloadHash, stateVersion, status, errorMessage);
+    return Objects.hash(payloadHash, payloadHashBech32m, stateVersion, status, errorMessage);
   }
 
   @Override
@@ -188,6 +219,7 @@ public class TransactionPayloadDetails {
     StringBuilder sb = new StringBuilder();
     sb.append("class TransactionPayloadDetails {\n");
     sb.append("    payloadHash: ").append(toIndentedString(payloadHash)).append("\n");
+    sb.append("    payloadHashBech32m: ").append(toIndentedString(payloadHashBech32m)).append("\n");
     sb.append("    stateVersion: ").append(toIndentedString(stateVersion)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    errorMessage: ").append(toIndentedString(errorMessage)).append("\n");

--- a/core/src/test/java/com/radixdlt/api/core/NetworkSubmitTransactionTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/NetworkSubmitTransactionTest.java
@@ -303,7 +303,7 @@ public class NetworkSubmitTransactionTest extends DeterministicCoreApiTestBase {
               .transactionStatusPost(
                   new TransactionStatusRequest()
                       .network(networkLogicalName)
-                      .intentHash(transaction.hexIntentHash()));
+                      .intentHash(addressing.encode(transaction.intentHash())));
 
       assertThat(statusResponse2.getIntentStatus())
           .isEqualTo(TransactionIntentStatus.COMMITTEDSUCCESS);


### PR DESCRIPTION
This addresses https://whimsical.com/babylon-work-tracker-Am2s7hSa7xHd5yCxgub67a@2bsEvpTYSt1Hj4AsGspsqMeRoRGJwUT9pBf

See naming decision at https://rdxworks.slack.com/archives/C01M90Y2448/p1692282868590599?thread_ts=1692182987.453539&cid=C01M90Y2448