### PR TITLE
Add conditionally git config for windows runners

### DIFF
--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -58,6 +58,10 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Set git config for long paths
+        if: matrix.os == 'windows-latest'
+        run: |
+          git config --system core.longpaths true
       - name: Install Rust Targets
         run: |
           rustup target install ${{ matrix.target }}


### PR DESCRIPTION
Wndows large runners don't have git config  that allows long paths

Ref issue - https://github.com/actions/runner-images/issues/6348