### PR TITLE
Adding more metrics coming from raw RocksDB statistics

### DIFF
--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -578,7 +578,12 @@ impl MeasurableDatabase for RocksDBStore {
                 warn!("LiveFile of unknown column family: {:?}", live_file);
                 continue;
             };
-            statistic.add(live_file.num_entries, live_file.size);
+            statistic.add_sst_summary(
+                live_file.num_entries,
+                live_file.num_deletions,
+                live_file.size,
+                live_file.level,
+            );
         }
         statistics.into_values().collect()
     }


### PR DESCRIPTION
⚠️ It is based on https://github.com/radixdlt/babylon-node/pull/712 but only to avoid solving self-conflicts later; it actually wants to merge into develop after the dep merges there.

Just a few extra details in the `rn_raw_db_*`; they should be useful when investigating future GC problems.

An excerpt from my tiny DB, just for proof-reading:
```
# HELP rn_raw_db_files A number of SST files holding a specific category, in bytes.
# TYPE rn_raw_db_files gauge
rn_raw_db_files{category="state_hash_tree_nodes"} 7
...
# HELP rn_raw_db_max_level A maximum level of an SST file, by category
# TYPE rn_raw_db_max_level gauge
rn_raw_db_max_level{category="state_hash_tree_nodes"} 2
...
# HELP rn_raw_db_size A sum of all SST file sizes holding a specific category, in bytes.
# TYPE rn_raw_db_size gauge
rn_raw_db_size{category="state_hash_tree_nodes"} 204869599
...
# HELP rn_raw_db_uncompacted_live_entries A sum of live entry counts across SST files, by category.
# TYPE rn_raw_db_uncompacted_live_entries gauge
rn_raw_db_uncompacted_live_entries{category="state_hash_tree_nodes"} 2950152
...
# HELP rn_raw_db_uncompacted_tombstone_entries A sum of tombstone entry counts across SST files, by category.
# TYPE rn_raw_db_uncompacted_tombstone_entries gauge
rn_raw_db_uncompacted_tombstone_entries{category="state_hash_tree_nodes"} 1434846
...
```