### PR TITLE
Consensus-messaging-related performance tweaks

### DIFF
--- a/common/src/main/java/com/radixdlt/monitoring/Metrics.java
+++ b/common/src/main/java/com/radixdlt/monitoring/Metrics.java
@@ -282,15 +282,19 @@ public record Metrics(
 
     public record Outbound(
         LabelledCounter<AbortedOutboundMessage> aborted,
-        Gauge queued,
+        LabelledCounter<EnqueuedOutboundMessage> enqueued,
+        Gauge currentQueueSize,
         Counter processed,
         Counter sent) {}
 
     public record AbortedOutboundMessage(OutboundMessageAbortedReason reason) {}
 
+    public record EnqueuedOutboundMessage(String type) {}
+
     public enum OutboundMessageAbortedReason {
       MESSAGE_EXPIRED,
-      MESSAGE_TOO_LARGE
+      MESSAGE_TOO_LARGE,
+      OUTBOUND_QUEUE_OVERFLOW
     }
   }
 

--- a/common/src/main/java/com/radixdlt/utils/UInt192.java
+++ b/common/src/main/java/com/radixdlt/utils/UInt192.java
@@ -113,7 +113,6 @@ public final class UInt192 implements Comparable<UInt192> {
     return from(UInt128.from(value));
   }
 
