### PR TITLE
Quick Fix: Returning SubstateSystemStructures missed for updates and deletes in Core API

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -1867,6 +1867,7 @@ components:
       required:
         - substate_id
         - new_value
+        - system_structure
       properties:
         substate_id:
           $ref: "#/components/schemas/SubstateId"
@@ -1876,6 +1877,9 @@ components:
         previous_value:
           $ref: "#/components/schemas/SubstateValue"
           description: The previous value of the substate. Only returned if enabled in SubstateFormatOptions on your request (default false).
+        system_structure:
+          $ref: "#/components/schemas/SubstateSystemStructure"
+          description: A structure with type references describing the substate's schema.
     SubstateValue:
       type: object
       properties:
@@ -1892,12 +1896,16 @@ components:
       type: object
       required:
         - substate_id
+        - system_structure
       properties:
         substate_id:
           $ref: "#/components/schemas/SubstateId"
         previous_value:
           $ref: "#/components/schemas/SubstateValue"
           description: The previous value of the substate. Only returned if enabled in SubstateFormatOptions on your request (default false).
+        system_structure:
+          $ref: "#/components/schemas/SubstateSystemStructure"
+          description: A structure with type references describing the substate's schema.
     EntityReference:
       type: object
       required:

--- a/core-rust/core-api-server/src/core_api/conversions/receipt.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/receipt.rs
@@ -159,6 +159,7 @@ pub fn to_api_updated_substate(
     typed_substate_key: &TypedSubstateKey,
     new_value_representations: &ValueRepresentations,
     previous_value_representations: &ValueRepresentations,
+    system_structure: &SubstateSystemStructure,
 ) -> Result<models::UpdatedSubstate, MappingError> {
     Ok(models::UpdatedSubstate {
         substate_id: Box::new(to_api_substate_id(
@@ -182,6 +183,7 @@ pub fn to_api_updated_substate(
         } else {
             None
         },
+        system_structure: Some(to_api_substate_system_structure(context, system_structure)?),
     })
 }
 
@@ -222,6 +224,7 @@ pub fn to_api_deleted_substate(
     substate_key: &SubstateKey,
     typed_substate_key: &TypedSubstateKey,
     previous_value_representations: &ValueRepresentations,
+    system_structure: &SubstateSystemStructure,
 ) -> Result<models::DeletedSubstate, MappingError> {
     let substate_id = to_api_substate_id(
         context,
@@ -241,6 +244,7 @@ pub fn to_api_deleted_substate(
         } else {
             None
         },
+        system_structure: Some(to_api_substate_system_structure(context, system_structure)?),
     })
 }
 
@@ -437,6 +441,7 @@ pub fn to_api_state_updates(
                     &typed_substate_key,
                     &ValueRepresentations::new(&typed_substate_key, new)?,
                     &ValueRepresentations::new(&typed_substate_key, previous)?,
+                    system_structure,
                 )?);
             }
             ChangeAction::Delete { previous } => {
@@ -447,6 +452,7 @@ pub fn to_api_state_updates(
                     &substate_key,
                     &typed_substate_key,
                     &ValueRepresentations::new(&typed_substate_key, previous)?,
+                    system_structure,
                 )?);
             }
         }

