### PR TITLE
Impl for GC-ing non-critical ledger proofs from configured old-enough epochs

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/environment/NodeConstants.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/environment/NodeConstants.java
@@ -141,12 +141,6 @@ public final class NodeConstants {
   public static final double MEMPOOL_TRANSACTION_OVERHEAD_FACTOR =
       (double) (MEMPOOL_TRANSACTION_OVERHEAD_FACTOR_PERCENT) / 100.0;
 
-  public static final int MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE =
-      Natives.builder(NodeConstants::getMaxTransactionBytesInResponse)
-          .build(new TypeToken<Natives.Call1<Tuple.Tuple0, UInt32>>() {})
-          .call(Tuple.Tuple0.of())
-          .toInt();
-
   private static native byte[] getDefaultMaxVertexTransactionCount(byte[] unused);
 
   private static native byte[] getDefaultMaxTotalVertexTransactionsSize(byte[] unused);
@@ -166,6 +160,4 @@ public final class NodeConstants {
   private static native byte[] getDefaultFinalizationCostUnitLimit(byte[] unused);
 
   private static native byte[] getMempoolTransactionOverheadFactorPercent(byte[] unused);
-
-  private static native byte[] getMaxTransactionBytesInResponse(byte[] unused);
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/environment/NodeConstants.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/environment/NodeConstants.java
@@ -141,6 +141,12 @@ public final class NodeConstants {
   public static final double MEMPOOL_TRANSACTION_OVERHEAD_FACTOR =
       (double) (MEMPOOL_TRANSACTION_OVERHEAD_FACTOR_PERCENT) / 100.0;
 
+  public static final int MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE =
+      Natives.builder(NodeConstants::getMaxTransactionBytesInResponse)
+          .build(new TypeToken<Natives.Call1<Tuple.Tuple0, UInt32>>() {})
+          .call(Tuple.Tuple0.of())
+          .toInt();
+
   private static native byte[] getDefaultMaxVertexTransactionCount(byte[] unused);
 
   private static native byte[] getDefaultMaxTotalVertexTransactionsSize(byte[] unused);
@@ -160,4 +166,6 @@ public final class NodeConstants {
   private static native byte[] getDefaultFinalizationCostUnitLimit(byte[] unused);
 
   private static native byte[] getMempoolTransactionOverheadFactorPercent(byte[] unused);
+
+  private static native byte[] getMaxTransactionBytesInResponse(byte[] unused);
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/environment/StateManagerConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/environment/StateManagerConfig.java
@@ -78,6 +78,7 @@ public record StateManagerConfig(
     DatabaseFlags databaseFlags,
     LoggingConfig loggingConfig,
     StateHashTreeGcConfig stateHashTreeGcConfig,
+    LedgerProofsGcConfig ledgerProofsGcConfig,
     boolean noFees) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(

--- a/core-rust-bridge/src/main/java/com/radixdlt/environment/StateManagerConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/environment/StateManagerConfig.java
@@ -69,6 +69,7 @@ import com.radixdlt.mempool.RustMempoolConfig;
 import com.radixdlt.rev2.NetworkDefinition;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
+import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 
 public record StateManagerConfig(
     NetworkDefinition networkDefinition,
@@ -79,6 +80,7 @@ public record StateManagerConfig(
     LoggingConfig loggingConfig,
     StateHashTreeGcConfig stateHashTreeGcConfig,
     LedgerProofsGcConfig ledgerProofsGcConfig,
+    LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
     boolean noFees) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(

--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
@@ -199,6 +199,7 @@ public final class NodeSborCodecs {
     LedgerStatus.registerCodec(codecMap);
     RecentSelfProposalMissStatistic.registerCodec(codecMap);
     StateHashTreeGcConfig.registerCodec(codecMap);
+    LedgerProofsGcConfig.registerCodec(codecMap);
   }
 
   public static void registerCodecsForExistingTypes(CodecMap codecMap) {

--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
@@ -200,6 +200,7 @@ public final class NodeSborCodecs {
     RecentSelfProposalMissStatistic.registerCodec(codecMap);
     StateHashTreeGcConfig.registerCodec(codecMap);
     LedgerProofsGcConfig.registerCodec(codecMap);
+    LedgerSyncLimitsConfig.registerCodec(codecMap);
   }
 
   public static void registerCodecsForExistingTypes(CodecMap codecMap) {

--- a/core-rust-bridge/src/main/java/com/radixdlt/testutil/TestStateReader.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/testutil/TestStateReader.java
@@ -94,6 +94,9 @@ public final class TestStateReader {
     this.leastStaleStateHashTreeVersionFunc =
         Natives.builder(nodeRustEnvironment, TestStateReader::leastStaleStateHashTreeVersion)
             .build(new TypeToken<>() {});
+    this.countProofsWithinEpochFunc =
+        Natives.builder(nodeRustEnvironment, TestStateReader::countProofsWithinEpoch)
+            .build(new TypeToken<>() {});
     this.getNodeGlobalRootFunc =
         Natives.builder(nodeRustEnvironment, TestStateReader::getNodeGlobalRoot)
             .build(new TypeToken<>() {});
@@ -134,8 +137,8 @@ public final class TestStateReader {
 
   private final Natives.Call1<Tuple.Tuple0, UInt64> epochFunc;
 
-  public UInt64 getEpoch() {
-    return epochFunc.call(Tuple.tuple());
+  public long getEpoch() {
+    return epochFunc.call(Tuple.tuple()).toNonNegativeLong().unwrap();
   }
 
   private static native byte[] epoch(NodeRustEnvironment nodeRustEnvironment, byte[] payload);
@@ -144,6 +147,15 @@ public final class TestStateReader {
 
   public long getLeastStaleStateHashTreeVersion() {
     return leastStaleStateHashTreeVersionFunc.call(Tuple.tuple()).toLong();
+  }
+
+  private static native byte[] countProofsWithinEpoch(
+      NodeRustEnvironment nodeRustEnvironment, byte[] payload);
+
+  private final Natives.Call1<UInt64, UInt64> countProofsWithinEpochFunc;
+
+  public long countProofsWithinEpoch(long epoch) {
+    return countProofsWithinEpochFunc.call(UInt64.fromNonNegativeLong(epoch)).toLong();
   }
 
   private static native byte[] leastStaleStateHashTreeVersion(

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/LedgerSyncLimitsConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/LedgerSyncLimitsConfig.java
@@ -64,78 +64,44 @@
 
 package com.radixdlt.transaction;
 
-import com.google.common.reflect.TypeToken;
-import com.radixdlt.environment.NodeRustEnvironment;
-import com.radixdlt.lang.Option;
-import com.radixdlt.lang.Tuple;
-import com.radixdlt.monitoring.LabelledTimer;
-import com.radixdlt.monitoring.Metrics;
-import com.radixdlt.monitoring.Metrics.MethodId;
-import com.radixdlt.sbor.Natives;
-import com.radixdlt.statecomputer.commit.LedgerProof;
-import com.radixdlt.utils.UInt64;
-import java.util.Optional;
+import com.radixdlt.sbor.codec.CodecMap;
+import com.radixdlt.sbor.codec.StructCodec;
+import com.radixdlt.utils.UInt32;
 
-public final class REv2TransactionAndProofStore {
-  public REv2TransactionAndProofStore(Metrics metrics, NodeRustEnvironment nodeRustEnvironment) {
-    LabelledTimer<MethodId> timer = metrics.stateManager().nativeCall();
-    this.getTxnsAndProof =
-        Natives.builder(nodeRustEnvironment, REv2TransactionAndProofStore::getTxnsAndProof)
-            .measure(
-                timer.label(new MethodId(REv2TransactionAndProofStore.class, "getTxnsAndProof")))
-            .build(new TypeToken<>() {});
-    this.getLastProofFunc =
-        Natives.builder(nodeRustEnvironment, REv2TransactionAndProofStore::getLastProof)
-            .measure(timer.label(new MethodId(REv2TransactionAndProofStore.class, "getLastProof")))
-            .build(new TypeToken<>() {});
-    this.getPostGenesisEpochProofFunc =
-        Natives.builder(nodeRustEnvironment, REv2TransactionAndProofStore::getPostGenesisEpochProof)
-            .measure(
-                timer.label(
-                    new MethodId(REv2TransactionAndProofStore.class, "getPostGenesisEpochProof")))
-            .build(new TypeToken<>() {});
-    this.getEpochProofFunc =
-        Natives.builder(nodeRustEnvironment, REv2TransactionAndProofStore::getEpochProof)
-            .measure(timer.label(new MethodId(REv2TransactionAndProofStore.class, "getEpochProof")))
-            .build(new TypeToken<>() {});
+/**
+ * Limits regarding the granularity of ledger sync (and thus of ledger proofs kept in storage).
+ * These exist mostly to limit the size of P2P messages.
+ *
+ * @param maxTxnsForResponsesSpanningMoreThanOneProof Maximum number of transactions to return in a
+ *     single ledger sync response, but only if at least one proof can be used. In other words:
+ *     <ul>
+ *       <li>if the next proof covers more than {@link #maxTxnsForResponsesSpanningMoreThanOneProof}
+ *           transactions, then all those transactions can still be returned (given they fit under
+ *           the {@link #maxTxnBytesForSingleResponse} limit);
+ *       <li>if the next proof contains less than {@link
+ *           #maxTxnsForResponsesSpanningMoreThanOneProof} transactions, then its subsequent proof
+ *           can only be used if its transactions also fit under this limit.
+ *     </ul>
+ *
+ * @param maxTxnBytesForSingleResponse Maximum transactions size (in terms of their total byte size)
+ *     to return in a single ledger sync response.
+ */
+public record LedgerSyncLimitsConfig(
+    UInt32 maxTxnsForResponsesSpanningMoreThanOneProof, UInt32 maxTxnBytesForSingleResponse) {
+
+  private static final int DEFAULT_MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF = 1000;
+
+  private static final int DEFAULT_MAX_TXN_BYTES_FOR_SINGLE_RESPONSE = 12 * 1024 * 1024;
+
+  public static void registerCodec(CodecMap codecMap) {
+    codecMap.register(
+        LedgerSyncLimitsConfig.class,
+        codecs -> StructCodec.fromRecordComponents(LedgerSyncLimitsConfig.class, codecs));
   }
 
-  public Option<TxnsAndProof> getTxnsAndProof(
-      long startStateVersionInclusive, LedgerSyncLimitsConfig limitsConfig) {
-    return this.getTxnsAndProof.call(
-        new TxnsAndProofRequest(
-            UInt64.fromNonNegativeLong(startStateVersionInclusive), limitsConfig));
+  public static LedgerSyncLimitsConfig defaults() {
+    return new LedgerSyncLimitsConfig(
+        UInt32.fromNonNegativeInt(DEFAULT_MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF),
+        UInt32.fromNonNegativeInt(DEFAULT_MAX_TXN_BYTES_FOR_SINGLE_RESPONSE));
   }
-
-  public Optional<LedgerProof> getLastProof() {
-    return this.getLastProofFunc.call(Tuple.tuple()).toOptional();
-  }
-
-  public Optional<LedgerProof> getPostGenesisEpochProof() {
-    return this.getPostGenesisEpochProofFunc.call(Tuple.tuple()).toOptional();
-  }
-
-  public Optional<LedgerProof> getEpochProof(long epoch) {
-    return this.getEpochProofFunc.call(UInt64.fromNonNegativeLong(epoch)).toOptional();
-  }
-
-  private final Natives.Call1<TxnsAndProofRequest, Option<TxnsAndProof>> getTxnsAndProof;
-
-  private static native byte[] getTxnsAndProof(
-      NodeRustEnvironment nodeRustEnvironment, byte[] payload);
-
-  private final Natives.Call1<Tuple.Tuple0, Option<LedgerProof>> getLastProofFunc;
-
-  private static native byte[] getLastProof(
-      NodeRustEnvironment nodeRustEnvironment, byte[] payload);
-
-  private final Natives.Call1<Tuple.Tuple0, Option<LedgerProof>> getPostGenesisEpochProofFunc;
-
-  private static native byte[] getPostGenesisEpochProof(
-      NodeRustEnvironment nodeRustEnvironment, byte[] payload);
-
-  private final Natives.Call1<UInt64, Option<LedgerProof>> getEpochProofFunc;
-
-  private static native byte[] getEpochProof(
-      NodeRustEnvironment nodeRustEnvironment, byte[] payload);
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/REv2TransactionAndProofStore.java
@@ -73,7 +73,6 @@ import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.monitoring.Metrics.MethodId;
 import com.radixdlt.sbor.Natives;
 import com.radixdlt.statecomputer.commit.LedgerProof;
-import com.radixdlt.utils.UInt32;
 import com.radixdlt.utils.UInt64;
 import java.util.Optional;
 
@@ -101,15 +100,9 @@ public final class REv2TransactionAndProofStore {
             .build(new TypeToken<>() {});
   }
 
-  public Option<TxnsAndProof> getTxnsAndProof(
-      long startStateVersionInclusive,
-      int maxNumberOfTxnsIfMoreThanOneProof,
-      int maxPayloadSizeInBytes) {
+  public Option<TxnsAndProof> getTxnsAndProof(long startStateVersionInclusive) {
     return this.getTxnsAndProof.call(
-        new TxnsAndProofRequest(
-            UInt64.fromNonNegativeLong(startStateVersionInclusive),
-            UInt32.fromNonNegativeInt(maxNumberOfTxnsIfMoreThanOneProof),
-            UInt32.fromNonNegativeInt(maxPayloadSizeInBytes)));
+        new TxnsAndProofRequest(UInt64.fromNonNegativeLong(startStateVersionInclusive)));
   }
 
   public Optional<LedgerProof> getLastProof() {

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/TxnsAndProofRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/TxnsAndProofRequest.java
@@ -66,14 +66,10 @@ package com.radixdlt.transaction;
 
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.StructCodec;
-import com.radixdlt.utils.UInt32;
 import com.radixdlt.utils.UInt64;
 
 /** A request for listing a batch of transactions together with their proof. */
-public record TxnsAndProofRequest(
-    UInt64 startStateVersionInclusive,
-    UInt32 maxNumberOfTxnsIfMoreThanOneProof,
-    UInt32 maxPayloadSizeInBytes) {
+public record TxnsAndProofRequest(UInt64 startStateVersionInclusive) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         TxnsAndProofRequest.class,

--- a/core-rust-bridge/src/main/java/com/radixdlt/transaction/TxnsAndProofRequest.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/transaction/TxnsAndProofRequest.java
@@ -69,7 +69,8 @@ import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.utils.UInt64;
 
 /** A request for listing a batch of transactions together with their proof. */
-public record TxnsAndProofRequest(UInt64 startStateVersionInclusive) {
+public record TxnsAndProofRequest(
+    UInt64 startStateVersionInclusive, LedgerSyncLimitsConfig limitsConfig) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         TxnsAndProofRequest.class,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
@@ -30,6 +30,8 @@ pub(crate) async fn handle_lts_transaction_status(
         pending_transaction_result_cache.peek_all_known_payloads_for_intent(&intent_hash);
     drop(pending_transaction_result_cache);
 
+    // TODO(locks): consider this (and other) usages of DB "read current" lock. *Carefully* migrate
+    // all applicable ones to "historical, non-locked" DB access.
     let database = state.state_manager.database.read_current();
 
     if !database.is_local_transaction_execution_index_enabled() {

--- a/core-rust/jni-export/src/constants.rs
+++ b/core-rust/jni-export/src/constants.rs
@@ -70,6 +70,7 @@ use node_common::config::limits::{
     DEFAULT_MAX_TOTAL_VERTEX_EXECUTION_COST_UNITS_CONSUMED,
     DEFAULT_MAX_TOTAL_VERTEX_FINALIZATION_COST_UNITS_CONSUMED,
     DEFAULT_MAX_TOTAL_VERTEX_TRANSACTIONS_SIZE, DEFAULT_MAX_VERTEX_TRANSACTION_COUNT,
+    MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE,
 };
 use node_common::config::{
     DEFAULT_MEMPOOL_MAX_TOTAL_TRANSACTIONS_SIZE, DEFAULT_MEMPOOL_MAX_TRANSACTION_COUNT,
@@ -181,6 +182,17 @@ extern "system" fn Java_com_radixdlt_environment_NodeConstants_getMempoolTransac
 ) -> jbyteArray {
     jni_sbor_coded_call(&env, request_payload, |_: ()| {
         MEMPOOL_TRANSACTION_OVERHEAD_FACTOR_PERCENT
+    })
+}
+
+#[no_mangle]
+extern "system" fn Java_com_radixdlt_environment_NodeConstants_getMaxTransactionBytesInResponse(
+    env: JNIEnv,
+    _class: JClass,
+    request_payload: jbyteArray,
+) -> jbyteArray {
+    jni_sbor_coded_call(&env, request_payload, |_: ()| {
+        MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE
     })
 }
 

--- a/core-rust/jni-export/src/constants.rs
+++ b/core-rust/jni-export/src/constants.rs
@@ -70,7 +70,6 @@ use node_common::config::limits::{
     DEFAULT_MAX_TOTAL_VERTEX_EXECUTION_COST_UNITS_CONSUMED,
     DEFAULT_MAX_TOTAL_VERTEX_FINALIZATION_COST_UNITS_CONSUMED,
     DEFAULT_MAX_TOTAL_VERTEX_TRANSACTIONS_SIZE, DEFAULT_MAX_VERTEX_TRANSACTION_COUNT,
-    MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE,
 };
 use node_common::config::{
     DEFAULT_MEMPOOL_MAX_TOTAL_TRANSACTIONS_SIZE, DEFAULT_MEMPOOL_MAX_TRANSACTION_COUNT,
@@ -182,17 +181,6 @@ extern "system" fn Java_com_radixdlt_environment_NodeConstants_getMempoolTransac
 ) -> jbyteArray {
     jni_sbor_coded_call(&env, request_payload, |_: ()| {
         MEMPOOL_TRANSACTION_OVERHEAD_FACTOR_PERCENT
-    })
-}
-
-#[no_mangle]
-extern "system" fn Java_com_radixdlt_environment_NodeConstants_getMaxTransactionBytesInResponse(
-    env: JNIEnv,
-    _class: JClass,
-    request_payload: jbyteArray,
-) -> jbyteArray {
-    jni_sbor_coded_call(&env, request_payload, |_: ()| {
-        MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE
     })
 }
 

--- a/core-rust/node-common/src/config/limits.rs
+++ b/core-rust/node-common/src/config/limits.rs
@@ -72,20 +72,6 @@ pub const DEFAULT_MAX_TOTAL_VERTEX_EXECUTION_COST_UNITS_CONSUMED: u32 =
 pub const DEFAULT_MAX_TOTAL_VERTEX_FINALIZATION_COST_UNITS_CONSUMED: u32 =
     FINALIZATION_COST_UNIT_LIMIT * 2;
 
-/// Maximum number of transactions to return in a single "get transactions with their proof"
-/// response, but only if at least one proof can be used. In other words:
-/// - if the next proof covers more than [`MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF`]
-///   transactions, then all those transactions can still be returned (given they fit under the
-///   [`MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE`] limit);
-/// - if the next proof contains less than [`MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF`]
-///   transactions, then its subsequent proof can only be used if its transactions also fit under
-///   this limit.
-pub const MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF: u32 = 1000;
-
-/// Maximum transactions size (in terms of their total byte size) to return in a single "get
-/// transactions with their proof" response.
-pub const MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE: u32 = 12 * 1024 * 1024;
-
 #[derive(Debug, Clone, Copy, ScryptoSbor)]
 pub struct VertexLimitsConfig {
     pub max_transaction_count: u32,

--- a/core-rust/node-common/src/config/limits.rs
+++ b/core-rust/node-common/src/config/limits.rs
@@ -72,6 +72,20 @@ pub const DEFAULT_MAX_TOTAL_VERTEX_EXECUTION_COST_UNITS_CONSUMED: u32 =
 pub const DEFAULT_MAX_TOTAL_VERTEX_FINALIZATION_COST_UNITS_CONSUMED: u32 =
     FINALIZATION_COST_UNIT_LIMIT * 2;
 
+/// Maximum number of transactions to return in a single "get transactions with their proof"
+/// response, but only if at least one proof can be used. In other words:
+/// - if the next proof covers more than [`MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF`]
+///   transactions, then all those transactions can still be returned (given they fit under the
+///   [`MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE`] limit);
+/// - if the next proof contains less than [`MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF`]
+///   transactions, then its subsequent proof can only be used if its transactions also fit under
+///   this limit.
+pub const MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF: u32 = 1000;
+
+/// Maximum transactions size (in terms of their total byte size) to return in a single "get
+/// transactions with their proof" response.
+pub const MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE: u32 = 12 * 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, ScryptoSbor)]
 pub struct VertexLimitsConfig {
     pub max_transaction_count: u32,

--- a/core-rust/state-manager/src/jni/mod.rs
+++ b/core-rust/state-manager/src/jni/mod.rs
@@ -71,3 +71,16 @@ pub mod test_state_reader;
 pub mod transaction_preparer;
 pub mod transaction_store;
 pub mod vertex_store_recovery;
+
+use radix_engine::prelude::*;
+
+/// Limits regarding the granularity of ledger sync (and thus of ledger proofs kept in storage).
+/// This struct is defined publicly here, since it is used by the transaction store and the ledger
+/// proofs GC.
+/// Please see the Java counterpart (i.e. `record LedgerSyncLimitsConfig`) for detailed descriptions
+/// of the fields.
+#[derive(Debug, Categorize, Encode, Decode, Clone, Default)]
+pub struct LedgerSyncLimitsConfig {
+    pub max_txns_for_responses_spanning_more_than_one_proof: u32,
+    pub max_txn_bytes_for_single_response: u32,
+}

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -260,7 +260,9 @@ impl StateManager {
         // ... and for deleting the old, non-critical ledger proofs (a.k.a. "Proofs GC"):
         let ledger_proofs_gc =
             LedgerProofsGc::new(database.clone(), config.ledger_proofs_gc_config);
-        scheduler.start_periodic(ledger_proofs_gc.interval(), move || ledger_proofs_gc.run());
+        scheduler
+            .named("ledger_proofs_gc")
+            .start_periodic(ledger_proofs_gc.interval(), move || ledger_proofs_gc.run());
 
         Self {
             state_computer,

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -106,7 +106,8 @@ pub struct DatabaseBackendConfig {
     IterableTransactionStore,
     IterableProofStore,
     ExecutedGenesisScenarioStore,
-    StateHashTreeGcStore
+    StateHashTreeGcStore,
+    LedgerProofsGcStore
 )]
 pub enum StateManagerDatabase {
     // TODO(clean-up): After InMemoryDb was deleted, we can get rid of this middle-man as well.

--- a/core-rust/state-manager/src/store/jmt_gc.rs
+++ b/core-rust/state-manager/src/store/jmt_gc.rs
@@ -122,12 +122,9 @@ impl StateHashTreeGc {
 
     /// Performs a single GC run, which is supposed to permanently delete *all* old-enough state
     /// hash tree nodes marked as stale.
-    /// This can involve a large backlog (i.e. on the first GC run), so the implementation will
-    /// regularly release the database lock (see [`Self::max_db_locking_duration`]).
-    /// Note: despite the GC modifying the database, we only obtain the read lock. In theory, we
-    /// do not need any locking at all (since we only touch very old state, which no other logic
-    /// modifies), but our current "DB management" implementation requires obtaining some lock to
-    /// access the database at all.
+    /// Note: despite the GC modifying the database, we only obtain the "historical" state lock (in
+    /// practice: not locking anything at all). This is valid, since we do not rely on the current
+    /// state's consistency here.
     pub fn run(&self) {
         let database = self.database.access_non_locked_historical();
         // The line below technically reads the "current state" from a "non-locked, historical" DB;

--- a/core-rust/state-manager/src/store/mod.rs
+++ b/core-rust/state-manager/src/store/mod.rs
@@ -63,7 +63,8 @@
  */
 
 mod db;
-pub mod gc;
+pub mod jmt_gc;
+pub mod proofs_gc;
 mod rocks_db;
 pub mod traits;
 mod typed_cf_api;

--- a/core-rust/state-manager/src/store/proofs_gc.rs
+++ b/core-rust/state-manager/src/store/proofs_gc.rs
@@ -87,6 +87,9 @@ pub struct LedgerProofsGcConfig {
     /// How often to run the GC, in seconds.
     /// Since this GC operates with an epoch precision, we do not need to run more often than epoch
     /// changes.
+    // TODO(after having some event-driven Rust infra): The entire `LedgerProofsGc` could be
+    // migrated away from `Scheduler` into `EventListener<EpochChangeCommittedEvent>` (as noted
+    // above - it wants to run async exactly once after each epoch).
     pub interval_sec: u32,
     /// How many most recent *completed* epochs should be left not GC-ed.
     /// Please note that the current epoch is never GC-ed.
@@ -124,8 +127,8 @@ impl LedgerProofsGc {
         self.interval
     }
 
-    /// Performs a single GC run, which is supposed to permanently delete *all* old-enough state
-    /// hash tree nodes marked as stale.
+    /// Performs a single GC run, which is supposed to permanently delete *all* non-critical ledger
+    /// proofs of configured old-enough epochs.
     pub fn run(&self) {
         // TODO(locks/snapshots): The GC's operation does not interact with the "current state", and
         // intuitively could use the "historical, non-locked" DB access. However, we have a (very

--- a/core-rust/state-manager/src/store/proofs_gc.rs
+++ b/core-rust/state-manager/src/store/proofs_gc.rs
@@ -152,9 +152,15 @@ impl LedgerProofsGc {
             // Nothing to GC ever, yet.
             return;
         };
-        let progress_started_at: LedgerProofsGcProgress = read_progress_database
-            .get_progress()
-            .unwrap_or_else(LedgerProofsGcProgress::none);
+        let progress_started_at: LedgerProofsGcProgress =
+            read_progress_database.get_progress().unwrap_or_else(|| {
+                LedgerProofsGcProgress::new(
+                    read_progress_database
+                        .get_post_genesis_epoch_proof()
+                        .expect("we checked that there is some completed epoch above")
+                        .ledger_header,
+                )
+            });
         drop(read_progress_database);
 
         if progress_started_at.last_pruned_epoch >= to_epoch {

--- a/core-rust/state-manager/src/store/proofs_gc.rs
+++ b/core-rust/state-manager/src/store/proofs_gc.rs
@@ -1,0 +1,220 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+use radix_engine::types::{Categorize, Decode, Encode};
+
+use node_common::config::limits::{
+    MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF, MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE,
+};
+use radix_engine_common::types::Epoch;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{error, info};
+
+use crate::store::traits::gc::{
+    LedgerProofsGcProgress, LedgerProofsGcProgressV1, LedgerProofsGcStore,
+};
+use crate::store::traits::proofs::QueryableProofStore;
+
+use crate::store::StateManagerDatabase;
+
+use node_common::locks::StateLock;
+
+/// A configuration for [`LedgerProofsGc`].
+#[derive(Debug, Categorize, Encode, Decode, Clone, Default)]
+pub struct LedgerProofsGcConfig {
+    /// How often to run the GC, in seconds.
+    /// Since this GC operates with an epoch precision, we do not need to run more often than epoch
+    /// changes.
+    pub interval_sec: u32,
+    /// How many most recent *completed* epochs should be left not GC-ed.
+    /// Please note that the current epoch is never GC-ed.
+    pub most_recent_full_resolution_epoch_count: usize,
+}
+
+/// A garbage collector of sufficiently-old, non-critical ledger proofs.
+/// A ledger proof is "non-critical" when it is not listed by our "get transactions with their
+/// proof" logic (used e.g. for ledger-sync responses).
+/// The implementation is suited for being driven by an external scheduler.
+pub struct LedgerProofsGc {
+    database: Arc<StateLock<StateManagerDatabase>>,
+    interval: Duration,
+    most_recent_full_resolution_epoch_count: u64,
+}
+
+impl LedgerProofsGc {
+    /// Creates a new GC.
+    pub fn new(
+        database: Arc<StateLock<StateManagerDatabase>>,
+        config: LedgerProofsGcConfig,
+    ) -> Self {
+        Self {
+            database,
+            interval: Duration::from_secs(u64::from(config.interval_sec)),
+            most_recent_full_resolution_epoch_count: u64::try_from(
+                config.most_recent_full_resolution_epoch_count,
+            )
+            .unwrap(),
+        }
+    }
+
+    /// An interval between [`run()`]s, to be used by this instance's scheduler.
+    pub fn interval(&self) -> Duration {
+        self.interval
+    }
+
+    /// Performs a single GC run, which is supposed to permanently delete *all* old-enough state
+    /// hash tree nodes marked as stale.
+    pub fn run(&self) {
+        // TODO(locks/snapshots): The GC's operation does not interact with the "current state", and
+        // intuitively could use the "historical, non-locked" DB access. However, we have a (very
+        // related) use-case, which lists arbitrary past transactions and their proof - and it could
+        // happen that a concurrently-running GC deletes the very proof that has to be used to fit
+        // within the limits. For this reason, the logic below carefully acquires/releases the DB's
+        // read/write lock for relevant stages of the execution.
+        // A more robust solution should either use DB snapshots (a development direction we are
+        // considering anyway), or a more selective lock over the ledger proofs CF alone (or even
+        // over a selected *range* of the ledger proofs CF).
+
+        // Read the GC's persisted state and initialize the run:
+        let read_progress_database = self.database.read_current();
+        let to_epoch = read_progress_database
+            .max_epoch()
+            .map(|current_epoch| current_epoch.number())
+            .and_then(|current| current.checked_sub(self.most_recent_full_resolution_epoch_count))
+            .map(Epoch::of);
+        let Some(to_epoch) = to_epoch else {
+            // Nothing to GC ever, yet.
+            return;
+        };
+        let progress_started_at: LedgerProofsGcProgress = read_progress_database
+            .get_progress()
+            .unwrap_or_else(LedgerProofsGcProgress::none);
+        drop(read_progress_database);
+
+        if progress_started_at.last_pruned_epoch >= to_epoch {
+            // Nothing to GC during this run.
+            return;
+        }
+
+        info!(
+            "Starting a GC run: pruning ledger proofs up to epoch {}; current progress: {:?}",
+            to_epoch.number(),
+            progress_started_at,
+        );
+        let mut last_pruned_state_version = progress_started_at.epoch_proof_state_version;
+
+        let mut retained_proofs = 0; // only for logging purposes
+        loop {
+            let at_state_version = last_pruned_state_version
+                .next()
+                .expect("state version overflow");
+
+            // Locate the next proof that we need to retain. We use the same method and limits as
+            // the business logic responsible for outputting proven transactions:
+            let locate_proof_database = self.database.read_current();
+            let transactions_and_proof = locate_proof_database.get_txns_and_proof(
+                at_state_version,
+                MAX_TXNS_FOR_RESPONSES_SPANNING_MORE_THAN_ONE_PROOF,
+                MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE,
+            );
+            drop(locate_proof_database);
+
+            let Some((_transactions, proof)) = transactions_and_proof else {
+                error!(
+                    "A chain of transactions-without-proof from state version {} does not fit within the limits; aborting the GC",
+                    at_state_version,
+                );
+                return;
+            };
+            let header = proof.ledger_header;
+
+            // Delete all the proofs from the beginning of transactions listing up to (but
+            // excluding) the returned proof:
+            last_pruned_state_version = header.state_version;
+            let delete_database = self.database.read_current();
+            delete_database.delete_ledger_proofs_range(at_state_version, last_pruned_state_version);
+
+            retained_proofs += 1;
+            if let Some(next_epoch) = header.next_epoch {
+                info!(
+                    "Recording progress of pruned epoch {} (having {} retained proofs)",
+                    header.epoch.number(),
+                    retained_proofs
+                );
+                retained_proofs = 0;
+                delete_database.set_progress(LedgerProofsGcProgressV1 {
+                    last_pruned_epoch: header.epoch,
+                    epoch_proof_state_version: last_pruned_state_version,
+                });
+                if next_epoch.epoch >= to_epoch {
+                    break;
+                }
+            }
+            drop(delete_database);
+        }
+
+        info!("Ledger proofs' GC run finished");
+    }
+}

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -310,7 +310,7 @@ pub mod proofs {
     #[enum_dispatch]
     pub trait QueryableProofStore {
         fn max_state_version(&self) -> StateVersion;
-        fn max_epoch(&self) -> Option<Epoch> {
+        fn max_completed_epoch(&self) -> Option<Epoch> {
             self.get_last_epoch_proof()
                 .map(|proof| proof.ledger_header.epoch)
         }

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -630,6 +630,7 @@ pub mod measurement {
 
 pub mod gc {
     use super::*;
+    use crate::LedgerHeader;
     use radix_engine_common::types::Epoch;
     use radix_engine_stores::hash_tree::tree_store::NodeKey;
 
@@ -684,10 +685,11 @@ pub mod gc {
     }
 
     impl LedgerProofsGcProgressV1 {
-        pub fn none() -> Self {
+        /// Initializes the very first progress, which skips over the genesis.
+        pub fn new(post_genesis_ledger_header: LedgerHeader) -> Self {
             Self {
-                last_pruned_epoch: Epoch::zero(),
-                epoch_proof_state_version: StateVersion::pre_genesis(),
+                last_pruned_epoch: post_genesis_ledger_header.epoch,
+                epoch_proof_state_version: post_genesis_ledger_header.state_version,
             }
         }
     }

--- a/core/src/main/java/com/radixdlt/messaging/MessagingModule.java
+++ b/core/src/main/java/com/radixdlt/messaging/MessagingModule.java
@@ -76,6 +76,7 @@ import com.radixdlt.consensus.Vote;
 import com.radixdlt.consensus.sync.GetVerticesErrorResponse;
 import com.radixdlt.consensus.sync.GetVerticesRequest;
 import com.radixdlt.consensus.sync.GetVerticesResponse;
+import com.radixdlt.environment.NodeConstants;
 import com.radixdlt.environment.rx.RemoteEvent;
 import com.radixdlt.environment.rx.RxRemoteDispatcher;
 import com.radixdlt.environment.rx.RxRemoteEnvironment;
@@ -95,7 +96,6 @@ import com.radixdlt.p2p.discovery.PeersResponse;
 import com.radixdlt.p2p.liveness.Ping;
 import com.radixdlt.p2p.liveness.Pong;
 import com.radixdlt.p2p.transport.FrameCodec;
-import com.radixdlt.rev2.REv2TransactionsAndProofReader;
 import com.radixdlt.sync.messages.remote.LedgerStatusUpdate;
 import com.radixdlt.sync.messages.remote.StatusRequest;
 import com.radixdlt.sync.messages.remote.StatusResponse;
@@ -142,7 +142,7 @@ public final class MessagingModule extends AbstractModule {
     final var maxMessageSizeBaseline =
         Math.max(
             Math.max(
-                REv2TransactionsAndProofReader.MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE,
+                NodeConstants.MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE,
                 proposalMaxUncommittedTransactionsPayloadSize),
             mempoolRelayerMaxMessagePayloadSize);
 

--- a/core/src/main/java/com/radixdlt/messaging/MessagingModule.java
+++ b/core/src/main/java/com/radixdlt/messaging/MessagingModule.java
@@ -71,12 +71,10 @@ import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.radixdlt.consensus.Proposal;
-import com.radixdlt.consensus.ProposalMaxUncommittedTransactionsPayloadSize;
 import com.radixdlt.consensus.Vote;
 import com.radixdlt.consensus.sync.GetVerticesErrorResponse;
 import com.radixdlt.consensus.sync.GetVerticesRequest;
 import com.radixdlt.consensus.sync.GetVerticesResponse;
-import com.radixdlt.environment.NodeConstants;
 import com.radixdlt.environment.rx.RemoteEvent;
 import com.radixdlt.environment.rx.RxRemoteDispatcher;
 import com.radixdlt.environment.rx.RxRemoteEnvironment;
@@ -101,6 +99,7 @@ import com.radixdlt.sync.messages.remote.StatusRequest;
 import com.radixdlt.sync.messages.remote.StatusResponse;
 import com.radixdlt.sync.messages.remote.SyncRequest;
 import com.radixdlt.sync.messages.remote.SyncResponse;
+import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 import com.radixdlt.utils.properties.RuntimeProperties;
 import io.reactivex.rxjava3.core.Flowable;
 import org.apache.logging.log4j.LogManager;
@@ -136,14 +135,11 @@ public final class MessagingModule extends AbstractModule {
   @Provides
   @MaxMessageSize
   private int maxMessageSize(
-      @ProposalMaxUncommittedTransactionsPayloadSize
-          int proposalMaxUncommittedTransactionsPayloadSize,
-      @MempoolRelayerMaxMessagePayloadSize int mempoolRelayerMaxMessagePayloadSize) {
+      @MempoolRelayerMaxMessagePayloadSize int mempoolRelayerMaxMessagePayloadSize,
+      LedgerSyncLimitsConfig ledgerSyncLimitsConfig) {
     final var maxMessageSizeBaseline =
         Math.max(
-            Math.max(
-                NodeConstants.MAX_TXN_BYTES_FOR_A_SINGLE_RESPONSE,
-                proposalMaxUncommittedTransactionsPayloadSize),
+            ledgerSyncLimitsConfig.maxTxnBytesForSingleResponse().toInt(),
             mempoolRelayerMaxMessagePayloadSize);
 
     // 30% should be more than enough for any vertex/QCs/proofs

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
@@ -104,6 +104,7 @@ public final class REv2StateManagerModule extends AbstractModule {
   private final Option<RustMempoolConfig> mempoolConfig;
   private final boolean debugLogging;
   private final StateHashTreeGcConfig stateHashTreeGcConfig;
+  private final LedgerProofsGcConfig ledgerProofsGcConfig;
   private final boolean noFees;
 
   private REv2StateManagerModule(
@@ -113,6 +114,7 @@ public final class REv2StateManagerModule extends AbstractModule {
       Option<RustMempoolConfig> mempoolConfig,
       boolean debugLogging,
       StateHashTreeGcConfig stateHashTreeGcConfig,
+      LedgerProofsGcConfig ledgerProofsGcConfig,
       boolean noFees) {
     this.proposalLimitsConfig = proposalLimitsConfig;
     this.vertexLimitsConfigOpt = vertexLimitsConfigOpt;
@@ -120,6 +122,7 @@ public final class REv2StateManagerModule extends AbstractModule {
     this.mempoolConfig = mempoolConfig;
     this.debugLogging = debugLogging;
     this.stateHashTreeGcConfig = stateHashTreeGcConfig;
+    this.ledgerProofsGcConfig = ledgerProofsGcConfig;
     this.noFees = noFees;
   }
 
@@ -128,7 +131,8 @@ public final class REv2StateManagerModule extends AbstractModule {
       VertexLimitsConfig vertexLimitsConfig,
       DatabaseFlags databaseFlags,
       Option<RustMempoolConfig> mempoolConfig,
-      StateHashTreeGcConfig stateHashTreeGcConfig) {
+      StateHashTreeGcConfig stateHashTreeGcConfig,
+      LedgerProofsGcConfig ledgerProofsGcConfig) {
     return new REv2StateManagerModule(
         proposalLimitsConfig,
         Option.some(vertexLimitsConfig),
@@ -136,6 +140,7 @@ public final class REv2StateManagerModule extends AbstractModule {
         mempoolConfig,
         false,
         stateHashTreeGcConfig,
+        ledgerProofsGcConfig,
         false);
   }
 
@@ -145,6 +150,7 @@ public final class REv2StateManagerModule extends AbstractModule {
       Option<RustMempoolConfig> mempoolConfig,
       boolean debugLogging,
       StateHashTreeGcConfig stateHashTreeGcConfig,
+      LedgerProofsGcConfig ledgerProofsGcConfig,
       boolean noFees) {
     return new REv2StateManagerModule(
         proposalLimitsConfig,
@@ -153,6 +159,7 @@ public final class REv2StateManagerModule extends AbstractModule {
         mempoolConfig,
         debugLogging,
         stateHashTreeGcConfig,
+        ledgerProofsGcConfig,
         noFees);
   }
 
@@ -194,6 +201,7 @@ public final class REv2StateManagerModule extends AbstractModule {
                     databaseFlags,
                     getLoggingConfig(),
                     stateHashTreeGcConfig,
+                    ledgerProofsGcConfig,
                     noFees));
           }
 

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
@@ -90,6 +90,7 @@ import com.radixdlt.statecomputer.RustStateComputer;
 import com.radixdlt.store.NodeStorageLocation;
 import com.radixdlt.sync.TransactionsAndProofReader;
 import com.radixdlt.testutil.TestStateReader;
+import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 import com.radixdlt.transaction.REv2TransactionAndProofStore;
 import com.radixdlt.transactions.NotarizedTransactionHash;
 import com.radixdlt.transactions.PreparedNotarizedTransaction;
@@ -105,6 +106,7 @@ public final class REv2StateManagerModule extends AbstractModule {
   private final boolean debugLogging;
   private final StateHashTreeGcConfig stateHashTreeGcConfig;
   private final LedgerProofsGcConfig ledgerProofsGcConfig;
+  private final LedgerSyncLimitsConfig ledgerSyncLimitsConfig;
   private final boolean noFees;
 
   private REv2StateManagerModule(
@@ -115,6 +117,7 @@ public final class REv2StateManagerModule extends AbstractModule {
       boolean debugLogging,
       StateHashTreeGcConfig stateHashTreeGcConfig,
       LedgerProofsGcConfig ledgerProofsGcConfig,
+      LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
       boolean noFees) {
     this.proposalLimitsConfig = proposalLimitsConfig;
     this.vertexLimitsConfigOpt = vertexLimitsConfigOpt;
@@ -123,6 +126,7 @@ public final class REv2StateManagerModule extends AbstractModule {
     this.debugLogging = debugLogging;
     this.stateHashTreeGcConfig = stateHashTreeGcConfig;
     this.ledgerProofsGcConfig = ledgerProofsGcConfig;
+    this.ledgerSyncLimitsConfig = ledgerSyncLimitsConfig;
     this.noFees = noFees;
   }
 
@@ -132,7 +136,8 @@ public final class REv2StateManagerModule extends AbstractModule {
       DatabaseFlags databaseFlags,
       Option<RustMempoolConfig> mempoolConfig,
       StateHashTreeGcConfig stateHashTreeGcConfig,
-      LedgerProofsGcConfig ledgerProofsGcConfig) {
+      LedgerProofsGcConfig ledgerProofsGcConfig,
+      LedgerSyncLimitsConfig ledgerSyncLimitsConfig) {
     return new REv2StateManagerModule(
         proposalLimitsConfig,
         Option.some(vertexLimitsConfig),
@@ -141,6 +146,7 @@ public final class REv2StateManagerModule extends AbstractModule {
         false,
         stateHashTreeGcConfig,
         ledgerProofsGcConfig,
+        ledgerSyncLimitsConfig,
         false);
   }
 
@@ -151,6 +157,7 @@ public final class REv2StateManagerModule extends AbstractModule {
       boolean debugLogging,
       StateHashTreeGcConfig stateHashTreeGcConfig,
       LedgerProofsGcConfig ledgerProofsGcConfig,
+      LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
       boolean noFees) {
     return new REv2StateManagerModule(
         proposalLimitsConfig,
@@ -160,6 +167,7 @@ public final class REv2StateManagerModule extends AbstractModule {
         debugLogging,
         stateHashTreeGcConfig,
         ledgerProofsGcConfig,
+        ledgerSyncLimitsConfig,
         noFees);
   }
 
@@ -169,7 +177,7 @@ public final class REv2StateManagerModule extends AbstractModule {
     bind(REv2TransactionsAndProofReader.class).in(Scopes.SINGLETON);
     bind(TransactionsAndProofReader.class).to(REv2TransactionsAndProofReader.class);
     bind(DatabaseFlags.class).toInstance(databaseFlags);
-
+    bind(LedgerSyncLimitsConfig.class).toInstance(ledgerSyncLimitsConfig);
     install(proposalLimitsConfig.asModule());
 
     install(
@@ -202,6 +210,7 @@ public final class REv2StateManagerModule extends AbstractModule {
                     getLoggingConfig(),
                     stateHashTreeGcConfig,
                     ledgerProofsGcConfig,
+                    ledgerSyncLimitsConfig,
                     noFees));
           }
 

--- a/core/src/test-core/java/com/radixdlt/harness/predicates/NodePredicate.java
+++ b/core/src/test-core/java/com/radixdlt/harness/predicates/NodePredicate.java
@@ -160,8 +160,7 @@ public class NodePredicate {
   }
 
   public static Predicate<Injector> atOrOverEpoch(long epoch) {
-    return i ->
-        i.getInstance(TestStateReader.class).getEpoch().toNonNegativeLong().unwrap() >= epoch;
+    return i -> i.getInstance(TestStateReader.class).getEpoch() >= epoch;
   }
 
   public static Predicate<Injector> bftAtOrOverRound(Round round) {

--- a/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
@@ -423,6 +423,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         rev2Config.debugLogging(),
                         rev2Config.stateHashTreeGcConfig(),
                         rev2Config.ledgerProofsGcConfig(),
+                        rev2Config.ledgerSyncLimitsConfig(),
                         rev2Config.noFees()));
               }
               case REV2ProposerConfig.Mempool mempool -> {
@@ -438,6 +439,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         rev2Config.debugLogging(),
                         rev2Config.stateHashTreeGcConfig(),
                         rev2Config.ledgerProofsGcConfig(),
+                        rev2Config.ledgerSyncLimitsConfig(),
                         rev2Config.noFees()));
               }
             }

--- a/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
@@ -422,6 +422,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         Option.none(),
                         rev2Config.debugLogging(),
                         rev2Config.stateHashTreeGcConfig(),
+                        rev2Config.ledgerProofsGcConfig(),
                         rev2Config.noFees()));
               }
               case REV2ProposerConfig.Mempool mempool -> {
@@ -436,6 +437,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         Option.some(mempool.mempoolConfig()),
                         rev2Config.debugLogging(),
                         rev2Config.stateHashTreeGcConfig(),
+                        rev2Config.ledgerProofsGcConfig(),
                         rev2Config.noFees()));
               }
             }

--- a/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
+++ b/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
@@ -81,6 +81,7 @@ import com.radixdlt.harness.simulation.application.TransactionGenerator;
 import com.radixdlt.mempool.MempoolReceiverConfig;
 import com.radixdlt.mempool.MempoolRelayerConfig;
 import com.radixdlt.mempool.RustMempoolConfig;
+import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -152,6 +153,7 @@ public sealed interface StateComputerConfig {
         debugLogging,
         StateHashTreeGcConfig.forTesting(),
         LedgerProofsGcConfig.forTesting(),
+        LedgerSyncLimitsConfig.defaults(),
         noFees);
   }
 
@@ -168,6 +170,7 @@ public sealed interface StateComputerConfig {
         false,
         StateHashTreeGcConfig.forTesting(),
         LedgerProofsGcConfig.forTesting(),
+        LedgerSyncLimitsConfig.defaults(),
         false);
   }
 
@@ -181,6 +184,7 @@ public sealed interface StateComputerConfig {
         false,
         StateHashTreeGcConfig.forTesting(),
         LedgerProofsGcConfig.forTesting(),
+        LedgerSyncLimitsConfig.defaults(),
         false);
   }
 
@@ -251,6 +255,7 @@ public sealed interface StateComputerConfig {
       boolean debugLogging,
       StateHashTreeGcConfig stateHashTreeGcConfig,
       LedgerProofsGcConfig ledgerProofsGcConfig,
+      LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
       boolean noFees)
       implements StateComputerConfig {}
 

--- a/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
+++ b/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
@@ -74,6 +74,7 @@ import com.radixdlt.consensus.liveness.ProposerElection;
 import com.radixdlt.consensus.liveness.ProposerElections;
 import com.radixdlt.consensus.liveness.WeightedRotatingLeaders;
 import com.radixdlt.environment.DatabaseFlags;
+import com.radixdlt.environment.LedgerProofsGcConfig;
 import com.radixdlt.environment.StateHashTreeGcConfig;
 import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.harness.simulation.application.TransactionGenerator;
@@ -150,6 +151,7 @@ public sealed interface StateComputerConfig {
         proposerConfig,
         debugLogging,
         StateHashTreeGcConfig.forTesting(),
+        LedgerProofsGcConfig.forTesting(),
         noFees);
   }
 
@@ -165,6 +167,7 @@ public sealed interface StateComputerConfig {
         proposerConfig,
         false,
         StateHashTreeGcConfig.forTesting(),
+        LedgerProofsGcConfig.forTesting(),
         false);
   }
 
@@ -177,6 +180,7 @@ public sealed interface StateComputerConfig {
         proposerConfig,
         false,
         StateHashTreeGcConfig.forTesting(),
+        LedgerProofsGcConfig.forTesting(),
         false);
   }
 
@@ -246,6 +250,7 @@ public sealed interface StateComputerConfig {
       REV2ProposerConfig proposerConfig,
       boolean debugLogging,
       StateHashTreeGcConfig stateHashTreeGcConfig,
+      LedgerProofsGcConfig ledgerProofsGcConfig,
       boolean noFees)
       implements StateComputerConfig {}
 

--- a/core/src/test/java/com/radixdlt/api/core/TransactionStreamTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/TransactionStreamTest.java
@@ -333,21 +333,22 @@ public class TransactionStreamTest extends DeterministicCoreApiTestBase {
                       .fromStateVersion(1L));
       assertThat(firstPartResponse.getProofs()).isNull();
 
-      var firstPartResponseWithProofs =
-          getStreamApi()
-              .streamTransactionsPost(
-                  new StreamTransactionsRequest()
-                      .network(networkLogicalName)
-                      .includeProofs(true)
-                      .limit(100)
-                      .fromStateVersion(1L));
-
       // An async "proofs pruning" is supposed to run over the genesis' epoch...
       Awaitility.await()
           .atMost(2, TimeUnit.SECONDS)
-          // ... leaving 9 (out of original 13) ledger proofs.
           .untilAsserted(
-              () -> assertThat(firstPartResponseWithProofs.getProofs().size()).isEqualTo(9));
+              () -> {
+                var firstPartResponseWithProofs =
+                    getStreamApi()
+                        .streamTransactionsPost(
+                            new StreamTransactionsRequest()
+                                .network(networkLogicalName)
+                                .includeProofs(true)
+                                .limit(100)
+                                .fromStateVersion(1L));
+                // ... leaving 9 (out of original 13) ledger proofs.
+                assertThat(firstPartResponseWithProofs.getProofs().size()).isEqualTo(9);
+              });
 
       var firstPartCommittedTransactions = firstPartResponse.getTransactions();
 

--- a/core/src/test/java/com/radixdlt/rev2/LedgerProofsGcTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/LedgerProofsGcTest.java
@@ -155,11 +155,11 @@ public final class LedgerProofsGcTest {
 
   @Test
   public void node_retains_enough_proofs_to_cover_max_transaction_size_in_old_enough_epochs() {
-    /// 6 rounds * 100 KB = 600KB
+    /// 6 rounds * 1 KB = 6KB
     var roundsPerEpoch = 6;
-    var txnSize = 100 * 1024;
-    /// Limit is 400 KB - so we require 2 proofs to cover 600 KB
-    var maxTxnPayloadSizeUnderProof = 400 * 1024; // cannot be much lower due to genesis' size
+    var txnSize = 1024;
+    /// Limit is 4 KB - so we require 2 proofs to cover 6 KB
+    var maxTxnPayloadSizeUnderProof = 4 * 1024; // the genesis is larger than that, but gets skipped
     try (var test = createTest(2, roundsPerEpoch, txnSize, 1000, maxTxnPayloadSizeUnderProof)) {
       test.startNode(0);
 

--- a/core/src/test/java/com/radixdlt/rev2/REv2IncreasingEpochTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2IncreasingEpochTest.java
@@ -112,17 +112,11 @@ public class REv2IncreasingEpochTest {
       // Arrange: Start single node network
       test.startAllNodes();
       var stateReader = test.getInstance(0, TestStateReader.class);
-      var epoch0 = stateReader.getEpoch().toNonNegativeLong().unwrap();
+      var epoch0 = stateReader.getEpoch();
 
       // Act/Assert: Run until next epoch is reached
       test.runUntilMessage(DeterministicTest.epochLedgerUpdate(epoch0 + 2), 1000);
-      assertThat(
-              test.getNodeInjectors()
-                  .get(0)
-                  .getInstance(TestStateReader.class)
-                  .getEpoch()
-                  .toNonNegativeLong()
-                  .unwrap())
+      assertThat(test.getNodeInjectors().get(0).getInstance(TestStateReader.class).getEpoch())
           .isGreaterThanOrEqualTo(epoch0 + 2);
     }
   }

--- a/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
@@ -97,6 +97,7 @@ import com.radixdlt.rev2.modules.REv2StateManagerModule;
 import com.radixdlt.statecomputer.commit.ActiveValidatorInfo;
 import com.radixdlt.statecomputer.commit.LedgerHeader;
 import com.radixdlt.store.NodeStorageLocation;
+import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 import com.radixdlt.transaction.REv2TransactionAndProofStore;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import com.radixdlt.utils.UInt192;
@@ -125,6 +126,7 @@ public class REv2StateComputerTest {
             false,
             StateHashTreeGcConfig.forTesting(),
             LedgerProofsGcConfig.forTesting(),
+            LedgerSyncLimitsConfig.defaults(),
             false),
         new REv2LedgerInitializerModule(
             RawGenesisDataWithHash.fromGenesisData(

--- a/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
@@ -75,10 +75,7 @@ import com.radixdlt.consensus.ProposalLimitsConfig;
 import com.radixdlt.consensus.bft.*;
 import com.radixdlt.consensus.liveness.ProposerElection;
 import com.radixdlt.consensus.vertexstore.VertexStoreState;
-import com.radixdlt.environment.DatabaseFlags;
-import com.radixdlt.environment.EventDispatcher;
-import com.radixdlt.environment.FatalPanicHandler;
-import com.radixdlt.environment.StateHashTreeGcConfig;
+import com.radixdlt.environment.*;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.genesis.GenesisData;
@@ -127,6 +124,7 @@ public class REv2StateComputerTest {
             Option.none(),
             false,
             StateHashTreeGcConfig.forTesting(),
+            LedgerProofsGcConfig.forTesting(),
             false),
         new REv2LedgerInitializerModule(
             RawGenesisDataWithHash.fromGenesisData(

--- a/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
@@ -127,6 +127,7 @@ public final class RustMempoolTest {
             new DatabaseFlags(false, false),
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
+            LedgerProofsGcConfig.forTesting(),
             false);
     final var metrics = new MetricsInitializer().initialize();
 
@@ -182,6 +183,7 @@ public final class RustMempoolTest {
             new DatabaseFlags(false, false),
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
+            LedgerProofsGcConfig.forTesting(),
             false);
     final var metrics = new MetricsInitializer().initialize();
 
@@ -320,6 +322,7 @@ public final class RustMempoolTest {
             new DatabaseFlags(false, false),
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
+            LedgerProofsGcConfig.forTesting(),
             false);
     final var metrics = new MetricsInitializer().initialize();
 

--- a/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
@@ -76,6 +76,7 @@ import com.radixdlt.mempool.*;
 import com.radixdlt.monitoring.MetricsInitializer;
 import com.radixdlt.serialization.DefaultSerialization;
 import com.radixdlt.statecomputer.RustStateComputer;
+import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 import com.radixdlt.transaction.REv2TransactionAndProofStore;
 import com.radixdlt.transactions.PreparedNotarizedTransaction;
 import com.radixdlt.transactions.RawNotarizedTransaction;
@@ -109,7 +110,8 @@ public final class RustMempoolTest {
             new Blake2b256Hasher(DefaultSerialization.getInstance()),
             new RustStateComputer(metrics, nodeRustEnvironment),
             new REv2TransactionsAndProofReader(
-                new REv2TransactionAndProofStore(metrics, nodeRustEnvironment)))
+                new REv2TransactionAndProofStore(metrics, nodeRustEnvironment),
+                LedgerSyncLimitsConfig.defaults()))
         .initialize(genesisProvider);
   }
 
@@ -128,6 +130,7 @@ public final class RustMempoolTest {
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
             LedgerProofsGcConfig.forTesting(),
+            LedgerSyncLimitsConfig.defaults(),
             false);
     final var metrics = new MetricsInitializer().initialize();
 
@@ -184,6 +187,7 @@ public final class RustMempoolTest {
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
             LedgerProofsGcConfig.forTesting(),
+            LedgerSyncLimitsConfig.defaults(),
             false);
     final var metrics = new MetricsInitializer().initialize();
 
@@ -323,6 +327,7 @@ public final class RustMempoolTest {
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
             LedgerProofsGcConfig.forTesting(),
+            LedgerSyncLimitsConfig.defaults(),
             false);
     final var metrics = new MetricsInitializer().initialize();
 

--- a/core/src/test/java/com/radixdlt/rev2/StateHashTreeGcTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/StateHashTreeGcTest.java
@@ -87,6 +87,7 @@ import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
 import com.radixdlt.networks.Network;
 import com.radixdlt.sync.TransactionsAndProofReader;
 import com.radixdlt.testutil.TestStateReader;
+import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 import com.radixdlt.utils.UInt32;
 import com.radixdlt.utils.UInt64;
 import java.util.function.Predicate;
@@ -123,6 +124,7 @@ public final class StateHashTreeGcTest {
                             UInt32.fromNonNegativeInt(1),
                             UInt64.fromNonNegativeLong(stateVersionHistoryLength)),
                         LedgerProofsGcConfig.forTesting(),
+                        LedgerSyncLimitsConfig.defaults(),
                         false))));
   }
 


### PR DESCRIPTION
Addresses https://docs.google.com/spreadsheets/d/1JPiisoLFOhrDBT1-qDj2uvVwIsojKQd8kHzf1CIhaFw/edit#gid=0&range=B15

The implementation here is quite similar to the "JMT GC", with notable exceptions:
- This GC goes epoch-by-epoch (not version-by-version)
  - This is because we do not want to prune the current epoch, which is still "live" (i.e. asking which proofs are critical gives different answers over time, until the epoch ends)
- This GC had no pre-existing "progress-tracking" CF (i.e. we don't have "stale proofs" CF)
  - Instead, I had to introduce the new, dedicated "proofs GC progress" CF, to persist the progress between runs.
- This GC _cannot_ use "historical, non-locked" DB access - it fully locks for read and write instead!
  - Please see the comment in the code for details
  - In general, I now think that our "DB locking" was rather naive from the beginning, and even the current "current vs historical state lock" is too weak to model all our data access dependencies. This GC works _fine_, but we should discuss locking more soon.