### PR TITLE
Returning the USD/XRD multiplier in the network configuration response

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -5626,6 +5626,7 @@ components:
         - network
         - network_id
         - network_hrp_suffix
+        - usd_price_in_xrd
         - address_types
         - well_known_addresses
       properties:
@@ -5647,6 +5648,11 @@ components:
         network_hrp_suffix:
           type: string
           description: The network suffix used for Bech32m HRPs used for addressing.
+        usd_price_in_xrd:
+          type: string
+          description: |
+            The current value of the protocol-based USD/XRD multiplier (i.e. an amount of XRDs to be paid for 1 USD).
+            A decimal is formed of some signed integer `m` of attos (`10^(-18)`) units, where `-2^(192 - 1) <= m < 2^(192 - 1)`.
         address_types:
           type: array
           items:

--- a/core-rust/core-api-server/src/core_api/generated/models/network_configuration_response.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/network_configuration_response.rs
@@ -24,6 +24,9 @@ pub struct NetworkConfigurationResponse {
     /// The network suffix used for Bech32m HRPs used for addressing.
     #[serde(rename = "network_hrp_suffix")]
     pub network_hrp_suffix: String,
+    /// The current value of the protocol-based USD/XRD multiplier (i.e. an amount of XRDs to be paid for 1 USD). A decimal is formed of some signed integer `m` of attos (`10^(-18)`) units, where `-2^(192 - 1) <= m < 2^(192 - 1)`. 
+    #[serde(rename = "usd_price_in_xrd")]
+    pub usd_price_in_xrd: String,
     #[serde(rename = "address_types")]
     pub address_types: Vec<crate::core_api::generated::models::AddressType>,
     #[serde(rename = "well_known_addresses")]
@@ -31,12 +34,13 @@ pub struct NetworkConfigurationResponse {
 }
 
 impl NetworkConfigurationResponse {
-    pub fn new(version: crate::core_api::generated::models::NetworkConfigurationResponseVersion, network: String, network_id: i32, network_hrp_suffix: String, address_types: Vec<crate::core_api::generated::models::AddressType>, well_known_addresses: crate::core_api::generated::models::NetworkConfigurationResponseWellKnownAddresses) -> NetworkConfigurationResponse {
+    pub fn new(version: crate::core_api::generated::models::NetworkConfigurationResponseVersion, network: String, network_id: i32, network_hrp_suffix: String, usd_price_in_xrd: String, address_types: Vec<crate::core_api::generated::models::AddressType>, well_known_addresses: crate::core_api::generated::models::NetworkConfigurationResponseWellKnownAddresses) -> NetworkConfigurationResponse {
         NetworkConfigurationResponse {
             version: Box::new(version),
             network,
             network_id,
             network_hrp_suffix,
+            usd_price_in_xrd,
             address_types,
             well_known_addresses: Box::new(well_known_addresses),
         }

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
@@ -25,6 +25,7 @@ pub(crate) async fn handle_status_network_configuration(
         network: network.logical_name,
         network_id: to_api_u8_as_i32(network.id),
         network_hrp_suffix: network.hrp_suffix,
+        usd_price_in_xrd: to_api_decimal(&Decimal::try_from(USD_PRICE_IN_XRD).unwrap()),
         address_types,
         well_known_addresses: Box::new(models::NetworkConfigurationResponseWellKnownAddresses {
             xrd: bech32_encoder.encode(XRD.as_ref()).unwrap(),

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/NetworkConfigurationResponse.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/NetworkConfigurationResponse.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   NetworkConfigurationResponse.JSON_PROPERTY_NETWORK,
   NetworkConfigurationResponse.JSON_PROPERTY_NETWORK_ID,
   NetworkConfigurationResponse.JSON_PROPERTY_NETWORK_HRP_SUFFIX,
+  NetworkConfigurationResponse.JSON_PROPERTY_USD_PRICE_IN_XRD,
   NetworkConfigurationResponse.JSON_PROPERTY_ADDRESS_TYPES,
   NetworkConfigurationResponse.JSON_PROPERTY_WELL_KNOWN_ADDRESSES
 })
@@ -56,6 +57,9 @@ public class NetworkConfigurationResponse {
 
   public static final String JSON_PROPERTY_NETWORK_HRP_SUFFIX = "network_hrp_suffix";
   private String networkHrpSuffix;
+
+  public static final String JSON_PROPERTY_USD_PRICE_IN_XRD = "usd_price_in_xrd";
+  private String usdPriceInXrd;
 
   public static final String JSON_PROPERTY_ADDRESS_TYPES = "address_types";
   private List<AddressType> addressTypes = new ArrayList<>();
@@ -172,6 +176,32 @@ public class NetworkConfigurationResponse {
   }
 
 
+  public NetworkConfigurationResponse usdPriceInXrd(String usdPriceInXrd) {
+    this.usdPriceInXrd = usdPriceInXrd;
+    return this;
+  }
+
+   /**
+   * The current value of the protocol-based USD/XRD multiplier (i.e. an amount of XRDs to be paid for 1 USD). A decimal is formed of some signed integer &#x60;m&#x60; of attos (&#x60;10^(-18)&#x60;) units, where &#x60;-2^(192 - 1) &lt;&#x3D; m &lt; 2^(192 - 1)&#x60;. 
+   * @return usdPriceInXrd
+  **/
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "The current value of the protocol-based USD/XRD multiplier (i.e. an amount of XRDs to be paid for 1 USD). A decimal is formed of some signed integer `m` of attos (`10^(-18)`) units, where `-2^(192 - 1) <= m < 2^(192 - 1)`. ")
+  @JsonProperty(JSON_PROPERTY_USD_PRICE_IN_XRD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
+  public String getUsdPriceInXrd() {
+    return usdPriceInXrd;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_USD_PRICE_IN_XRD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  public void setUsdPriceInXrd(String usdPriceInXrd) {
+    this.usdPriceInXrd = usdPriceInXrd;
+  }
+
+
   public NetworkConfigurationResponse addressTypes(List<AddressType> addressTypes) {
     this.addressTypes = addressTypes;
     return this;
@@ -245,13 +275,14 @@ public class NetworkConfigurationResponse {
         Objects.equals(this.network, networkConfigurationResponse.network) &&
         Objects.equals(this.networkId, networkConfigurationResponse.networkId) &&
         Objects.equals(this.networkHrpSuffix, networkConfigurationResponse.networkHrpSuffix) &&
+        Objects.equals(this.usdPriceInXrd, networkConfigurationResponse.usdPriceInXrd) &&
         Objects.equals(this.addressTypes, networkConfigurationResponse.addressTypes) &&
         Objects.equals(this.wellKnownAddresses, networkConfigurationResponse.wellKnownAddresses);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, network, networkId, networkHrpSuffix, addressTypes, wellKnownAddresses);
+    return Objects.hash(version, network, networkId, networkHrpSuffix, usdPriceInXrd, addressTypes, wellKnownAddresses);
   }
 
   @Override
@@ -262,6 +293,7 @@ public class NetworkConfigurationResponse {
     sb.append("    network: ").append(toIndentedString(network)).append("\n");
     sb.append("    networkId: ").append(toIndentedString(networkId)).append("\n");
     sb.append("    networkHrpSuffix: ").append(toIndentedString(networkHrpSuffix)).append("\n");
+    sb.append("    usdPriceInXrd: ").append(toIndentedString(usdPriceInXrd)).append("\n");
     sb.append("    addressTypes: ").append(toIndentedString(addressTypes)).append("\n");
     sb.append("    wellKnownAddresses: ").append(toIndentedString(wellKnownAddresses)).append("\n");
     sb.append("}");


### PR DESCRIPTION
Simply addresses https://whimsical.com/babylon-work-tracker-Am2s7hSa7xHd5yCxgub67a@2bsEvpTYSt1HjJdfjS7WGGnHc4nWfrQsv2V