--- a/core-rust/core-api-server/src/core_api/generated/models/deleted_substate.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/deleted_substate.rs
@@ -17,13 +17,16 @@ pub struct DeletedSubstate {
     pub substate_id: Box<crate::core_api::generated::models::SubstateId>,
     #[serde(rename = "previous_value", skip_serializing_if = "Option::is_none")]
     pub previous_value: Option<Box<crate::core_api::generated::models::SubstateValue>>,
+    #[serde(rename = "system_structure")]
+    pub system_structure: Option<crate::core_api::generated::models::SubstateSystemStructure>, // Using Option permits Default trait; Will always be Some in normal use
 }
 
 impl DeletedSubstate {
-    pub fn new(substate_id: crate::core_api::generated::models::SubstateId) -> DeletedSubstate {
+    pub fn new(substate_id: crate::core_api::generated::models::SubstateId, system_structure: crate::core_api::generated::models::SubstateSystemStructure) -> DeletedSubstate {
         DeletedSubstate {
             substate_id: Box::new(substate_id),
             previous_value: None,
+            system_structure: Option::Some(system_structure),
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/updated_substate.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/updated_substate.rs
@@ -19,14 +19,17 @@ pub struct UpdatedSubstate {
     pub new_value: Box<crate::core_api::generated::models::SubstateValue>,
     #[serde(rename = "previous_value", skip_serializing_if = "Option::is_none")]
     pub previous_value: Option<Box<crate::core_api::generated::models::SubstateValue>>,
+    #[serde(rename = "system_structure")]
+    pub system_structure: Option<crate::core_api::generated::models::SubstateSystemStructure>, // Using Option permits Default trait; Will always be Some in normal use
 }
 
 impl UpdatedSubstate {
-    pub fn new(substate_id: crate::core_api::generated::models::SubstateId, new_value: crate::core_api::generated::models::SubstateValue) -> UpdatedSubstate {
+    pub fn new(substate_id: crate::core_api::generated::models::SubstateId, new_value: crate::core_api::generated::models::SubstateValue, system_structure: crate::core_api::generated::models::SubstateSystemStructure) -> UpdatedSubstate {
         UpdatedSubstate {
             substate_id: Box::new(substate_id),
             new_value: Box::new(new_value),
             previous_value: None,
+            system_structure: Option::Some(system_structure),
         }
     }
 }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/DeletedSubstate.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/DeletedSubstate.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.radixdlt.api.core.generated.models.SubstateId;
+import com.radixdlt.api.core.generated.models.SubstateSystemStructure;
 import com.radixdlt.api.core.generated.models.SubstateValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -34,7 +35,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({
   DeletedSubstate.JSON_PROPERTY_SUBSTATE_ID,
-  DeletedSubstate.JSON_PROPERTY_PREVIOUS_VALUE
+  DeletedSubstate.JSON_PROPERTY_PREVIOUS_VALUE,
+  DeletedSubstate.JSON_PROPERTY_SYSTEM_STRUCTURE
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class DeletedSubstate {
@@ -43,6 +45,9 @@ public class DeletedSubstate {
 
   public static final String JSON_PROPERTY_PREVIOUS_VALUE = "previous_value";
   private SubstateValue previousValue;
+
+  public static final String JSON_PROPERTY_SYSTEM_STRUCTURE = "system_structure";
+  private SubstateSystemStructure systemStructure;
 
   public DeletedSubstate() { 
   }
@@ -99,6 +104,32 @@ public class DeletedSubstate {
   }
 
 
+  public DeletedSubstate systemStructure(SubstateSystemStructure systemStructure) {
+    this.systemStructure = systemStructure;
+    return this;
+  }
+
+   /**
+   * Get systemStructure
+   * @return systemStructure
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_SYSTEM_STRUCTURE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public SubstateSystemStructure getSystemStructure() {
+    return systemStructure;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SYSTEM_STRUCTURE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setSystemStructure(SubstateSystemStructure systemStructure) {
+    this.systemStructure = systemStructure;
+  }
+
+
   /**
    * Return true if this DeletedSubstate object is equal to o.
    */
@@ -112,12 +143,13 @@ public class DeletedSubstate {
     }
     DeletedSubstate deletedSubstate = (DeletedSubstate) o;
     return Objects.equals(this.substateId, deletedSubstate.substateId) &&
-        Objects.equals(this.previousValue, deletedSubstate.previousValue);
+        Objects.equals(this.previousValue, deletedSubstate.previousValue) &&
+        Objects.equals(this.systemStructure, deletedSubstate.systemStructure);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(substateId, previousValue);
+    return Objects.hash(substateId, previousValue, systemStructure);
   }
 
   @Override
@@ -126,6 +158,7 @@ public class DeletedSubstate {
     sb.append("class DeletedSubstate {\n");
     sb.append("    substateId: ").append(toIndentedString(substateId)).append("\n");
     sb.append("    previousValue: ").append(toIndentedString(previousValue)).append("\n");
+    sb.append("    systemStructure: ").append(toIndentedString(systemStructure)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/UpdatedSubstate.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/UpdatedSubstate.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.radixdlt.api.core.generated.models.SubstateId;
+import com.radixdlt.api.core.generated.models.SubstateSystemStructure;
 import com.radixdlt.api.core.generated.models.SubstateValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -35,7 +36,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({
   UpdatedSubstate.JSON_PROPERTY_SUBSTATE_ID,
   UpdatedSubstate.JSON_PROPERTY_NEW_VALUE,
-  UpdatedSubstate.JSON_PROPERTY_PREVIOUS_VALUE
+  UpdatedSubstate.JSON_PROPERTY_PREVIOUS_VALUE,
+  UpdatedSubstate.JSON_PROPERTY_SYSTEM_STRUCTURE
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class UpdatedSubstate {
@@ -47,6 +49,9 @@ public class UpdatedSubstate {
 
   public static final String JSON_PROPERTY_PREVIOUS_VALUE = "previous_value";
   private SubstateValue previousValue;
+
+  public static final String JSON_PROPERTY_SYSTEM_STRUCTURE = "system_structure";
+  private SubstateSystemStructure systemStructure;
 
   public UpdatedSubstate() { 
   }
@@ -129,6 +134,32 @@ public class UpdatedSubstate {
   }
 
 
+  public UpdatedSubstate systemStructure(SubstateSystemStructure systemStructure) {
+    this.systemStructure = systemStructure;
+    return this;
+  }
+
+   /**
+   * Get systemStructure
+   * @return systemStructure
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_SYSTEM_STRUCTURE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public SubstateSystemStructure getSystemStructure() {
+    return systemStructure;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_SYSTEM_STRUCTURE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setSystemStructure(SubstateSystemStructure systemStructure) {
+    this.systemStructure = systemStructure;
+  }
+
+
   /**
    * Return true if this UpdatedSubstate object is equal to o.
    */
@@ -143,12 +174,13 @@ public class UpdatedSubstate {
     UpdatedSubstate updatedSubstate = (UpdatedSubstate) o;
     return Objects.equals(this.substateId, updatedSubstate.substateId) &&
         Objects.equals(this.newValue, updatedSubstate.newValue) &&
-        Objects.equals(this.previousValue, updatedSubstate.previousValue);
+        Objects.equals(this.previousValue, updatedSubstate.previousValue) &&
+        Objects.equals(this.systemStructure, updatedSubstate.systemStructure);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(substateId, newValue, previousValue);
+    return Objects.hash(substateId, newValue, previousValue, systemStructure);
   }
 
   @Override
@@ -158,6 +190,7 @@ public class UpdatedSubstate {
     sb.append("    substateId: ").append(toIndentedString(substateId)).append("\n");
     sb.append("    newValue: ").append(toIndentedString(newValue)).append("\n");
     sb.append("    previousValue: ").append(toIndentedString(previousValue)).append("\n");
+    sb.append("    systemStructure: ").append(toIndentedString(systemStructure)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
The recent https://github.com/radixdlt/babylon-node/pull/620 introduced `system_structure` for created substates, but it was missing from updated and deleted substates.