### PR TITLE
Improve logging (EventLoggerModule)

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
@@ -165,6 +165,8 @@ public final class NodeSborCodecs {
     NextEpoch.registerCodec(codecMap);
     ActiveValidatorInfo.registerCodec(codecMap);
     CommitRequest.registerCodec(codecMap);
+    CommitSummary.registerCodec(codecMap);
+    LeaderRoundCounter.registerCodec(codecMap);
     InvalidCommitRequestError.registerCodec(codecMap);
     DatabaseBackendConfig.registerCodec(codecMap);
     DatabaseFlags.registerCodec(codecMap);

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/RustStateComputer.java
@@ -67,7 +67,6 @@ package com.radixdlt.statecomputer;
 import com.google.common.reflect.TypeToken;
 import com.radixdlt.environment.NodeRustEnvironment;
 import com.radixdlt.lang.Result;
-import com.radixdlt.lang.Tuple;
 import com.radixdlt.monitoring.LabelledTimer;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.monitoring.Metrics.MethodId;
@@ -112,11 +111,11 @@ public class RustStateComputer {
 
   private static native byte[] prepare(NodeRustEnvironment nodeRustEnvironment, byte[] payload);
 
-  public Result<Tuple.Tuple0, InvalidCommitRequestError> commit(CommitRequest commitRequest) {
+  public Result<CommitSummary, InvalidCommitRequestError> commit(CommitRequest commitRequest) {
     return commitFunc.call(commitRequest);
   }
 
-  private final Natives.Call1<CommitRequest, Result<Tuple.Tuple0, InvalidCommitRequestError>>
+  private final Natives.Call1<CommitRequest, Result<CommitSummary, InvalidCommitRequestError>>
       commitFunc;
 
   private static native byte[] commit(NodeRustEnvironment nodeRustEnvironment, byte[] payload);

--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/LeaderRoundCounter.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/commit/LeaderRoundCounter.java
@@ -62,63 +62,16 @@
  * permissions under this License.
  */
 
-package com.radixdlt.harness.simulation.monitors.consensus;
+package com.radixdlt.statecomputer.commit;
 
-import com.radixdlt.consensus.bft.Round;
-import com.radixdlt.consensus.epoch.EpochRound;
-import com.radixdlt.harness.simulation.TestInvariant;
-import com.radixdlt.harness.simulation.network.SimulationNodes.RunningNetwork;
-import com.radixdlt.ledger.LedgerUpdate;
-import com.radixdlt.utils.Pair;
-import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Observable;
-import java.time.Duration;
+import com.radixdlt.sbor.codec.CodecMap;
+import com.radixdlt.sbor.codec.StructCodec;
+import com.radixdlt.utils.UInt64;
 
-/**
- * Checks that the first time a ledger update occurs on the network that it is close to the real
- * wall clock time.
- */
-public final class ConsensusTimestampChecker implements TestInvariant {
-
-  private final Duration acceptableTimeRange;
-
-  public ConsensusTimestampChecker(Duration acceptableTimeRange) {
-    this.acceptableTimeRange = acceptableTimeRange;
-  }
-
-  private Maybe<TestInvariantError> checkCloseTimestamp(LedgerUpdate update) {
-    final var now = System.currentTimeMillis();
-    final var proof = update.proof();
-    final var timestamp = proof.consensusParentRoundTimestamp();
-    // Initial rounds of Consensus can have a timestamp of 0
-    if (timestamp == 0) {
-      return Maybe.empty();
-    }
-    final var diff = now - timestamp;
-    if (0 <= diff && diff < acceptableTimeRange.toMillis()) {
-      return Maybe.empty();
-    } else {
-      return Maybe.just(
-          new TestInvariantError(
-              String.format(
-                  "Expecting timestamp to be close to %s but was %s%+d at %s:%s with %s",
-                  now, now, diff, proof.getEpoch(), proof.getRound(), update)));
-    }
-  }
-
-  private static boolean isFirstRoundOfFirstEpoch(LedgerUpdate ledgerUpdate) {
-    return ledgerUpdate.proof().getEpoch() == 1
-        && ledgerUpdate.proof().getRound().equals(Round.of(1));
-  }
-
-  @Override
-  public Observable<TestInvariantError> check(RunningNetwork network) {
-    return network
-        .ledgerUpdates()
-        .map(Pair::getSecond)
-        // Test on only the first ledger update in the network
-        .distinct(update -> EpochRound.of(update.proof().getEpoch(), update.proof().getRound()))
-        .filter(l -> !isFirstRoundOfFirstEpoch(l))
-        .flatMapMaybe(this::checkCloseTimestamp);
+public record LeaderRoundCounter(UInt64 successful, UInt64 missedByFallback, UInt64 missedByGap) {
+  public static void registerCodec(CodecMap codecMap) {
+    codecMap.register(
+        LeaderRoundCounter.class,
+        codecs -> StructCodec.fromRecordComponents(LeaderRoundCounter.class, codecs));
   }
 }

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::LedgerProof;
+use crate::{CommitSummary, LedgerProof};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
@@ -177,7 +177,7 @@ extern "system" fn Java_com_radixdlt_statecomputer_RustStateComputer_commit(
     jni_sbor_coded_call(
         &env,
         request_payload,
-        |commit_request: CommitRequest| -> Result<(), InvalidCommitRequestError> {
+        |commit_request: CommitRequest| -> Result<CommitSummary, InvalidCommitRequestError> {
             let state_computer = JNINodeRustEnvironment::get_state_computer(&env, j_node_rust_env);
             state_computer.commit(commit_request)
         },

--- a/core-rust/state-manager/src/transaction/round_update_transaction.rs
+++ b/core-rust/state-manager/src/transaction/round_update_transaction.rs
@@ -228,7 +228,7 @@ impl LeaderRoundCountersBuilder {
 }
 
 /// A set of counters of rounds led by a concrete leader.
-#[derive(Default, Debug)]
+#[derive(Default, Clone, Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct LeaderRoundCounter {
     pub successful: usize,
     pub missed_by_fallback: usize,

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -321,6 +321,12 @@ pub struct CommitRequest {
 }
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+pub struct CommitSummary {
+    pub validator_round_counters: Vec<(ComponentAddress, LeaderRoundCounter)>,
+    pub num_user_transactions: u32,
+}
+
+#[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct PrepareRequest {
     pub committed_ledger_hashes: LedgerHashes,
     pub ancestor_transactions: Vec<RawLedgerTransaction>,

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/ProposerTimestampInaccurateClockAndLeaderDownTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/ProposerTimestampInaccurateClockAndLeaderDownTest.java
@@ -194,7 +194,7 @@ public final class ProposerTimestampInaccurateClockAndLeaderDownTest {
                 >= 1);
       } else if (node.equals(downNode)) {
         // The down node shouldn't process any consensus events
-        assertEquals(0, (long) counters.bft().successfullyProcessedVotes().get());
+        assertEquals(0, (long) counters.bft().successfullyProcessedVotes().getSum());
         assertEquals(0, (long) counters.bft().successfullyProcessedProposals().get());
       } else {
         // A healthy node:

--- a/core/src/main/java/com/radixdlt/consensus/ConsensusByzantineEvent.java
+++ b/core/src/main/java/com/radixdlt/consensus/ConsensusByzantineEvent.java
@@ -69,19 +69,10 @@ import com.radixdlt.consensus.bft.BFTValidatorId;
 import com.radixdlt.p2p.NodeId;
 
 public sealed interface ConsensusByzantineEvent {
-
   record ConflictingGenesis(QuorumCertificate qc, NodeId author)
-      implements ConsensusByzantineEvent {
-    public NodeId getAuthor() {
-      return author;
-    }
-  }
+      implements ConsensusByzantineEvent {}
 
   /** A Double vote which has detected. This is proof that there is byzantine node. */
   record DoubleVote(BFTValidatorId author, PreviousVote previousVote, Vote vote, HashCode voteHash)
-      implements ConsensusByzantineEvent {
-    public BFTValidatorId getAuthor() {
-      return author;
-    }
-  }
+      implements ConsensusByzantineEvent {}
 }

--- a/core/src/main/java/com/radixdlt/consensus/LedgerProof.java
+++ b/core/src/main/java/com/radixdlt/consensus/LedgerProof.java
@@ -78,7 +78,6 @@ import com.radixdlt.serialization.DsonOutput.Output;
 import com.radixdlt.serialization.SerializerConstants;
 import com.radixdlt.serialization.SerializerDummy;
 import com.radixdlt.serialization.SerializerId2;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
@@ -140,21 +139,6 @@ public final class LedgerProof {
             ledgerTimestamp);
     return new LedgerProof(
         HashUtils.zero256(), genesisLedgerHeader, new TimestampedECDSASignatures());
-  }
-
-  public static final class OrderByEpochAndVersionComparator implements Comparator<LedgerProof> {
-    @Override
-    public int compare(LedgerProof p0, LedgerProof p1) {
-      if (p0.ledgerHeader.getEpoch() != p1.ledgerHeader.getEpoch()) {
-        return p0.ledgerHeader.getEpoch() > p1.ledgerHeader.getEpoch() ? 1 : -1;
-      }
-
-      if (p0.ledgerHeader.isEndOfEpoch() != p1.ledgerHeader.isEndOfEpoch()) {
-        return p0.ledgerHeader.isEndOfEpoch() ? 1 : -1;
-      }
-
-      return Long.compare(p0.ledgerHeader.getStateVersion(), p1.ledgerHeader.getStateVersion());
-    }
   }
 
   public static LedgerProof fromDto(DtoLedgerProof dto) {

--- a/core/src/main/java/com/radixdlt/consensus/epoch/EpochManager.java
+++ b/core/src/main/java/com/radixdlt/consensus/epoch/EpochManager.java
@@ -325,7 +325,7 @@ public final class EpochManager {
     this.currentLedgerHeader = ledgerUpdate.proof().getHeader();
 
     ledgerUpdate
-        .maybeEpochChange()
+        .epochChange()
         .ifPresentOrElse(
             this::processEpochChange, () -> this.syncLedgerUpdateProcessor.process(ledgerUpdate));
   }

--- a/core/src/main/java/com/radixdlt/consensus/epoch/EpochManager.java
+++ b/core/src/main/java/com/radixdlt/consensus/epoch/EpochManager.java
@@ -322,15 +322,12 @@ public final class EpochManager {
   }
 
   private void processLedgerUpdate(LedgerUpdate ledgerUpdate) {
-    this.currentLedgerHeader = ledgerUpdate.getTail().getHeader();
+    this.currentLedgerHeader = ledgerUpdate.proof().getHeader();
 
-    var epochChange = ledgerUpdate.getStateComputerOutput().getInstance(EpochChange.class);
-
-    if (epochChange != null) {
-      this.processEpochChange(epochChange);
-    } else {
-      this.syncLedgerUpdateProcessor.process(ledgerUpdate);
-    }
+    ledgerUpdate
+        .maybeEpochChange()
+        .ifPresentOrElse(
+            this::processEpochChange, () -> this.syncLedgerUpdateProcessor.process(ledgerUpdate));
   }
 
   private void processEpochChange(EpochChange epochChange) {

--- a/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
+++ b/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
@@ -636,11 +636,12 @@ public final class BFTSync implements BFTSyncer {
 
   // TODO: Verify headers match
   private void processLedgerUpdate(LedgerUpdate ledgerUpdate) {
-    log.trace("SYNC_STATE: update {}", ledgerUpdate.getTail());
+    final var proof = ledgerUpdate.proof();
+    log.trace("SYNC_STATE: update {}", proof);
 
-    this.currentLedgerHeader = ledgerUpdate.getTail().getHeader();
+    this.currentLedgerHeader = proof.getHeader();
 
-    var listeners = this.ledgerSyncing.headMap(ledgerUpdate.getTail().getHeader(), true).values();
+    var listeners = this.ledgerSyncing.headMap(proof.getHeader(), true).values();
     var listenersIterator = listeners.iterator();
 
     while (listenersIterator.hasNext()) {
@@ -657,7 +658,6 @@ public final class BFTSync implements BFTSyncer {
 
     syncing
         .entrySet()
-        .removeIf(
-            e -> e.getValue().highQC.highestQC().getRound().lte(ledgerUpdate.getTail().getRound()));
+        .removeIf(e -> e.getValue().highQC.highestQC().getRound().lte(proof.getRound()));
   }
 }

--- a/core/src/main/java/com/radixdlt/ledger/LedgerUpdate.java
+++ b/core/src/main/java/com/radixdlt/ledger/LedgerUpdate.java
@@ -74,7 +74,7 @@ import java.util.Optional;
 public record LedgerUpdate(
     CommitSummary commitSummary,
     LedgerExtension ledgerExtension,
-    Optional<EpochChange> maybeEpochChange) {
+    Optional<EpochChange> epochChange) {
 
   public LedgerProof proof() {
     return ledgerExtension.getProof();

--- a/core/src/main/java/com/radixdlt/ledger/LedgerUpdate.java
+++ b/core/src/main/java/com/radixdlt/ledger/LedgerUpdate.java
@@ -64,58 +64,23 @@
 
 package com.radixdlt.ledger;
 
-import com.google.common.collect.ClassToInstanceMap;
 import com.radixdlt.consensus.LedgerProof;
-import com.radixdlt.consensus.bft.BFTValidatorSet;
+import com.radixdlt.consensus.epoch.EpochChange;
+import com.radixdlt.statecomputer.commit.CommitSummary;
 import com.radixdlt.transactions.RawLedgerTransaction;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
-public final class LedgerUpdate {
-  private final LedgerExtension ledgerExtension;
-  // FIXME: Easiest way to implement this part for now
-  private final ClassToInstanceMap<Object> output;
+public record LedgerUpdate(
+    CommitSummary commitSummary,
+    LedgerExtension ledgerExtension,
+    Optional<EpochChange> maybeEpochChange) {
 
-  public LedgerUpdate(LedgerExtension ledgerExtension, ClassToInstanceMap<Object> output) {
-    this.ledgerExtension = Objects.requireNonNull(ledgerExtension);
-    this.output = Objects.requireNonNull(output);
-  }
-
-  public ClassToInstanceMap<Object> getStateComputerOutput() {
-    return output;
-  }
-
-  public List<RawLedgerTransaction> getNewTransactions() {
-    return ledgerExtension.getTransactions();
-  }
-
-  public LedgerProof getTail() {
+  public LedgerProof proof() {
     return ledgerExtension.getProof();
   }
 
-  public Optional<BFTValidatorSet> getNextValidatorSet() {
-    return ledgerExtension.getProof().getNextValidatorSet();
-  }
-
-  @Override
-  public String toString() {
-    return String.format("%s{transactions=%s}", this.getClass().getSimpleName(), ledgerExtension);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(ledgerExtension, output);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (!(o instanceof LedgerUpdate)) {
-      return false;
-    }
-
-    LedgerUpdate other = (LedgerUpdate) o;
-    return Objects.equals(other.ledgerExtension, this.ledgerExtension)
-        && Objects.equals(other.output, this.output);
+  public List<RawLedgerTransaction> transactions() {
+    return ledgerExtension.getTransactions();
   }
 }

--- a/core/src/main/java/com/radixdlt/logger/EventLoggerConfig.java
+++ b/core/src/main/java/com/radixdlt/logger/EventLoggerConfig.java
@@ -65,16 +65,20 @@
 package com.radixdlt.logger;
 
 import com.radixdlt.addressing.Addressing;
+import com.radixdlt.consensus.bft.BFTValidatorId;
 import com.radixdlt.crypto.ECDSASecp256k1PublicKey;
 import java.util.function.Function;
 
-public record EventLoggerConfig(Function<ECDSASecp256k1PublicKey, String> nodeKeyToString) {
+public record EventLoggerConfig(
+    Function<ECDSASecp256k1PublicKey, String> formatNodeAddress,
+    Function<BFTValidatorId, String> formatBftValidatorId) {
   public static EventLoggerConfig addressed(Addressing addressing) {
     return new EventLoggerConfig(
-        k -> {
-          var addr = addressing.encodeNodeAddress(k);
-          var len = addr.length();
+        key -> {
+          final var addr = addressing.encodeNodeAddress(key);
+          final var len = addr.length();
           return addr.substring(0, 2) + "..." + addr.substring(len - 9);
-        });
+        },
+        v -> addressing.encode(v.getValidatorAddress()));
   }
 }

--- a/core/src/main/java/com/radixdlt/logger/EventLoggerModule.java
+++ b/core/src/main/java/com/radixdlt/logger/EventLoggerModule.java
@@ -186,9 +186,9 @@ public final class EventLoggerModule extends AbstractModule {
     logLedgerUpdate(
         ledgerUpdate,
         ledgerUpdate.commitSummary().numUserTransactions().toInt(),
-        calculateLoggingLevel(ledgerUpdateLogLimiter, ledgerUpdate.maybeEpochChange()));
+        calculateLoggingLevel(ledgerUpdateLogLimiter, ledgerUpdate.epochChange()));
 
-    ledgerUpdate.maybeEpochChange().ifPresent(epochChange -> logEpochChange(self, epochChange));
+    ledgerUpdate.epochChange().ifPresent(epochChange -> logEpochChange(self, epochChange));
 
     self.bftValidatorId()
         .ifPresent(

--- a/core/src/main/java/com/radixdlt/monitoring/InMemorySystemInfo.java
+++ b/core/src/main/java/com/radixdlt/monitoring/InMemorySystemInfo.java
@@ -90,7 +90,7 @@ public final class InMemorySystemInfo {
 
   public EventProcessor<LedgerUpdate> ledgerUpdateEventProcessor() {
     return update -> {
-      var ledgerProof = update.getTail();
+      var ledgerProof = update.proof();
       if (ledgerProof.getNextEpoch().isPresent()) {
         epochsLedgerProof.set(ledgerProof);
       }

--- a/core/src/main/java/com/radixdlt/p2p/transport/PeerChannel.java
+++ b/core/src/main/java/com/radixdlt/p2p/transport/PeerChannel.java
@@ -308,8 +308,9 @@ public final class PeerChannel extends SimpleChannelInboundHandler<ByteBuf> {
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) {
-    log.info("Closed: {}", this);
-
+    if (log.isTraceEnabled()) {
+      log.trace("Closed: {}", this);
+    }
     final var prevState = this.state;
     this.state = ChannelState.INACTIVE;
     this.inboundMessageSink.onComplete();

--- a/core/src/main/java/com/radixdlt/sync/LocalSyncService.java
+++ b/core/src/main/java/com/radixdlt/sync/LocalSyncService.java
@@ -580,7 +580,7 @@ public final class LocalSyncService {
   }
 
   private SyncState updateCurrentHeaderIfNeeded(SyncState currentState, LedgerUpdate ledgerUpdate) {
-    final var updatedHeader = ledgerUpdate.getTail();
+    final var updatedHeader = ledgerUpdate.proof();
     final var isNewerState =
         updatedHeader.getStateVersion() > currentState.getCurrentHeader().getStateVersion();
     if (isNewerState) {

--- a/core/src/main/java/com/radixdlt/sync/RemoteSyncService.java
+++ b/core/src/main/java/com/radixdlt/sync/RemoteSyncService.java
@@ -172,7 +172,7 @@ public final class RemoteSyncService {
   }
 
   private void processLedgerUpdate(LedgerUpdate ledgerUpdate) {
-    final LedgerProof updatedHeader = ledgerUpdate.getTail();
+    final LedgerProof updatedHeader = ledgerUpdate.proof();
     if (updatedHeader.getStateVersion() > this.currentHeader.getStateVersion()) {
       this.currentHeader = updatedHeader;
       this.sendStatusUpdateToSomePeers(updatedHeader);

--- a/core/src/main/java/com/radixdlt/sync/epochs/EpochsLocalSyncService.java
+++ b/core/src/main/java/com/radixdlt/sync/epochs/EpochsLocalSyncService.java
@@ -111,10 +111,10 @@ public class EpochsLocalSyncService {
 
   private void processLedgerUpdate(LedgerUpdate ledgerUpdate) {
     ledgerUpdate
-        .maybeEpochChange()
+        .epochChange()
         .ifPresent(
             epochChange -> {
-              this.currentEpoch = ledgerUpdate.maybeEpochChange().orElseThrow();
+              this.currentEpoch = ledgerUpdate.epochChange().orElseThrow();
               this.localSyncService =
                   localSyncServiceFactory.create(
                       new RemoteSyncResponseValidatorSetVerifier(

--- a/core/src/main/resources/no_highlight_log4j2.properties
+++ b/core/src/main/resources/no_highlight_log4j2.properties
@@ -17,7 +17,7 @@ logger.netty-platformdependent0-nodebug.additivity = false
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %highlight{%d{ISO8601} [%p/%c{1}/%t%X{self}] - %m}{OFF=bright white, FATAL=blink bright red, ERROR=bright red, WARN=bright yellow, INFO=bright white, DEBUG=dim cyan, TRACE=dim white}%n
+appender.console.layout.pattern = %d{ISO8601} [%p/%c{1}/%t%X{self}] - %m%n
 appender.console.filter.threshold.type = ThresholdFilter
 appender.console.filter.threshold.level = ${env:RADIXDLT_CONSOLE_APPENDER_THRESHOLD:-ALL}
 

--- a/core/src/test-core/java/com/radixdlt/harness/deterministic/DeterministicNodes.java
+++ b/core/src/test-core/java/com/radixdlt/harness/deterministic/DeterministicNodes.java
@@ -178,7 +178,8 @@ public final class DeterministicNodes implements AutoCloseable {
                 install(
                     new EventLoggerModule(
                         new EventLoggerConfig(
-                            k -> "Node" + addressBook.apply(NodeId.fromPublicKey(k)))));
+                            k -> "Node" + addressBook.apply(NodeId.fromPublicKey(k)),
+                            v -> "Node" + addressBook.apply(NodeId.fromPublicKey(v.getKey())))));
                 bind(ECDSASecp256k1PublicKey.class)
                     .annotatedWith(Self.class)
                     .toInstance(config.key());

--- a/core/src/test-core/java/com/radixdlt/harness/deterministic/DeterministicTest.java
+++ b/core/src/test-core/java/com/radixdlt/harness/deterministic/DeterministicTest.java
@@ -461,7 +461,7 @@ public final class DeterministicTest implements AutoCloseable {
     return timedMsg -> {
       final var message = timedMsg.value();
       if (message.message() instanceof final LedgerUpdate ledgerUpdate) {
-        var epochChange = ledgerUpdate.maybeEpochChange();
+        var epochChange = ledgerUpdate.epochChange();
         return epochChange.isPresent() && epochChange.orElseThrow().getNextEpoch() == epoch;
       }
 

--- a/core/src/test-core/java/com/radixdlt/harness/deterministic/DeterministicTest.java
+++ b/core/src/test-core/java/com/radixdlt/harness/deterministic/DeterministicTest.java
@@ -72,7 +72,6 @@ import com.radixdlt.addressing.Addressing;
 import com.radixdlt.consensus.Proposal;
 import com.radixdlt.consensus.bft.*;
 import com.radixdlt.consensus.bft.Round;
-import com.radixdlt.consensus.epoch.EpochChange;
 import com.radixdlt.consensus.epoch.EpochRound;
 import com.radixdlt.consensus.epoch.EpochRoundUpdate;
 import com.radixdlt.environment.deterministic.network.ControlledMessage;
@@ -462,8 +461,8 @@ public final class DeterministicTest implements AutoCloseable {
     return timedMsg -> {
       final var message = timedMsg.value();
       if (message.message() instanceof final LedgerUpdate ledgerUpdate) {
-        var epochChange = ledgerUpdate.getStateComputerOutput().getInstance(EpochChange.class);
-        return epochChange != null && epochChange.getNextEpoch() == epoch;
+        var epochChange = ledgerUpdate.maybeEpochChange();
+        return epochChange.isPresent() && epochChange.orElseThrow().getNextEpoch() == epoch;
       }
 
       return false;

--- a/core/src/test-core/java/com/radixdlt/harness/simulation/monitors/ledger/ConsensusToLedgerCommittedInvariant.java
+++ b/core/src/test-core/java/com/radixdlt/harness/simulation/monitors/ledger/ConsensusToLedgerCommittedInvariant.java
@@ -97,7 +97,7 @@ public class ConsensusToLedgerCommittedInvariant implements TestInvariant {
             .<Set<RawLedgerTransaction>>scan(
                 new HashSet<>(),
                 (set, next) -> {
-                  set.addAll(next.getSecond().getNewTransactions());
+                  set.addAll(next.getSecond().transactions());
                   return set;
                 })
             .subscribe(committedTxns::onNext);

--- a/core/src/test-core/java/com/radixdlt/harness/simulation/monitors/ledger/LedgerInOrderInvariant.java
+++ b/core/src/test-core/java/com/radixdlt/harness/simulation/monitors/ledger/LedgerInOrderInvariant.java
@@ -98,7 +98,7 @@ public class LedgerInOrderInvariant implements TestInvariant {
               final var ledgerUpdate = nodeAndLedgerUpdate.getSecond();
               final var nodeTxns =
                   transactionsPerNode.computeIfAbsent(node, k -> new ArrayList<>());
-              nodeTxns.addAll(ledgerUpdate.getNewTransactions());
+              nodeTxns.addAll(ledgerUpdate.transactions());
 
               return transactionsPerNode.entrySet().stream()
                   .filter(e -> nodeTxns != e.getValue())

--- a/core/src/test-core/java/com/radixdlt/harness/simulation/network/SimulationNodes.java
+++ b/core/src/test-core/java/com/radixdlt/harness/simulation/network/SimulationNodes.java
@@ -274,8 +274,8 @@ public class SimulationNodes {
       final var epochChangeObservable =
           ledgerUpdateObservable.flatMapMaybe(
               ledgerUpdate -> {
-                final var e = ledgerUpdate.getStateComputerOutput().getInstance(EpochChange.class);
-                return e == null ? Maybe.empty() : Maybe.just(Pair.of(node, e));
+                final var e = ledgerUpdate.maybeEpochChange();
+                return e.isEmpty() ? Maybe.empty() : Maybe.just(Pair.of(node, e.orElseThrow()));
               });
       epochChangeObservables.onNext(epochChangeObservable);
     }

--- a/core/src/test-core/java/com/radixdlt/harness/simulation/network/SimulationNodes.java
+++ b/core/src/test-core/java/com/radixdlt/harness/simulation/network/SimulationNodes.java
@@ -274,7 +274,7 @@ public class SimulationNodes {
       final var epochChangeObservable =
           ledgerUpdateObservable.flatMapMaybe(
               ledgerUpdate -> {
-                final var e = ledgerUpdate.maybeEpochChange();
+                final var e = ledgerUpdate.epochChange();
                 return e.isEmpty() ? Maybe.empty() : Maybe.just(Pair.of(node, e.orElseThrow()));
               });
       epochChangeObservables.onNext(epochChangeObservable);

--- a/core/src/test-core/java/com/radixdlt/modules/MockedSyncServiceModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/MockedSyncServiceModule.java
@@ -130,19 +130,19 @@ public class MockedSyncServiceModule extends AbstractModule {
     return new EventProcessorOnDispatch<>(
         LedgerUpdate.class,
         update -> {
-          final LedgerProof headerAndProof = update.getTail();
+          final LedgerProof headerAndProof = update.proof();
           long stateVersion = headerAndProof.getStateVersion();
-          long firstVersion = stateVersion - update.getNewTransactions().size() + 1;
-          for (int i = 0; i < update.getNewTransactions().size(); i++) {
-            sharedCommittedTransactions.put(firstVersion + i, update.getNewTransactions().get(i));
+          long firstVersion = stateVersion - update.transactions().size() + 1;
+          for (int i = 0; i < update.transactions().size(); i++) {
+            sharedCommittedTransactions.put(firstVersion + i, update.transactions().get(i));
           }
 
           update
-              .getTail()
+              .proof()
               .getNextEpoch()
               .ifPresent(
                   nextEpoch -> {
-                    sharedEpochProofs.put(nextEpoch.getEpoch(), update.getTail());
+                    sharedEpochProofs.put(nextEpoch.getEpoch(), update.proof());
                   });
         });
   }

--- a/core/src/test-core/java/com/radixdlt/statecomputer/StatelessComputer.java
+++ b/core/src/test-core/java/com/radixdlt/statecomputer/StatelessComputer.java
@@ -64,7 +64,7 @@
 
 package com.radixdlt.statecomputer;
 
-import com.google.common.collect.ImmutableClassToInstanceMap;
+import com.google.common.collect.ImmutableList;
 import com.radixdlt.consensus.*;
 import com.radixdlt.consensus.bft.BFTValidatorSet;
 import com.radixdlt.consensus.bft.Round;
@@ -77,7 +77,9 @@ import com.radixdlt.environment.EventDispatcher;
 import com.radixdlt.ledger.*;
 import com.radixdlt.mempool.MempoolAdd;
 import com.radixdlt.p2p.NodeId;
+import com.radixdlt.statecomputer.commit.CommitSummary;
 import com.radixdlt.transactions.RawNotarizedTransaction;
+import com.radixdlt.utils.UInt32;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -147,7 +149,7 @@ public final class StatelessComputer implements StateComputerLedger.StateCompute
   }
 
   private LedgerUpdate generateLedgerUpdate(LedgerExtension ledgerExtension) {
-    var output =
+    final var maybeEpochChange =
         ledgerExtension
             .getProof()
             .getNextEpoch()
@@ -174,11 +176,12 @@ public final class StatelessComputer implements StateComputerLedger.StateCompute
                   var bftConfiguration =
                       new BFTConfiguration(proposerElection, validatorSet, initialState);
                   return new EpochChange(proof, bftConfiguration);
-                })
-            .map(e -> ImmutableClassToInstanceMap.<Object, EpochChange>of(EpochChange.class, e))
-            .orElse(ImmutableClassToInstanceMap.of());
+                });
 
-    return new LedgerUpdate(ledgerExtension, output);
+    return new LedgerUpdate(
+        new CommitSummary(ImmutableList.of(), UInt32.fromNonNegativeInt(0)),
+        ledgerExtension,
+        maybeEpochChange);
   }
 
   @Override

--- a/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/epoch/EpochManagerTest.java
@@ -69,7 +69,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
-import com.google.common.collect.ImmutableClassToInstanceMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.*;
@@ -108,11 +108,13 @@ import com.radixdlt.networks.Network;
 import com.radixdlt.p2p.NodeId;
 import com.radixdlt.rev2.LastEpochProof;
 import com.radixdlt.rev2.LastProof;
+import com.radixdlt.statecomputer.commit.CommitSummary;
 import com.radixdlt.sync.messages.local.LocalSyncRequest;
 import com.radixdlt.sync.messages.remote.LedgerStatusUpdate;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.TimeSupplier;
 import com.radixdlt.utils.UInt192;
+import com.radixdlt.utils.UInt32;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -340,7 +342,9 @@ public class EpochManagerTest {
     when(ledgerUpdateExtension.getProof()).thenReturn(mock(LedgerProof.class));
     var ledgerUpdate =
         new LedgerUpdate(
-            ledgerUpdateExtension, ImmutableClassToInstanceMap.of(EpochChange.class, epochChange));
+            new CommitSummary(ImmutableList.of(), UInt32.fromNonNegativeInt(0)),
+            ledgerUpdateExtension,
+            Optional.of(epochChange));
 
     // Act
     epochManager.epochsLedgerUpdateEventProcessor().process(ledgerUpdate);

--- a/core/src/test/java/com/radixdlt/sync/LocalSyncServiceTest.java
+++ b/core/src/test/java/com/radixdlt/sync/LocalSyncServiceTest.java
@@ -69,7 +69,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.radixdlt.consensus.LedgerProof;
@@ -84,11 +83,13 @@ import com.radixdlt.p2p.PeerControl;
 import com.radixdlt.p2p.PeersView;
 import com.radixdlt.p2p.PeersView.PeerInfo;
 import com.radixdlt.p2p.capability.LedgerSyncCapability;
+import com.radixdlt.statecomputer.commit.CommitSummary;
 import com.radixdlt.sync.messages.local.SyncCheckReceiveStatusTimeout;
 import com.radixdlt.sync.messages.local.SyncCheckTrigger;
 import com.radixdlt.sync.messages.local.SyncLedgerUpdateTimeout;
 import com.radixdlt.sync.messages.local.SyncRequestTimeout;
 import com.radixdlt.sync.messages.remote.*;
+import com.radixdlt.utils.UInt32;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
@@ -686,8 +687,9 @@ public class LocalSyncServiceTest {
 
   private LedgerUpdate ledgerUpdateAtStateVersion(long stateVersion) {
     return new LedgerUpdate(
+        new CommitSummary(ImmutableList.of(), UInt32.fromNonNegativeInt(0)),
         LedgerExtension.create(ImmutableList.of(), createHeaderAtStateVersion(stateVersion)),
-        ImmutableClassToInstanceMap.of());
+        Optional.empty());
   }
 
   private LedgerProof createHeaderAtStateVersion(long version) {

--- a/core/src/test/java/com/radixdlt/sync/RemoteSyncServiceTest.java
+++ b/core/src/test/java/com/radixdlt/sync/RemoteSyncServiceTest.java
@@ -192,10 +192,12 @@ public class RemoteSyncServiceTest {
     final var tail = mock(LedgerProof.class);
     final var ledgerUpdate = mock(LedgerUpdate.class);
     when(tail.getStateVersion()).thenReturn(2L);
-    when(ledgerUpdate.getTail()).thenReturn(tail);
+    when(ledgerUpdate.proof()).thenReturn(tail);
 
     final var validatorSet = mock(BFTValidatorSet.class);
-    when(ledgerUpdate.getNextValidatorSet()).thenReturn(Optional.of(validatorSet));
+    final var proof = mock(LedgerProof.class);
+    when(proof.getNextValidatorSet()).thenReturn(Optional.of(validatorSet));
+    when(ledgerUpdate.proof()).thenReturn(proof);
 
     when(this.localSyncService.getSyncState())
         .thenReturn(


### PR DESCRIPTION
- state manager commit() now returns a CommitSummary
- replaced `private final ClassToInstanceMap<Object> output;` in LedgerUpdate with typed fields (i.e. just an EpochChange)