### PR TITLE
Remove clokwerk in favour of a Tokio thread

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -33,15 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,9 +307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
- "iana-time-zone",
  "num-traits",
- "winapi",
 ]
 
 [[package]]
@@ -330,15 +319,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clokwerk"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd108d365fcb6d7eddf17a6718eb6a33db18ba4178f8cc6b667f480710f10d76"
-dependencies = [
- "chrono",
 ]
 
 [[package]]
@@ -399,12 +379,6 @@ dependencies = [
  "transaction",
  "utils",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -846,29 +820,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2073,6 +2024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,7 +2118,6 @@ name = "state-manager"
 version = "0.1.0"
 dependencies = [
  "blake2",
- "clokwerk",
  "enum_dispatch",
  "hex",
  "im",
@@ -2328,12 +2287,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
+ "bytes",
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.3",
+ "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2779,15 +2753,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -35,7 +35,7 @@ utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.0.0", 
 itertools = { version = "0.11.0" }
 jni = { version = "0.19.0" }
 tracing = { version = "0.1" }
-tokio = { version = "1.21.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.32.0", features = ["full"] }
 prometheus = { version = "0.13.2", default-features = false, features = [] }
 blake2 = { version = "0.10.6", default-features = false }
 serde = { version = "1.0.81", features = ["derive"] }

--- a/core-rust/state-manager/Cargo.toml
+++ b/core-rust/state-manager/Cargo.toml
@@ -32,4 +32,4 @@ slotmap = { version = "1.0.6" }
 im = { version = "15.1.0" }
 rand = { version = "0.8.5" }
 enum_dispatch = { version = "0.3.11" }
-clokwerk = {version = "0.4.0" }
+

--- a/core-rust/state-manager/src/jni/node_rust_environment.rs
+++ b/core-rust/state-manager/src/jni/node_rust_environment.rs
@@ -62,10 +62,7 @@
  * permissions under this License.
  */
 
-use clokwerk::Interval;
-use clokwerk::{ScheduleHandle, Scheduler};
 use std::sync::Arc;
-use std::time::Duration;
 
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
@@ -76,22 +73,16 @@ use node_common::locks::*;
 use prometheus::Registry;
 use radix_engine_common::prelude::NetworkDefinition;
 use tokio::runtime::Runtime;
+use tokio::sync::oneshot;
 
 use crate::mempool_manager::MempoolManager;
 use crate::mempool_relay_dispatcher::MempoolRelayDispatcher;
 use crate::priority_mempool::PriorityMempool;
-use crate::store::traits::measurement::MeasurableDatabase;
+use crate::store::metrics::RawDBMetricsReportThread;
 use crate::store::StateManagerDatabase;
 
 use super::fatal_panic_handler::FatalPanicHandler;
-use crate::{RawDbMetrics, StateComputer, StateManager, StateManagerConfig};
-
-/// An interval between time-intensive measurement of raw DB metrics.
-/// Some of our raw DB metrics take ~a few milliseconds to collect. We cannot afford the overhead of
-/// updating them every time they change (i.e. on every DB commit) and we also should not perform
-/// this considerable I/O within the Prometheus' exposition servlet thread - hence, a periodic task
-/// (which in practice still runs more often than Prometheus' scraping).
-const RAW_DB_MEASUREMENT_INTERVAL: Interval = Interval::Seconds(10);
+use crate::{StateComputer, StateManager, StateManagerConfig};
 
 const POINTER_JNI_FIELD_NAME: &str = "rustNodeRustEnvironmentPointer";
 
@@ -127,7 +118,16 @@ pub struct JNINodeRustEnvironment {
     /// A handle to a running background metric collector thread.
     /// It is not directly used, but is held by this instance in order for the thread to be stopped
     /// (when this field is dropped by [`Self::cleanup()`]).
-    pub metric_collector_thread: ScheduleHandle,
+    pub raw_db_metrics_shutdown_signal_sender: Option<oneshot::Sender<()>>,
+}
+
+impl Drop for JNINodeRustEnvironment {
+    fn drop(&mut self) {
+        if let Some(sender) = self.raw_db_metrics_shutdown_signal_sender.take() {
+            // Using `let _ =` to ignore send errors.
+            let _ = sender.send(());
+        }
+    }
 }
 
 impl JNINodeRustEnvironment {
@@ -152,15 +152,19 @@ impl JNINodeRustEnvironment {
             &metric_registry,
         );
 
+        let (raw_db_metrics_shutdown_signal_sender, raw_db_metrics_report_shutdown_signal_receiver) =
+            oneshot::channel::<()>();
+
         let metric_collector_thread =
-            start_raw_db_metrics_reporting(state_manager.database.clone(), &metric_registry);
+            RawDBMetricsReportThread::new(state_manager.database.clone(), &metric_registry);
+        metric_collector_thread.start(&runtime, raw_db_metrics_report_shutdown_signal_receiver);
 
         let jni_node_rust_env = JNINodeRustEnvironment {
             runtime: Arc::new(runtime),
             network,
             state_manager,
             metric_registry,
-            metric_collector_thread,
+            raw_db_metrics_shutdown_signal_sender: Some(raw_db_metrics_shutdown_signal_sender),
         };
 
         env.set_rust_field(j_node_rust_env, POINTER_JNI_FIELD_NAME, jni_node_rust_env)
@@ -171,7 +175,6 @@ impl JNINodeRustEnvironment {
         let jni_node_rust_env: JNINodeRustEnvironment = env
             .take_rust_field(j_node_rust_env, POINTER_JNI_FIELD_NAME)
             .unwrap();
-
         drop(jni_node_rust_env);
     }
 
@@ -219,19 +222,3 @@ impl JNINodeRustEnvironment {
 }
 
 pub fn export_extern_functions() {}
-
-/// Starts a background thread responsible for periodic raw DB metrics collection, and returns a
-/// handle that keeps it running.
-/// See [`RAW_DB_MEASUREMENT_INTERVAL`] for more details.
-fn start_raw_db_metrics_reporting(
-    database: Arc<RwLock<StateManagerDatabase>>,
-    metric_registry: &Registry,
-) -> ScheduleHandle {
-    let raw_db_metrics = RawDbMetrics::new(metric_registry);
-    let mut scheduler = Scheduler::new();
-    scheduler.every(RAW_DB_MEASUREMENT_INTERVAL).run(move || {
-        let statistics = database.read().get_data_volume_statistics();
-        raw_db_metrics.update(statistics);
-    });
-    scheduler.watch_thread(Duration::from_secs(1))
-}

--- a/core-rust/state-manager/src/metrics.rs
+++ b/core-rust/state-manager/src/metrics.rs
@@ -72,11 +72,8 @@ use crate::StateVersion;
 use node_common::config::limits::*;
 use node_common::locks::{LockFactory, Mutex};
 use node_common::metrics::*;
-use prometheus::{
-    Gauge, Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
-};
+use prometheus::{Gauge, Histogram, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
 
-use crate::store::traits::measurement::CategoryDbVolumeStatistic;
 use radix_engine::transaction::TransactionFeeSummary;
 use radix_engine_common::prelude::*;
 
@@ -102,11 +99,6 @@ pub struct VertexPrepareMetrics {
     pub proposal_transactions_size: Histogram,
     pub wasted_proposal_bandwidth: Histogram,
     pub stop_reason: IntCounterVec,
-}
-
-pub struct RawDbMetrics {
-    pub entries: IntGaugeVec,
-    pub size: IntGaugeVec,
 }
 
 impl LedgerMetrics {
@@ -374,40 +366,6 @@ impl VertexPrepareMetrics {
         self.wasted_proposal_bandwidth
             .observe((total_proposal_size - committed_proposal_size) as f64);
         self.stop_reason.with_label(stop_reason).inc();
-    }
-}
-
-impl RawDbMetrics {
-    pub fn new(registry: &Registry) -> Self {
-        Self {
-            entries: IntGaugeVec::new(
-                opts(
-                    "raw_db_entries",
-                    "An approximate number of entries persisted in the database, by category.",
-                ),
-                &["category"],
-            )
-            .registered_at(registry),
-            size: IntGaugeVec::new(
-                opts(
-                    "raw_db_size",
-                    "An approximate size of the database, in bytes, by category of entries.",
-                ),
-                &["category"],
-            )
-            .registered_at(registry),
-        }
-    }
-
-    pub fn update(&self, statistics: impl IntoIterator<Item = CategoryDbVolumeStatistic>) {
-        for statistic in statistics {
-            self.entries
-                .with_label(&statistic.category_name)
-                .set(i64::try_from(statistic.entry_count).unwrap_or_default());
-            self.size
-                .with_label(&statistic.category_name)
-                .set(i64::try_from(statistic.size_bytes).unwrap_or_default());
-        }
     }
 }
 

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -82,8 +82,8 @@ use transaction::model::*;
 
 use radix_engine_store_interface::interface::*;
 
-use std::path::PathBuf;
 use itertools::Itertools;
+use std::path::PathBuf;
 
 use tracing::{error, info, warn};
 
@@ -1078,14 +1078,12 @@ impl SubstateDatabase for RocksDBStore {
 }
 
 impl ListableSubstateDatabase for RocksDBStore {
-    fn list_partition_keys(&self) -> Box<dyn Iterator<Item=DbPartitionKey> + '_> {
+    fn list_partition_keys(&self) -> Box<dyn Iterator<Item = DbPartitionKey> + '_> {
         Box::new(
             self.open_db_context()
                 .cf(SubstatesCf)
                 .iterate(Direction::Forward)
-                .map(|(iter_key_bytes, _)| {
-                    iter_key_bytes.0
-                })
+                .map(|(iter_key_bytes, _)| iter_key_bytes.0)
                 // Rocksdb iterator returns sorted entries, so ok to to eliminate
                 // duplicates with dedup()
                 .dedup(),


### PR DESCRIPTION
This builds on top of https://github.com/radixdlt/babylon-node/pull/707 and removes `clokwerk` lib in favour of a tokio thread.