### PR TITLE
Add enable_unbounded_endpoints core-api flag

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/api/CoreApiServerModule.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/api/CoreApiServerModule.java
@@ -69,6 +69,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.radixdlt.environment.CoreApiServerConfig;
+import com.radixdlt.environment.CoreApiServerFlags;
 import com.radixdlt.environment.NodeAutoCloseable;
 import com.radixdlt.environment.NodeRustEnvironment;
 import com.radixdlt.utils.UInt32;
@@ -77,8 +78,9 @@ public final class CoreApiServerModule extends AbstractModule {
 
   private final CoreApiServerConfig config;
 
-  public CoreApiServerModule(String apiBindAddress, int apiPort) {
-    this.config = new CoreApiServerConfig(apiBindAddress, UInt32.fromNonNegativeInt(apiPort));
+  public CoreApiServerModule(String apiBindAddress, int apiPort, CoreApiServerFlags flags) {
+    this.config =
+        new CoreApiServerConfig(apiBindAddress, UInt32.fromNonNegativeInt(apiPort), flags);
   }
 
   @Provides

--- a/core-rust-bridge/src/main/java/com/radixdlt/environment/CoreApiServerConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/environment/CoreApiServerConfig.java
@@ -68,7 +68,7 @@ import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.utils.UInt32;
 
-public record CoreApiServerConfig(String bindInterface, UInt32 port) {
+public record CoreApiServerConfig(String bindInterface, UInt32 port, CoreApiServerFlags flags) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         CoreApiServerConfig.class,

--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
@@ -172,6 +172,7 @@ public final class NodeSborCodecs {
     DatabaseFlags.registerCodec(codecMap);
     TransactionHeader.registerCodec(codecMap);
     CoreApiServerConfig.registerCodec(codecMap);
+    CoreApiServerFlags.registerCodec(codecMap);
     ValidatorInfo.registerCodec(codecMap);
     GenesisData.registerCodec(codecMap);
     GenesisConsensusManagerConfig.registerCodec(codecMap);

--- a/core-rust/core-api-server/src/core_api/errors.rs
+++ b/core-rust/core-api-server/src/core_api/errors.rs
@@ -133,7 +133,7 @@ pub(crate) fn assert_unbounded_endpoints_flag_enabled<E: ErrorDetails>(
 ) -> Result<(), ResponseError<E>> {
     if !state.flags.enable_unbounded_endpoints {
         return Err(client_error(
-            "This endpoint is unbounded and `enable_unbounded_endpoints` flag is disabled.",
+            "This endpoint is disabled as the response is potentially unbounded, and this node is configured with `enable_unbounded_endpoints` false.",
         ));
     }
     Ok(())

--- a/core-rust/core-api-server/src/core_api/errors.rs
+++ b/core-rust/core-api-server/src/core_api/errors.rs
@@ -9,7 +9,7 @@ use hyper::StatusCode;
 use radix_engine_interface::network::NetworkDefinition;
 use tower_http::catch_panic::ResponseForPanic;
 
-use super::models;
+use super::{models, CoreApiState};
 use models::{
     lts_transaction_submit_error_details::LtsTransactionSubmitErrorDetails,
     transaction_submit_error_details::TransactionSubmitErrorDetails,
@@ -124,6 +124,17 @@ pub(crate) fn assert_matching_network<E: ErrorDetails>(
             "Invalid network - the network is actually: {}",
             network_definition.logical_name
         )));
+    }
+    Ok(())
+}
+
+pub(crate) fn assert_unbounded_endpoints_flag_enabled<E: ErrorDetails>(
+    state: &CoreApiState,
+) -> Result<(), ResponseError<E>> {
+    if !state.flags.enable_unbounded_endpoints {
+        return Err(client_error(
+            "This endpoint is unbounded and `enable_unbounded_endpoints` flag is disabled.",
+        ));
     }
     Ok(())
 }

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
@@ -11,6 +11,7 @@ pub(crate) async fn handle_lts_state_account_all_fungible_resource_balances(
     Json(request): Json<models::LtsStateAccountAllFungibleResourceBalancesRequest>,
 ) -> Result<Json<models::LtsStateAccountAllFungibleResourceBalancesResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
+    assert_unbounded_endpoints_flag_enabled(&state)?;
 
     if !request.account_address.starts_with("account_") {
         return Err(client_error(

--- a/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/mempool_list.rs
@@ -6,6 +6,7 @@ pub(crate) async fn handle_mempool_list(
     Json(request): Json<models::MempoolListRequest>,
 ) -> Result<Json<models::MempoolListResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
+    assert_unbounded_endpoints_flag_enabled(&state)?;
     let mapping_context = MappingContext::new(&state.network);
 
     let mempool = state.state_manager.mempool.read();

--- a/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
@@ -14,6 +14,7 @@ pub(crate) async fn handle_state_access_controller(
     Json(request): Json<models::StateAccessControllerRequest>,
 ) -> Result<Json<models::StateAccessControllerResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
+    assert_unbounded_endpoints_flag_enabled(&state)?;
 
     let mapping_context = MappingContext::new(&state.network);
     let extraction_context = ExtractionContext::new(&state.network);

--- a/core-rust/core-api-server/src/core_api/handlers/state_account.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_account.rs
@@ -11,6 +11,7 @@ pub(crate) async fn handle_state_account(
     Json(request): Json<models::StateAccountRequest>,
 ) -> Result<Json<models::StateAccountResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
+    assert_unbounded_endpoints_flag_enabled(&state)?;
 
     let mapping_context = MappingContext::new(&state.network);
     let extraction_context = ExtractionContext::new(&state.network);

--- a/core-rust/core-api-server/src/core_api/handlers/state_component.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_component.rs
@@ -13,6 +13,7 @@ pub(crate) async fn handle_state_component(
     Json(request): Json<models::StateComponentRequest>,
 ) -> Result<Json<models::StateComponentResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
+    assert_unbounded_endpoints_flag_enabled(&state)?;
 
     let mapping_context = MappingContext::new(&state.network);
     let extraction_context = ExtractionContext::new(&state.network);

--- a/core-rust/core-api-server/src/core_api/server.rs
+++ b/core-rust/core-api-server/src/core_api/server.rs
@@ -78,8 +78,8 @@ use axum::{
 };
 
 use prometheus::Registry;
-use radix_engine::types::{Categorize, Decode, Encode};
 use radix_engine_common::network::NetworkDefinition;
+use radix_engine_common::ScryptoSbor;
 use state_manager::StateManager;
 use tower_http::catch_panic::CatchPanicLayer;
 use tracing::{debug, error, info, trace, warn, Level};
@@ -93,6 +93,7 @@ use handle_status_network_configuration as handle_provide_info_at_root_path;
 #[derive(Clone)]
 pub struct CoreApiState {
     pub network: NetworkDefinition,
+    pub flags: CoreApiServerFlags,
     pub state_manager: StateManager,
 }
 
@@ -246,8 +247,14 @@ fn resolve_level(status_code: StatusCode) -> Level {
     }
 }
 
-#[derive(Debug, Categorize, Encode, Decode, Clone)]
+#[derive(Debug, Clone, ScryptoSbor)]
+pub struct CoreApiServerFlags {
+    pub enable_unbounded_endpoints: bool,
+}
+
+#[derive(Debug, Clone, ScryptoSbor)]
 pub struct CoreApiServerConfig {
     pub bind_interface: String,
     pub port: u32,
+    pub flags: CoreApiServerFlags,
 }

--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -75,6 +75,7 @@ import com.radixdlt.consensus.ProposalLimitsConfig;
 import com.radixdlt.consensus.bft.*;
 import com.radixdlt.consensus.epoch.EpochsConsensusModule;
 import com.radixdlt.consensus.sync.BFTSyncPatienceMillis;
+import com.radixdlt.environment.CoreApiServerFlags;
 import com.radixdlt.environment.DatabaseFlags;
 import com.radixdlt.environment.NodeConstants;
 import com.radixdlt.environment.VertexLimitsConfig;
@@ -355,7 +356,13 @@ public final class RadixNodeModule extends AbstractModule {
     final var coreApiBindAddress =
         properties.get("api.core.bind_address", DEFAULT_CORE_API_BIND_ADDRESS);
     final var coreApiPort = properties.get("api.core.port", DEFAULT_CORE_API_PORT);
-    install(new CoreApiServerModule(coreApiBindAddress, coreApiPort));
+    final var coreApiFlagsEnableUnboundedEndpoints =
+        properties.get("api.core.flags.enable_unbounded_endpoints", true);
+    install(
+        new CoreApiServerModule(
+            coreApiBindAddress,
+            coreApiPort,
+            new CoreApiServerFlags(coreApiFlagsEnableUnboundedEndpoints)));
 
     final var systemApiBindAddress =
         properties.get("api.system.bind_address", DEFAULT_SYSTEM_API_BIND_ADDRESS);

--- a/core/src/test/java/com/radixdlt/api/DeterministicCoreApiTestBase.java
+++ b/core/src/test/java/com/radixdlt/api/DeterministicCoreApiTestBase.java
@@ -81,6 +81,7 @@ import com.radixdlt.api.core.generated.models.LtsTransactionStatusRequest;
 import com.radixdlt.api.core.generated.models.LtsTransactionStatusResponse;
 import com.radixdlt.api.core.generated.models.LtsTransactionSubmitRequest;
 import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.environment.CoreApiServerFlags;
 import com.radixdlt.environment.DatabaseFlags;
 import com.radixdlt.environment.StartProcessorOnRunner;
 import com.radixdlt.genesis.GenesisBuilder;
@@ -149,7 +150,8 @@ public abstract class DeterministicCoreApiTestBase {
         DeterministicTest.builder()
             .addPhysicalNodes(PhysicalNodeConfig.createBatch(1, true))
             .messageSelector(firstSelector())
-            .addModule(new CoreApiServerModule("127.0.0.1", coreApiPort))
+            .addModule(
+                new CoreApiServerModule("127.0.0.1", coreApiPort, new CoreApiServerFlags(true)))
             .addModule(
                 new AbstractModule() {
                   @ProvidesIntoSet

--- a/docker/config/default.config.envsubst
+++ b/docker/config/default.config.envsubst
@@ -26,9 +26,11 @@ mempool.reevaluation.max_count=${RADIXDLT_MEMPOOL_REEVALUATION_MAX_COUNT}
 protocol.vertex.max_transaction_count=${RADIXDLT_PROTOCOL_VERTEX_MAX_TRANSACTION_COUNT}
 protocol.vertex.max_total_transactions_size=${RADIXDLT_PROTOCOL_VERTEX_MAX_TOTAL_TRANSACTIONS_SIZE}
 protocol.vertex.max_total_execution_cost_units_consumed=${RADIXDLT_PROTOCOL_VERTEX_MAX_TOTAL_EXECUTION_COST_UNITS_CONSUMED}
+protocol.vertex.max_total_finalization_cost_units_consumed=${RADIXDLT_PROTOCOL_VERTEX_MAX_TOTAL_FINALIZATION_COST_UNITS_CONSUMED}
 
 api.core.port=$RADIXDLT_CORE_API_PORT
 api.core.bind_address=$RADIXDLT_CORE_API_BIND_ADDRESS
+api.core.flags.enable_unbounded_endpoints=${RADIXDLT_CORE_API_FLAGS_ENABLE_UNBOUNDED_ENDPOINTS}
 
 api.system.port=$RADIXDLT_SYSTEM_API_PORT
 api.system.bind_address=$RADIXDLT_SYSTEM_API_BIND_ADDRESS


### PR DESCRIPTION
Add `api.core.flags.enable_unbounded_endpoints` config entry (default is `true`, docker env var `RADIXDLT_CORE_API_FLAGS_ENABLE_UNBOUNDED_ENDPOINTS`) which disables all unbounded endpoints (mostly ones that use `dump_component_state` + `/mempool/list`).