-  @JsonCreator
   public static UInt192 from(String s) {
     Objects.requireNonNull(s);
 
@@ -165,6 +164,7 @@ public final class UInt192 implements Comparable<UInt192> {
    * @throws IllegalArgumentException if {@code bytes} is 0 length.
    * @see #toByteArray()
    */
+  @JsonCreator
   public static UInt192 from(byte[] bytes) {
     Objects.requireNonNull(bytes);
     if (bytes.length == 0) {
@@ -438,8 +438,8 @@ public final class UInt192 implements Comparable<UInt192> {
   }
 
   @JsonValue
-  public String toJson() {
-    return toString(10);
+  public byte[] toJson() {
+    return toByteArray();
   }
 
   @Override

--- a/core-rust/node-common/src/config/limits.rs
+++ b/core-rust/node-common/src/config/limits.rs
@@ -65,7 +65,7 @@
 use radix_engine_common::prelude::*;
 
 // TODO: revisit & tune before Babylon
-pub const DEFAULT_MAX_VERTEX_TRANSACTION_COUNT: u32 = 10;
+pub const DEFAULT_MAX_VERTEX_TRANSACTION_COUNT: u32 = 100;
 pub const DEFAULT_MAX_TOTAL_VERTEX_TRANSACTIONS_SIZE: usize = (3.8 * 1024.0 * 1024.0) as usize;
 pub const DEFAULT_MAX_TOTAL_VERTEX_EXECUTION_COST_UNITS_CONSUMED: u32 =
     EXECUTION_COST_UNIT_LIMIT * 2;

--- a/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolRelayerTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolRelayerTest.java
@@ -134,7 +134,7 @@ public final class REv2MempoolRelayerTest {
       // Run all nodes except validator node0
       test.runUntilState(
           n -> allHaveExactMempoolCount(MEMPOOL_TX_SIZE).test(n.subList(1, n.size())),
-          10000,
+          12000,
           m -> m.channelId().senderIndex() != 0 && m.channelId().receiverIndex() != 0);
     }
   }

--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -142,8 +142,8 @@ public final class RadixNodeModule extends AbstractModule {
     // Default values mean that pacemakers will sync if they are within 5 rounds of each other.
     // 5 consecutive failing rounds will take 1*(2^6)-1 seconds = 63 seconds.
     bindConstant().annotatedWith(PacemakerBaseTimeoutMs.class).to(3000L);
-    bindConstant().annotatedWith(PacemakerBackoffRate.class).to(1.1);
-    bindConstant().annotatedWith(PacemakerMaxExponent.class).to(0);
+    bindConstant().annotatedWith(PacemakerBackoffRate.class).to(1.2);
+    bindConstant().annotatedWith(PacemakerMaxExponent.class).to(13);
     bindConstant().annotatedWith(AdditionalRoundTimeIfProposalReceivedMs.class).to(30_000L);
     bindConstant().annotatedWith(TimeoutQuorumResolutionDelayMs.class).to(1500L);
 

--- a/core/src/main/java/com/radixdlt/consensus/ConsensusHasher.java
+++ b/core/src/main/java/com/radixdlt/consensus/ConsensusHasher.java
@@ -69,30 +69,36 @@ import com.radixdlt.crypto.Hasher;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Optional;
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public final class ConsensusHasher {
   private ConsensusHasher() {
     throw new IllegalStateException();
   }
 
   public static HashCode toHash(
-      HashCode opaque, LedgerHeader header, long nodeTimestamp, Hasher hasher) {
+      HashCode opaque,
+      Optional<LedgerHeader> committedHeaderOpt,
+      long localExecutionTimestamp,
+      Hasher hasher) {
     var raw = new ByteArrayOutputStream();
     var outputStream = new DataOutputStream(raw);
     try {
-      outputStream.writeInt(header != null ? 0 : 1); // 4 bytes (Version)
+      outputStream.writeInt(committedHeaderOpt.isPresent() ? 0 : 1); // 4 bytes (Version)
       outputStream.write(opaque.asBytes()); // 32 bytes
-      if (header != null) {
-        outputStream.writeLong(header.getStateVersion()); // 8 bytes
-        var ledgerHashes = header.getHashes(); // 3 * 32 bytes
+      if (committedHeaderOpt.isPresent()) {
+        final var committedHeader = committedHeaderOpt.orElseThrow();
+        outputStream.writeLong(committedHeader.getStateVersion()); // 8 bytes
+        var ledgerHashes = committedHeader.getHashes(); // 3 * 32 bytes
         outputStream.write(ledgerHashes.getTransactionRoot().asBytes());
         outputStream.write(ledgerHashes.getReceiptRoot().asBytes());
         outputStream.write(ledgerHashes.getStateRoot().asBytes());
-        outputStream.writeLong(header.getEpoch()); // 8 bytes
-        outputStream.writeLong(header.getRound().number()); // 8 bytes
-        outputStream.writeLong(header.consensusParentRoundTimestamp()); // 8 bytes
-        outputStream.writeLong(header.proposerTimestamp()); // 8 bytes
-        var optNextEpoch = header.getNextEpoch();
+        outputStream.writeLong(committedHeader.getEpoch()); // 8 bytes
+        outputStream.writeLong(committedHeader.getRound().number()); // 8 bytes
+        outputStream.writeLong(committedHeader.consensusParentRoundTimestamp()); // 8 bytes
+        outputStream.writeLong(committedHeader.proposerTimestamp()); // 8 bytes
+        var optNextEpoch = committedHeader.getNextEpoch();
         if (optNextEpoch.isPresent()) {
           var nextEpoch = optNextEpoch.get();
           outputStream.writeByte(1); // 1 byte
@@ -108,7 +114,7 @@ public final class ConsensusHasher {
           outputStream.writeByte(0); // 1 byte
         }
       }
-      outputStream.writeLong(nodeTimestamp); // 8 bytes
+      outputStream.writeLong(localExecutionTimestamp); // 8 bytes
     } catch (IOException e) {
       throw new IllegalStateException();
     }

--- a/core/src/main/java/com/radixdlt/consensus/Vote.java
+++ b/core/src/main/java/com/radixdlt/consensus/Vote.java
@@ -69,12 +69,10 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.hash.HashCode;
 import com.google.errorprone.annotations.Immutable;
 import com.radixdlt.consensus.bft.BFTValidatorId;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.crypto.ECDSASecp256k1Signature;
-import com.radixdlt.crypto.Hasher;
 import com.radixdlt.crypto.exception.PublicKeyException;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.DsonOutput.Output;
@@ -173,16 +171,6 @@ public final class Vote implements ConsensusEvent {
 
   public VoteData getVoteData() {
     return voteData;
-  }
-
-  public static HashCode getHashOfData(Hasher hasher, VoteData voteData, long timestamp) {
-    var opaque = hasher.hashDsonEncoded(voteData);
-    var header = voteData.getCommitted().map(BFTHeader::getLedgerHeader).orElse(null);
-    return ConsensusHasher.toHash(opaque, header, timestamp, hasher);
-  }
-
-  public HashCode getHashOfData(Hasher hasher) {
-    return getHashOfData(hasher, this.voteData, this.timestamp);
   }
 
   public long getTimestamp() {

--- a/core/src/main/java/com/radixdlt/consensus/VoteData.java
+++ b/core/src/main/java/com/radixdlt/consensus/VoteData.java
@@ -66,6 +66,8 @@ package com.radixdlt.consensus;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.hash.HashCode;
+import com.radixdlt.crypto.Hasher;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.DsonOutput.Output;
 import com.radixdlt.serialization.SerializerConstants;
@@ -120,6 +122,16 @@ public final class VoteData {
 
   public Optional<BFTHeader> getCommitted() {
     return Optional.ofNullable(committed);
+  }
+
+  public Optional<LedgerHeader> committedLedgerHeader() {
+    return getCommitted().map(BFTHeader::getLedgerHeader);
+  }
+
+  public HashCode toConsensusVoteHash(Hasher hasher, long localExecutionTimestamp) {
+    final var selfHash = hasher.hashDsonEncoded(this);
+    return ConsensusHasher.toHash(
+        selfHash, committedLedgerHeader(), localExecutionTimestamp, hasher);
   }
 
   @Override

--- a/core/src/main/java/com/radixdlt/consensus/bft/processor/BFTEventStatelessVerifier.java
+++ b/core/src/main/java/com/radixdlt/consensus/bft/processor/BFTEventStatelessVerifier.java
@@ -130,9 +130,15 @@ public final class BFTEventStatelessVerifier implements BFTEventProcessor {
       return;
     }
 
+    final var voteData = vote.getVoteData();
+    final var voteTimestamp = vote.getTimestamp();
+
     final var verifiedVoteData =
         verifyHashSignature(
-            vote.getAuthor(), vote.getHashOfData(hasher), vote.getSignature(), vote);
+            vote.getAuthor(),
+            voteData.toConsensusVoteHash(hasher, voteTimestamp),
+            vote.getSignature(),
+            vote);
     if (!verifiedVoteData) {
       log.warn("Ignoring invalid vote data {}", vote);
       metrics

--- a/core/src/main/java/com/radixdlt/consensus/safety/SafetyRules.java
+++ b/core/src/main/java/com/radixdlt/consensus/safety/SafetyRules.java
@@ -72,10 +72,10 @@ import com.radixdlt.consensus.liveness.VoteTimeout;
 import com.radixdlt.consensus.safety.SafetyState.Builder;
 import com.radixdlt.crypto.ECDSASecp256k1Signature;
 import com.radixdlt.crypto.Hasher;
-import java.util.LinkedHashSet;
+import com.radixdlt.lang.Unit;
+import com.radixdlt.utils.LRUCache;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -94,7 +94,8 @@ public final class SafetyRules {
   private final PersistentSafetyStateStore persistentSafetyStateStore;
 
   private SafetyState state;
-  private final Set<HashCode> verifiedCertificatesCache = new LinkedHashSet<>();
+  private final LRUCache<HashCode, Unit> verifiedCertificatesCache =
+      new LRUCache<>(VERIFIED_CERTIFICATES_CACHE_MAX_SIZE);
 
   public SafetyRules(
       BFTValidatorId self,
@@ -230,10 +231,10 @@ public final class SafetyRules {
     }
 
     final VoteData voteData = constructVoteData(proposedVertex, proposedHeader);
-    final var voteHash = Vote.getHashOfData(hasher, voteData, timestamp);
+    final var consensusVoteHash = voteData.toConsensusVoteHash(hasher, timestamp);
 
     // TODO make signing more robust by including author in signed hash
-    final ECDSASecp256k1Signature signature = this.signer.sign(voteHash);
+    final ECDSASecp256k1Signature signature = this.signer.sign(consensusVoteHash);
     var vote = new Vote(this.self, voteData, timestamp, signature, highQC, Optional.empty());
 
     safetyStateBuilder.lastVote(vote);
@@ -257,7 +258,8 @@ public final class SafetyRules {
   public boolean verifyQcAgainstTheValidatorSet(QuorumCertificate qc) {
     final var qcHash = hasher.hashDsonEncoded(qc);
 
-    if (verifiedCertificatesCache.contains(qcHash)) {
+    // Using get() instead of contains() to bump recently accessed state
+    if (verifiedCertificatesCache.get(qcHash).isPresent()) {
       return true;
     }
 
@@ -283,19 +285,10 @@ public final class SafetyRules {
     final var isQcValid = allSignaturesAddedSuccessfully && validationState.complete();
 
     if (isQcValid) {
-      addVerifiedCertificateToCache(qcHash);
+      verifiedCertificatesCache.put(qcHash, Unit.unit());
     }
 
     return isQcValid;
-  }
-
-  private void addVerifiedCertificateToCache(HashCode certificateHash) {
-    if (verifiedCertificatesCache.size() >= VERIFIED_CERTIFICATES_CACHE_MAX_SIZE) {
-      final var iter = verifiedCertificatesCache.iterator();
-      iter.next();
-      iter.remove();
-    }
-    verifiedCertificatesCache.add(certificateHash);
   }
 
   private boolean isGenesisQc(QuorumCertificate qc) {
@@ -314,19 +307,24 @@ public final class SafetyRules {
 
   private boolean areAllQcTimestampedSignaturesValid(QuorumCertificate qc) {
     final var voteData = qc.getVoteData();
+    final var committedLedgerHeader = voteData.committedLedgerHeader();
+    final var voteDataHash = hasher.hashDsonEncoded(voteData);
     return qc.getTimestampedSignatures().getSignatures().entrySet().parallelStream()
         .allMatch(
             e -> {
-              final var nodePublicKey = e.getKey().getKey();
-              final var voteHash = Vote.getHashOfData(hasher, voteData, e.getValue().timestamp());
-              return hashVerifier.verify(nodePublicKey, voteHash, e.getValue().signature());
+              final var consensusVoteHash =
+                  ConsensusHasher.toHash(
+                      voteDataHash, committedLedgerHeader, e.getValue().timestamp(), hasher);
+              return hashVerifier.verify(
+                  e.getKey().getKey(), consensusVoteHash, e.getValue().signature());
             });
   }
 
   public boolean verifyTcAgainstTheValidatorSet(TimeoutCertificate tc) {
     final var tcHash = hasher.hashDsonEncoded(tc);
 
-    if (verifiedCertificatesCache.contains(tcHash)) {
+    // Using get() instead of contains() to bump recently accessed state
+    if (verifiedCertificatesCache.get(tcHash).isPresent()) {
       return true;
     }
 
@@ -335,7 +333,7 @@ public final class SafetyRules {
             && areAllTcTimestampedSignaturesValid(tc);
 
     if (isTcValid) {
-      addVerifiedCertificateToCache(tcHash);
+      verifiedCertificatesCache.put(tcHash, Unit.unit());
     }
 
     return isTcValid;

--- a/core/src/main/java/com/radixdlt/mempool/MempoolRelayerConfig.java
+++ b/core/src/main/java/com/radixdlt/mempool/MempoolRelayerConfig.java
@@ -74,7 +74,7 @@ public record MempoolRelayerConfig(
     int maxMessageTransactionCount,
     int maxMessagePayloadSize) {
   public static final int DEFAULT_INTERVAL_MS = 20000;
-  public static final int DEFAULT_MAX_PEERS = 100;
+  public static final int DEFAULT_MAX_PEERS = 20;
   public static final int DEFAULT_MAX_MESSAGE_TRANSACTION_COUNT = 10;
   public static final int DEFAULT_MAX_MESSAGE_PAYLOAD_SIZE = 2 * 1024 * 1024;
   public static final int DEFAULT_MAX_RELAYED_SIZE = 6 * 1024 * 1024;

--- a/core/src/main/java/com/radixdlt/mempool/MempoolRelayerConfig.java
+++ b/core/src/main/java/com/radixdlt/mempool/MempoolRelayerConfig.java
@@ -74,7 +74,7 @@ public record MempoolRelayerConfig(
     int maxMessageTransactionCount,
     int maxMessagePayloadSize) {
   public static final int DEFAULT_INTERVAL_MS = 20000;
-  public static final int DEFAULT_MAX_PEERS = 20;
+  public static final int DEFAULT_MAX_PEERS = 10;
   public static final int DEFAULT_MAX_MESSAGE_TRANSACTION_COUNT = 10;
   public static final int DEFAULT_MAX_MESSAGE_PAYLOAD_SIZE = 2 * 1024 * 1024;
   public static final int DEFAULT_MAX_RELAYED_SIZE = 6 * 1024 * 1024;

--- a/core/src/main/java/com/radixdlt/messaging/consensus/ConsensusEventMessage.java
+++ b/core/src/main/java/com/radixdlt/messaging/consensus/ConsensusEventMessage.java
@@ -65,6 +65,7 @@
 package com.radixdlt.messaging.consensus;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.radixdlt.consensus.ConsensusEvent;
 import com.radixdlt.consensus.Proposal;
@@ -105,6 +106,11 @@ public final class ConsensusEventMessage extends Message {
 
     this.proposal = proposal;
     this.vote = vote;
+  }
+
+  @JsonIgnore
+  public boolean isProposal() {
+    return proposal != null;
   }
 
   public ConsensusEventMessage(Proposal proposal) {

--- a/core/src/main/java/com/radixdlt/messaging/core/Message.java
+++ b/core/src/main/java/com/radixdlt/messaging/core/Message.java
@@ -67,10 +67,6 @@ package com.radixdlt.messaging.core;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.radixdlt.serialization.DsonOutput;
 import com.radixdlt.serialization.DsonOutput.Output;
-import com.radixdlt.serialization.Serialization;
-import com.radixdlt.utils.Compress;
-import com.radixdlt.utils.Ints;
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class Message extends BasicContainer {
@@ -93,17 +89,6 @@ public abstract class Message extends BasicContainer {
 
   public long getTimestamp() {
     return this.timestamp;
-  }
-
-  public byte[] toByteArray(Serialization serialization) throws IOException {
-    byte[] bytes = serialization.toDson(this, Output.WIRE);
-    byte[] data = Compress.compress(bytes);
-
-    byte[] byteArray = new byte[data.length + Integer.BYTES];
-    Ints.copyTo(data.length, byteArray, 0);
-    System.arraycopy(data, 0, byteArray, Integer.BYTES, data.length);
-
-    return byteArray;
   }
 
   @Override

--- a/core/src/test/java/com/radixdlt/consensus/PendingVotesTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/PendingVotesTest.java
@@ -348,7 +348,6 @@ public class PendingVotesTest {
     BFTHeader proposed = new BFTHeader(parentRound.next(), vertexId, mock(LedgerHeader.class));
     BFTHeader parent = new BFTHeader(parentRound, HashUtils.random256(), mock(LedgerHeader.class));
     VoteData voteData = new VoteData(proposed, parent, null);
-    when(vote.getHashOfData(any())).thenReturn(Vote.getHashOfData(hasher, voteData, 123456L));
     when(vote.getVoteData()).thenReturn(voteData);
     when(vote.getTimestamp()).thenReturn(123456L);
     when(vote.getAuthor()).thenReturn(author);

--- a/core/src/test/java/com/radixdlt/consensus/bft/processor/BFTEventStatelessVerifierTest.java
+++ b/core/src/test/java/com/radixdlt/consensus/bft/processor/BFTEventStatelessVerifierTest.java
@@ -231,6 +231,8 @@ public class BFTEventStatelessVerifierTest {
   @Test
   public void when_process_correct_vote_then_should_be_forwarded() {
     Vote vote = mock(Vote.class);
+    final var voteData = mock(VoteData.class);
+    when(vote.getVoteData()).thenReturn(voteData);
     when(vote.getRound()).thenReturn(Round.of(1));
     when(vote.getEpoch()).thenReturn(0L);
     BFTValidatorId author = mock(BFTValidatorId.class);
@@ -262,6 +264,8 @@ public class BFTEventStatelessVerifierTest {
   @Test
   public void when_process_bad_signature_vote_then_should_not_be_forwarded() {
     Vote vote = mock(Vote.class);
+    final var voteData = mock(VoteData.class);
+    when(vote.getVoteData()).thenReturn(voteData);
     BFTValidatorId author = mock(BFTValidatorId.class);
     when(vote.getAuthor()).thenReturn(author);
     when(vote.getSignature()).thenReturn(mock(ECDSASecp256k1Signature.class));
@@ -282,6 +286,8 @@ public class BFTEventStatelessVerifierTest {
     ECDSASecp256k1Signature timeoutSignature = mock(ECDSASecp256k1Signature.class);
     when(vote.getSignature()).thenReturn(voteSignature);
     when(vote.getTimeoutSignature()).thenReturn(Optional.of(timeoutSignature));
+    final var voteData = mock(VoteData.class);
+    when(vote.getVoteData()).thenReturn(voteData);
     when(validatorSet.containsValidator(eq(author))).thenReturn(true);
     when(verifier.verify(any(), any(), eq(voteSignature))).thenReturn(true);
     when(verifier.verify(any(), any(), eq(timeoutSignature))).thenReturn(false);

--- a/core/src/test/java/com/radixdlt/modules/ConsensusModuleTest.java
+++ b/core/src/test/java/com/radixdlt/modules/ConsensusModuleTest.java
@@ -267,7 +267,7 @@ public class ConsensusModuleTest {
             LedgerHeader.create(1, Round.of(1), 1, LedgerHashes.zero(), 1, 1));
     final var voteData = new VoteData(next, parent.getProposedHeader(), parent.getParentHeader());
     final var timestamp = 1;
-    final var voteDataHash = Vote.getHashOfData(hasher, voteData, timestamp);
+    final var voteDataHash = voteData.toConsensusVoteHash(hasher, timestamp);
     final var qcSignature = proposerKeyPair.sign(voteDataHash);
     var unsyncedQC =
         new QuorumCertificate(


### PR DESCRIPTION
This includes a few tweaks:
- `UInt192` json/dson serialziation using `byte[]`, instead of `String`
- Use `LruCache` for `verifiedCertificatesCache`
- Don't dson-encode (and hash) VoteData separately for each signature in a QC
- Additional metrics for outbound messages
- increase max pacemaker timeout to `(1.2^13)×3 ~= 32s`