### PR TITLE
tweak: Remove SBOR JSON by default from the transaction stream

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -1109,7 +1109,7 @@ components:
           description: Whether to return the raw hex-encoded bytes (default true)
           type: boolean
         programmatic_json:
-          description: Whether to return the programmatic json format (default true)
+          description: Whether to return the programmatic json format (normally default true, defaults false for streamed transactions)
           type: boolean
     TransactionFormatOptions:
       type: object
@@ -1122,7 +1122,7 @@ components:
           description: Whether to return the hex-encoded blobs (default false)
           type: boolean
         message:
-          description: Whether to return the transaction message (default false)
+          description: Whether to return the transaction message (default true)
           type: boolean
         raw_system_transaction:
           description: Whether to return the raw hex-encoded system transaction bytes (default false)

--- a/core-rust/core-api-server/src/core_api/conversions/context.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/context.rs
@@ -28,6 +28,20 @@ impl MappingContext {
         }
     }
 
+    /// For the transactions stream, we default to settings which the Gateway requires, and aim to
+    /// optimize for performance.
+    /// 
+    /// We therefore disable programmatic JSON to cut down on bandwidth for large transaction receipts.
+    pub fn new_for_transaction_stream(network_definition: &NetworkDefinition) -> Self {
+        Self {
+            sbor_options: SborOptions {
+                include_raw: true,
+                include_programmatic_json: false,
+            },
+            ..Self::new(network_definition)
+        }
+    }
+
     pub fn new_for_uncommitted_data(network_definition: &NetworkDefinition) -> Self {
         Self {
             network_definition: network_definition.clone(),
@@ -135,7 +149,7 @@ impl Default for TransactionOptions {
         Self {
             include_manifest: true,
             include_blobs: false,
-            include_message: false,
+            include_message: true,
             include_raw_system: false,
             include_raw_notarized: true,
             include_raw_ledger: false,

--- a/core-rust/core-api-server/src/core_api/generated/models/sbor_format_options.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/sbor_format_options.rs
@@ -17,7 +17,7 @@ pub struct SborFormatOptions {
     /// Whether to return the raw hex-encoded bytes (default true)
     #[serde(rename = "raw", skip_serializing_if = "Option::is_none")]
     pub raw: Option<bool>,
-    /// Whether to return the programmatic json format (default true)
+    /// Whether to return the programmatic json format (normally default true, defaults false for streamed transactions)
     #[serde(rename = "programmatic_json", skip_serializing_if = "Option::is_none")]
     pub programmatic_json: Option<bool>,
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_format_options.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_format_options.rs
@@ -20,7 +20,7 @@ pub struct TransactionFormatOptions {
     /// Whether to return the hex-encoded blobs (default false)
     #[serde(rename = "blobs", skip_serializing_if = "Option::is_none")]
     pub blobs: Option<bool>,
-    /// Whether to return the transaction message (default false)
+    /// Whether to return the transaction message (default true)
     #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
     pub message: Option<bool>,
     /// Whether to return the raw hex-encoded system transaction bytes (default false)

--- a/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
@@ -17,7 +17,7 @@ pub(crate) async fn handle_stream_transactions(
     Json(request): Json<models::StreamTransactionsRequest>,
 ) -> Result<Json<models::StreamTransactionsResponse>, ResponseError<()>> {
     assert_matching_network(&request.network, &state.network)?;
-    let mapping_context = MappingContext::new(&state.network)
+    let mapping_context = MappingContext::new_for_transaction_stream(&state.network)
         .with_sbor_formats(&request.sbor_format_options)
         .with_transaction_formats(&request.transaction_format_options)
         .with_substate_formats(&request.substate_format_options);

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/SborFormatOptions.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/SborFormatOptions.java
@@ -78,11 +78,11 @@ public class SborFormatOptions {
   }
 
    /**
-   * Whether to return the programmatic json format (default true)
+   * Whether to return the programmatic json format (normally default true, defaults false for streamed transactions)
    * @return programmaticJson
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "Whether to return the programmatic json format (default true)")
+  @ApiModelProperty(value = "Whether to return the programmatic json format (normally default true, defaults false for streamed transactions)")
   @JsonProperty(JSON_PROPERTY_PROGRAMMATIC_JSON)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionFormatOptions.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionFormatOptions.java
@@ -120,11 +120,11 @@ public class TransactionFormatOptions {
   }
 
    /**
-   * Whether to return the transaction message (default false)
+   * Whether to return the transaction message (default true)
    * @return message
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "Whether to return the transaction message (default false)")
+  @ApiModelProperty(value = "Whether to return the transaction message (default true)")
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/regenerate-apis.sh
+++ b/regenerate-apis.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Fail on error
+set -e
+
+echo "\nRegenerating Core API models (Rust + Java)...\n"
+python3 ./core-rust/core-api-server/scripts/generate-openapi-server.py
+
+echo "\nRegenerating Core API models (Typescript)...\n"
+python3 ./sdk/typescript/regeneration/generate-typescript-client.py
+
+echo "\nRegenerating System API models (Java)...\n"
+python3 ./core/src/main/java/com/radixdlt/api/regeneration/generate.py

--- a/sdk/typescript/lib/generated/models/CommittedTransaction.ts
+++ b/sdk/typescript/lib/generated/models/CommittedTransaction.ts
@@ -56,6 +56,12 @@ export interface CommittedTransaction {
      * @memberof CommittedTransaction
      */
     receipt: TransactionReceipt;
+    /**
+     * An integer between `0` and `10^14`, marking the proposer timestamp in ms.
+     * @type {number}
+     * @memberof CommittedTransaction
+     */
+    proposer_timestamp_ms: number;
 }
 
 /**
@@ -66,6 +72,7 @@ export function instanceOfCommittedTransaction(value: object): boolean {
     isInstance = isInstance && "resultant_state_identifiers" in value;
     isInstance = isInstance && "ledger_transaction" in value;
     isInstance = isInstance && "receipt" in value;
+    isInstance = isInstance && "proposer_timestamp_ms" in value;
 
     return isInstance;
 }
@@ -83,6 +90,7 @@ export function CommittedTransactionFromJSONTyped(json: any, ignoreDiscriminator
         'resultant_state_identifiers': CommittedStateIdentifierFromJSON(json['resultant_state_identifiers']),
         'ledger_transaction': LedgerTransactionFromJSON(json['ledger_transaction']),
         'receipt': TransactionReceiptFromJSON(json['receipt']),
+        'proposer_timestamp_ms': json['proposer_timestamp_ms'],
     };
 }
 
@@ -98,6 +106,7 @@ export function CommittedTransactionToJSON(value?: CommittedTransaction | null):
         'resultant_state_identifiers': CommittedStateIdentifierToJSON(value.resultant_state_identifiers),
         'ledger_transaction': LedgerTransactionToJSON(value.ledger_transaction),
         'receipt': TransactionReceiptToJSON(value.receipt),
+        'proposer_timestamp_ms': value.proposer_timestamp_ms,
     };
 }
 

--- a/sdk/typescript/lib/generated/models/LtsCommittedTransactionOutcome.ts
+++ b/sdk/typescript/lib/generated/models/LtsCommittedTransactionOutcome.ts
@@ -55,6 +55,12 @@ export interface LtsCommittedTransactionOutcome {
      */
     state_version: number;
     /**
+     * An integer between `0` and `10^14`, marking the proposer timestamp in ms.
+     * @type {number}
+     * @memberof LtsCommittedTransactionOutcome
+     */
+    proposer_timestamp_ms: number;
+    /**
      * The hex-encoded transaction accumulator hash. This hash captures the order of all transactions on ledger.
      * This hash is `ACC_{N+1} = combine(ACC_N, LEDGER_HASH_{N}))` (where `combine()` is an arbitrary deterministic function we use).
      * @type {string}
@@ -102,6 +108,7 @@ export interface LtsCommittedTransactionOutcome {
 export function instanceOfLtsCommittedTransactionOutcome(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "state_version" in value;
+    isInstance = isInstance && "proposer_timestamp_ms" in value;
     isInstance = isInstance && "accumulator_hash" in value;
     isInstance = isInstance && "status" in value;
     isInstance = isInstance && "fungible_entity_balance_changes" in value;
@@ -122,6 +129,7 @@ export function LtsCommittedTransactionOutcomeFromJSONTyped(json: any, ignoreDis
     return {
         
         'state_version': json['state_version'],
+        'proposer_timestamp_ms': json['proposer_timestamp_ms'],
         'accumulator_hash': json['accumulator_hash'],
         'user_transaction_identifiers': !exists(json, 'user_transaction_identifiers') ? undefined : TransactionIdentifiersFromJSON(json['user_transaction_identifiers']),
         'status': LtsCommittedTransactionStatusFromJSON(json['status']),
@@ -141,6 +149,7 @@ export function LtsCommittedTransactionOutcomeToJSON(value?: LtsCommittedTransac
     return {
         
         'state_version': value.state_version,
+        'proposer_timestamp_ms': value.proposer_timestamp_ms,
         'accumulator_hash': value.accumulator_hash,
         'user_transaction_identifiers': TransactionIdentifiersToJSON(value.user_transaction_identifiers),
         'status': LtsCommittedTransactionStatusToJSON(value.status),

--- a/sdk/typescript/lib/generated/models/SborFormatOptions.ts
+++ b/sdk/typescript/lib/generated/models/SborFormatOptions.ts
@@ -26,7 +26,7 @@ export interface SborFormatOptions {
      */
     raw?: boolean;
     /**
-     * Whether to return the programmatic json format (default true)
+     * Whether to return the programmatic json format (normally default true, defaults false for streamed transactions)
      * @type {boolean}
      * @memberof SborFormatOptions
      */

--- a/sdk/typescript/lib/generated/models/TransactionFormatOptions.ts
+++ b/sdk/typescript/lib/generated/models/TransactionFormatOptions.ts
@@ -32,7 +32,7 @@ export interface TransactionFormatOptions {
      */
     blobs?: boolean;
     /**
-     * Whether to return the transaction message (default false)
+     * Whether to return the transaction message (default true)
      * @type {boolean}
      * @memberof TransactionFormatOptions
      */


### PR DESCRIPTION
# Summary

* After consulting Builders and Gateway teams, this removes the JSON encoding of SborData in the Core API - just for the stream transactions endpoint. This results in additional work and lots of additional bandwidth, so cutting this out should make the API calls more efficient.
* This PR also turns on typed models for the transaction message by default.