### PR TITLE
Refactor: precomputing resultant fungible account balances together with global balance changes

### DIFF
--- a/core-rust/core-api-server/src/core_api/conversions/lts.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/lts.rs
@@ -1,20 +1,13 @@
-use node_common::utils::IsAccountExt;
 use radix_engine::{
-    system::{
-        system_db_reader::SystemDatabaseReader, system_modules::costing::RoyaltyRecipient,
-        system_substates::FieldSubstate,
-    },
+    system::system_modules::costing::RoyaltyRecipient,
     transaction::BalanceChange,
-    types::{Decimal, GlobalAddress, IndexMap, ResourceAddress, FUNGIBLE_VAULT_BLUEPRINT},
+    types::{Decimal, GlobalAddress, IndexMap, ResourceAddress},
 };
-use radix_engine_queries::typed_substate_layout::{
-    FungibleVaultBalanceFieldPayload, FungibleVaultField, TypeInfoSubstate,
-};
-use sbor::HasLatestVersion;
+
 use state_manager::store::{traits::SubstateNodeAncestryStore, StateManagerDatabase};
 use state_manager::{
-    BySubstate, ChangeAction, CommittedTransactionIdentifiers, LedgerTransactionOutcome,
-    LocalTransactionReceipt, StateVersion, TransactionTreeHash,
+    CommittedTransactionIdentifiers, LedgerTransactionOutcome, LocalTransactionReceipt,
+    StateVersion, TransactionTreeHash,
 };
 
 use radix_engine::transaction::{FeeDestination, FeeSource, TransactionFeeSummary};
@@ -71,13 +64,16 @@ pub fn to_api_lts_committed_transaction_outcome(
             &local_execution.fee_summary,
             &local_execution.fee_source,
             &local_execution.fee_destination,
-            &local_execution.global_balance_changes,
+            &local_execution
+                .global_balance_summary
+                .global_balance_changes,
         )?,
         resultant_account_fungible_balances: to_api_lts_resultant_account_fungible_balances(
-            database,
             context,
-            &receipt.on_ledger.substate_changes,
-        ),
+            &local_execution
+                .global_balance_summary
+                .resultant_fungible_account_balances,
+        )?,
         total_fee: to_api_decimal(&local_execution.fee_summary.total_cost()),
     })
 }
@@ -372,117 +368,24 @@ pub fn to_api_lts_fungible_resource_balance_change(
 }
 
 pub fn to_api_lts_resultant_account_fungible_balances(
-    database: &StateManagerDatabase,
     context: &MappingContext,
-    substate_changes: &BySubstate<ChangeAction>,
-) -> Vec<models::LtsResultantAccountFungibleBalances> {
-    // TODO(after upstream fix): this can be much easily computed in [`ProcessedCommitResult::compute_global_balance_changes_update`] and
-    // just extracted here, after we have RE return resultant balance along with the change delta value.
-    let fungible_vaults = substate_changes
-        .iter_node_ids()
-        .filter(|node_id| node_id.is_internal_fungible_vault())
-        .collect::<Vec<_>>();
-    let ancestries = database
-        .batch_get_ancestry(fungible_vaults.clone())
-        .into_iter()
-        .map(|record| record.expect("InternalFungibleVault does not have a parent"));
-    let node_id_to_ancestor: NonIterMap<_, _> =
-        fungible_vaults.into_iter().zip(ancestries).collect();
-    let system_db_reader = SystemDatabaseReader::new(database);
-    let mut resultant_fungible_balances_by_account = HashMap::new();
-    substate_changes
+    fungible_account_balances: &IndexMap<GlobalAddress, IndexMap<ResourceAddress, Decimal>>,
+) -> Result<Vec<models::LtsResultantAccountFungibleBalances>, MappingError> {
+    fungible_account_balances
         .iter()
-        .filter(|(substate_reference, _)| substate_reference.0.is_internal_fungible_vault())
-        .filter(|(substate_reference, _)| substate_reference.1 == FungibleVaultPartitionOffset::Field.as_main_partition())
-        .filter(|(substate_reference, _)| {
-            substate_reference.2 == FungibleVaultField::Balance.into()
-        })
-        .filter_map(|(substate_reference, change_action)| {
-            let vault_id = &substate_reference.0;
-
-            let ancestor_record = node_id_to_ancestor
-                .get(vault_id)
-                .expect("Invariant broken: vaults should always have an ancestor");
-            let account_address = ancestor_record.parent.0;
-
-            let Ok(account_address) = GlobalAddress::try_from(account_address) else {
-                return None;
-            };
-
-            if !account_address.is_account() {
-                return None;
-            }
-
-            // We check the parent of the vault is indeed owned by Account's ResourceVaultKeyValue - meaning strictly an account vault,
-            // and not an unrelated one (i.e. recently removed RoyaltyVault).
-            if ancestor_record.parent.1 != AccountPartitionOffset::ResourceVaultKeyValue.as_main_partition() {
-                return None;
-            }
-
-            if ancestor_record.parent != ancestor_record.root {
-                panic!("Invariant broken: Account vault expected to be directly owned by the account partition");
-            }
-
-            Some((account_address, substate_reference, change_action))
-        })
-        .map(|(account_address, substate_reference, change_action)| {
-            let vault_id = &substate_reference.0;
-
-            let vault_type_info = system_db_reader
-                .get_type_info(vault_id)
-                .expect("Vault missing TypeInfo substate");
-
-            let TypeInfoSubstate::Object(vault_type_info) = vault_type_info else {
-                panic!("TypeInfoSubstate of FungibleVault is not of type Object.");
-            };
-
-            assert!(
-                vault_type_info
-                    .blueprint_info
-                    .blueprint_id
-                    .eq(&BlueprintId::new(
-                        &RESOURCE_PACKAGE,
-                        FUNGIBLE_VAULT_BLUEPRINT,
-                    )),
-                "Vault's TypeInfo wrongly says this is not a fungible vault."
-            );
-
-            let resource_address =
-                ResourceAddress::new_or_panic(vault_type_info.get_outer_object().into());
-            (account_address, resource_address, change_action)
-        })
-        .map(|(account_address, resource_address, change_action)| {
-            let fungible_vault_balance_substate: FieldSubstate<FungibleVaultBalanceFieldPayload> =
-                match change_action {
-                    ChangeAction::Create { new } => scrypto_decode(new).unwrap(),
-                    ChangeAction::Update { new, .. } => scrypto_decode(new).unwrap(),
-                    ChangeAction::Delete { .. } => {
-                        panic!("Invariant broken: vault substate is never deleted.")
-                    }
-                };
-
-            let resultant_balance = fungible_vault_balance_substate
-                .into_payload()
-                .into_latest()
-                .amount();
-
-            (account_address, resource_address, resultant_balance)
-        })
-        .for_each(|(account_address, resource_address, resultant_balance)| {
-            resultant_fungible_balances_by_account
-                .entry(account_address)
-                .or_insert(Vec::new())
-                .push(models::LtsResultantFungibleBalance {
-                    resource_address: to_api_resource_address(context, &resource_address).unwrap(),
-                    resultant_balance: to_api_decimal(&resultant_balance),
-                })
-        });
-    resultant_fungible_balances_by_account
-        .into_iter()
-        .map(|entry| models::LtsResultantAccountFungibleBalances {
-            account_address: to_api_global_address(context, &entry.0)
-                .expect("Invariant broken: account_address is not a global address"),
-            resultant_balances: entry.1,
+        .map(|(account_address, resource_balances)| {
+            Ok(models::LtsResultantAccountFungibleBalances {
+                account_address: to_api_global_address(context, account_address)?,
+                resultant_balances: resource_balances
+                    .iter()
+                    .map(|(resource_address, resultant_balance)| {
+                        Ok(models::LtsResultantFungibleBalance {
+                            resource_address: to_api_resource_address(context, resource_address)?,
+                            resultant_balance: to_api_decimal(resultant_balance),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            })
         })
         .collect()
 }

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
@@ -163,7 +163,7 @@ fn to_api_response(
             let local_receipt = LocalTransactionReceipt::new(
                 commit_result,
                 result.substate_changes,
-                result.global_balance_changes,
+                result.global_balance_summary,
                 execution_fee_data,
             );
 

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -4,9 +4,8 @@ use radix_engine_queries::typed_substate_layout::EpochChangeEvent;
 use radix_engine::errors::RuntimeError;
 
 use radix_engine::transaction::{
-    BalanceChange, CommitResult, CostingParameters, EventSystemStructure, FeeDestination,
-    FeeSource, StateUpdateSummary, SubstateSystemStructure, TransactionFeeSummary,
-    TransactionOutcome,
+    CommitResult, CostingParameters, EventSystemStructure, FeeDestination, FeeSource,
+    StateUpdateSummary, SubstateSystemStructure, TransactionFeeSummary, TransactionOutcome,
 };
 use radix_engine::types::*;
 
@@ -19,8 +18,8 @@ use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, Writeab
 use crate::accumulator_tree::tree_builder::{AccuTree, Merklizable};
 use crate::transaction::PayloadIdentifiers;
 use crate::{
-    ConsensusReceipt, EventHash, ExecutionFeeData, LedgerHashes, SubstateChangeHash,
-    SubstateReference,
+    ConsensusReceipt, EventHash, ExecutionFeeData, GlobalBalanceSummary, LedgerHashes,
+    SubstateChangeHash, SubstateReference,
 };
 
 #[derive(Debug, Clone, Sbor)]
@@ -78,12 +77,6 @@ impl ApplicationEvent {
     pub fn get_hash(&self) -> EventHash {
         EventHash::from(hash(scrypto_encode(self).unwrap()))
     }
-}
-
-#[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-pub struct DeletedSubstateVersion {
-    pub substate_hash: Hash,
-    pub version: u32,
 }
 
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -169,7 +162,7 @@ pub struct LocalTransactionExecution {
     pub transaction_costing_parameters: TransactionCostingParameters,
     pub application_logs: Vec<(Level, String)>,
     pub state_update_summary: StateUpdateSummary,
-    pub global_balance_changes: IndexMap<GlobalAddress, IndexMap<ResourceAddress, BalanceChange>>,
+    pub global_balance_summary: GlobalBalanceSummary,
     pub substates_system_structure: BySubstate<SubstateSystemStructure>,
     pub events_system_structure: IndexMap<EventTypeIdentifier, EventSystemStructure>,
     pub next_epoch: Option<EpochChangeEvent>,
@@ -207,7 +200,7 @@ impl LocalTransactionReceipt {
     pub fn new(
         commit_result: CommitResult,
         substate_changes: BySubstate<ChangeAction>,
-        global_balance_changes: IndexMap<GlobalAddress, IndexMap<ResourceAddress, BalanceChange>>,
+        global_balance_summary: GlobalBalanceSummary,
         execution_fee_data: ExecutionFeeData,
     ) -> Self {
         let next_epoch = commit_result.next_epoch();
@@ -231,7 +224,7 @@ impl LocalTransactionReceipt {
                 transaction_costing_parameters: execution_fee_data.transaction_costing_parameters,
                 application_logs: commit_result.application_logs,
                 state_update_summary: commit_result.state_update_summary,
-                global_balance_changes,
+                global_balance_summary,
                 substates_system_structure: BySubstate::wrap(
                     system_structure.substate_system_structures,
                 ),

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -73,6 +73,7 @@ use crate::{
     StateHash, StateVersion, TransactionTreeHash,
 };
 use radix_engine::blueprints::consensus_manager::EpochChangeEvent;
+use radix_engine::blueprints::resource::{FungibleVaultBalanceFieldSubstate, FungibleVaultField};
 use radix_engine::transaction::{
     AbortResult, BalanceChange, CommitResult, CostingParameters, RejectResult,
     TransactionFeeSummary, TransactionReceipt, TransactionResult,
@@ -86,12 +87,14 @@ use radix_engine::track::SystemUpdates;
 use crate::staging::node_ancestry_resolver::NodeAncestryResolver;
 use crate::staging::overlays::{MapSubstateNodeAncestryStore, StagedSubstateNodeAncestryStore};
 use crate::store::traits::{KeyedSubstateNodeAncestryRecord, SubstateNodeAncestryStore};
+use node_common::utils::IsAccountExt;
 use radix_engine_store_interface::db_key_mapper::DatabaseKeyMapper;
 use radix_engine_store_interface::interface::{DatabaseUpdate, DatabaseUpdates, SubstateDatabase};
 use radix_engine_stores::hash_tree::tree_store::{
     NodeKey, ReadableTreeStore, TreeNode, WriteableTreeStore,
 };
 use radix_engine_stores::hash_tree::{put_at_next_version, SubstateHashChange};
+use sbor::HasLatestVersion;
 use transaction::prelude::TransactionCostingParameters;
 
 pub enum ProcessedTransactionReceipt {
@@ -206,7 +209,7 @@ impl ProcessedCommitResult {
             &commit_result.state_updates.system_updates,
         );
 
-        let balance_changes_update = Self::compute_global_balance_changes_update(
+        let global_balance_update = Self::compute_global_balance_update(
             store,
             &substate_changes,
             &commit_result.state_update_summary.vault_balance_changes,
@@ -227,7 +230,7 @@ impl ProcessedCommitResult {
         let local_receipt = LocalTransactionReceipt::new(
             commit_result,
             substate_changes,
-            balance_changes_update.global_balance_changes,
+            global_balance_update.global_balance_summary,
             execution_fee_data,
         );
         let consensus_receipt = local_receipt.on_ledger.get_consensus_receipt();
@@ -253,7 +256,7 @@ impl ProcessedCommitResult {
                 receipt_tree_diff,
             },
             database_updates,
-            new_substate_node_ancestry_records: balance_changes_update
+            new_substate_node_ancestry_records: global_balance_update
                 .new_substate_node_ancestry_records,
         }
     }
@@ -280,11 +283,11 @@ impl ProcessedCommitResult {
 
     // TODO(after RCnet-v3): Extract the `pub fn`s below (re-used by preview) to an isolated helper.
 
-    pub fn compute_global_balance_changes_update<S: SubstateNodeAncestryStore>(
+    pub fn compute_global_balance_update<S: SubstateNodeAncestryStore>(
         store: &S,
         substate_changes: &BySubstate<ChangeAction>,
         vault_balance_changes: &IndexMap<NodeId, (ResourceAddress, BalanceChange)>,
-    ) -> GlobalBalanceChangesUpdate {
+    ) -> GlobalBalanceUpdate {
         // We need a fresh (!) view of a node ancestry store to group Vaults by their Global* roots.
         let new_substate_node_ancestry_records =
             NodeAncestryResolver::batch_resolve(store, substate_changes.iter()).collect::<Vec<_>>();
@@ -300,10 +303,10 @@ impl ProcessedCommitResult {
         let staged = StagedSubstateNodeAncestryStore::new(store, &overlay);
 
         // Call the group-by logic and return the results together with the ancestry store update.
-        let global_balance_changes =
-            Self::compute_global_balance_changes(&staged, vault_balance_changes);
-        GlobalBalanceChangesUpdate {
-            global_balance_changes,
+        let global_balance_summary =
+            GlobalBalanceSummary::compute_from(&staged, vault_balance_changes, substate_changes);
+        GlobalBalanceUpdate {
+            global_balance_summary,
             new_substate_node_ancestry_records,
         }
     }
@@ -373,29 +376,98 @@ impl ProcessedCommitResult {
         );
         collector.into_diff_with(root_hash)
     }
+}
 
-    fn compute_global_balance_changes<S: SubstateNodeAncestryStore>(
+/// A summary of vault balances per global root entity.
+#[derive(Debug, Clone, PartialEq, Eq, Default, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+pub struct GlobalBalanceSummary {
+    /// A cumulative balance change of each global root entity owning one or more vaults from the
+    /// input "vault balance changes".
+    /// These entries are not pruned, i.e. a fungible delta of `0.0`, or a non-fungible delta of
+    /// `{added: #1#, removed: #1#}` may be encountered here (and it simply means that resources
+    /// were only moved around different vaults of the same global root entity).
+    pub global_balance_changes: IndexMap<GlobalAddress, IndexMap<ResourceAddress, BalanceChange>>,
+
+    /// A resultant balances of fungible resources held by global accounts.
+    /// Note: aggregating a resultant balance of *any* global root entity is, in principle, not
+    /// possible using only the "vault balance changes" input (because there may be vaults whose
+    /// balance was not changed). We "aggregate" it for accounts using an assumption that an account
+    /// has at most one vault for each resource.
+    pub resultant_fungible_account_balances:
+        IndexMap<GlobalAddress, IndexMap<ResourceAddress, Decimal>>,
+}
+
+impl GlobalBalanceSummary {
+    /// Computes a [`GlobalBalanceSummary`] from the given vault balance changes.
+    /// This uses the ancestry information from the given [`SubstateNodeAncestryStore`] to resolve
+    /// the owning global entity, and parses the substate changes to collect the resulting balances
+    /// of fungible vaults.
+    pub fn compute_from<S: SubstateNodeAncestryStore>(
         store: &S,
         vault_balance_changes: &IndexMap<NodeId, (ResourceAddress, BalanceChange)>,
-    ) -> IndexMap<GlobalAddress, IndexMap<ResourceAddress, BalanceChange>> {
+        substate_changes: &BySubstate<ChangeAction>,
+    ) -> Self {
         let ancestries = store.batch_get_ancestry(vault_balance_changes.keys());
         let mut global_balance_changes = index_map_new();
+        let mut resultant_fungible_account_balances = index_map_new();
         for (vault_entry, ancestry) in vault_balance_changes.iter().zip(ancestries) {
             let (vault_id, (resource_address, balance_change)) = vault_entry;
             let root = ancestry
                 .map(|ancestry| ancestry.root.0)
                 .unwrap_or_else(|| *vault_id);
-            let Ok(global_ancestor_address) = GlobalAddress::try_from(root) else {
+            let Ok(root_address) = GlobalAddress::try_from(root) else {
                 panic!("root {:?} resolved for vault {:?} is not global", root, vault_id);
             };
+
+            // Aggregate (i.e. sum) balance changes for every global root entity.
             global_balance_changes
-                .entry(global_ancestor_address)
+                .entry(root_address)
                 .or_insert_with(index_map_new::<ResourceAddress, BalanceChange>)
                 .entry(*resource_address)
                 .and_modify(|existing| *existing = existing.clone() + balance_change.clone())
                 .or_insert_with(|| balance_change.clone());
+
+            // Collect (i.e. not sum) resultant balances for fungible resources of global accounts.
+            if vault_id.is_internal_fungible_vault() && root_address.is_account() {
+                let substate_change = substate_changes
+                    .get(
+                        vault_id,
+                        &FungibleVaultPartitionOffset::Field.as_main_partition(),
+                        &FungibleVaultField::Balance.into(),
+                    )
+                    .expect(
+                        "broken invariant: vault's balance changed without its substate change",
+                    );
+                let resultant_balance_substate = match substate_change {
+                    ChangeAction::Create { new } => new,
+                    ChangeAction::Update { new, .. } => new,
+                    ChangeAction::Delete { .. } => {
+                        panic!("broken invariant: vault {:?} deleted", vault_id)
+                    }
+                };
+                let resultant_balance =
+                    scrypto_decode::<FungibleVaultBalanceFieldSubstate>(resultant_balance_substate)
+                        .expect("cannot decode vault balance substate")
+                        .into_payload()
+                        .into_latest()
+                        .amount();
+                let balance_existed = resultant_fungible_account_balances
+                    .entry(root_address)
+                    .or_insert_with(index_map_new::<ResourceAddress, Decimal>)
+                    .insert(*resource_address, resultant_balance)
+                    .is_some();
+                if balance_existed {
+                    panic!(
+                        "broken invariant: multiple vaults of resource {:?} exist for account {:?}",
+                        resource_address, root_address
+                    )
+                }
+            }
         }
-        global_balance_changes
+        Self {
+            global_balance_changes,
+            resultant_fungible_account_balances,
+        }
     }
 }
 
@@ -449,8 +521,8 @@ impl Default for StateHashTreeDiff {
 }
 
 #[derive(Clone, Debug)]
-pub struct GlobalBalanceChangesUpdate {
-    pub global_balance_changes: IndexMap<GlobalAddress, IndexMap<ResourceAddress, BalanceChange>>,
+pub struct GlobalBalanceUpdate {
+    pub global_balance_summary: GlobalBalanceSummary,
     pub new_substate_node_ancestry_records: Vec<KeyedSubstateNodeAncestryRecord>,
 }
 

--- a/core-rust/state-manager/src/store/in_memory.rs
+++ b/core-rust/state-manager/src/store/in_memory.rs
@@ -525,7 +525,7 @@ impl InMemoryStore {
         state_version: StateVersion,
         receipt: &LocalTransactionExecution,
     ) {
-        for (address, _) in receipt.global_balance_changes.iter() {
+        for (address, _) in receipt.global_balance_summary.global_balance_changes.iter() {
             if !address.is_account() {
                 continue;
             }

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -1090,7 +1090,12 @@ impl RocksDBStore {
         state_version: StateVersion,
         receipt: &LocalTransactionReceipt,
     ) {
-        for (address, _) in receipt.local_execution.global_balance_changes.iter() {
+        for address in receipt
+            .local_execution
+            .global_balance_summary
+            .global_balance_changes
+            .keys()
+        {
             if !address.is_account() {
                 continue;
             }


### PR DESCRIPTION
As promised in https://github.com/radixdlt/radixdlt-scrypto/pull/1415#issuecomment-1699649478.
The goal is to simplify LTS endpoint's, as noticed in https://github.com/radixdlt/babylon-node/pull/636#discussion_r1310031671.

The PR is "more lines deleted than added", which weakly proves simplification.
The `LtsTransactionOutcomesTest.test_resultant_account_balances()` keeps passing verbatim, which weakly proves correctness.