### PR TITLE
Making sure entire Core API treats tip percentage as u16

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -1469,8 +1469,8 @@ components:
           type: integer
           format: int32
           minimum: 0
-          maximum: 255
-          description: An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+          maximum: 65535
+          description: An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
     NetworkIdentifierByte:
       description: The logical id of the network
       type: integer
@@ -1771,8 +1771,8 @@ components:
           type: integer
           format: int32
           minimum: 0
-          maximum: 255
-          description: An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+          maximum: 65535
+          description: An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
     FeeSource:
       type: object
       required:
@@ -6963,8 +6963,8 @@ components:
           type: integer
           format: int32
           minimum: 0
-          maximum: 255
-          description: An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+          maximum: 65535
+          description: An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
         nonce:
           type: integer
           format: int64

--- a/core-rust/core-api-server/src/core_api/generated/models/costing_parameters.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/costing_parameters.rs
@@ -34,7 +34,7 @@ pub struct CostingParameters {
     /// The string-encoded decimal representing the price of 1 byte of storage, expressed in XRD. A decimal is formed of some signed integer `m` of attos (`10^(-18)`) units, where `-2^(192 - 1) <= m < 2^(192 - 1)`. 
     #[serde(rename = "xrd_storage_price")]
     pub xrd_storage_price: String,
-    /// An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+    /// An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
     #[serde(rename = "tip_percentage")]
     pub tip_percentage: i32,
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_header.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_header.rs
@@ -30,7 +30,7 @@ pub struct TransactionHeader {
     /// Specifies whether the notary public key should be included in the transaction signers list
     #[serde(rename = "notary_is_signatory")]
     pub notary_is_signatory: bool,
-    /// An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+    /// An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
     #[serde(rename = "tip_percentage")]
     pub tip_percentage: i32,
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/transaction_preview_request.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/transaction_preview_request.rs
@@ -33,7 +33,7 @@ pub struct TransactionPreviewRequest {
     /// Whether the notary should count as a signatory (optional, default false)
     #[serde(rename = "notary_is_signatory", skip_serializing_if = "Option::is_none")]
     pub notary_is_signatory: Option<bool>,
-    /// An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+    /// An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
     #[serde(rename = "tip_percentage")]
     pub tip_percentage: i32,
     /// An integer between `0` and `2^32 - 1`, chosen to allow a unique intent to be created (to enable submitting an otherwise identical/duplicate intent). 

--- a/core-rust/state-manager/src/mempool/priority_mempool.rs
+++ b/core-rust/state-manager/src/mempool/priority_mempool.rs
@@ -302,7 +302,6 @@ impl PriorityMempool {
         if !to_be_removed.is_empty() {
             let best_to_be_removed = to_be_removed.last().unwrap();
             if new_order_data < MempoolDataProposalPriorityOrdering(best_to_be_removed.clone()) {
-                // Note: update when DEFAULT_MAX_TIP_PERCENTAGE is changed/overwriten
                 let min_tip_percentage_required = best_to_be_removed
                     .transaction
                     .tip_percentage()

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/CostingParameters.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/CostingParameters.java
@@ -263,13 +263,13 @@ public class CostingParameters {
   }
 
    /**
-   * An integer between &#x60;0&#x60; and &#x60;255&#x60;, giving the validator tip as a percentage amount. A value of &#x60;1&#x60; corresponds to 1% of the fee.
+   * An integer between &#x60;0&#x60; and &#x60;65535&#x60;, giving the validator tip as a percentage amount. A value of &#x60;1&#x60; corresponds to 1% of the fee.
    * minimum: 0
-   * maximum: 255
+   * maximum: 65535
    * @return tipPercentage
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.")
+  @ApiModelProperty(required = true, value = "An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.")
   @JsonProperty(JSON_PROPERTY_TIP_PERCENTAGE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionHeader.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionHeader.java
@@ -236,13 +236,13 @@ public class TransactionHeader {
   }
 
    /**
-   * An integer between &#x60;0&#x60; and &#x60;255&#x60;, giving the validator tip as a percentage amount. A value of &#x60;1&#x60; corresponds to 1% of the fee.
+   * An integer between &#x60;0&#x60; and &#x60;65535&#x60;, giving the validator tip as a percentage amount. A value of &#x60;1&#x60; corresponds to 1% of the fee.
    * minimum: 0
-   * maximum: 255
+   * maximum: 65535
    * @return tipPercentage
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.")
+  @ApiModelProperty(required = true, value = "An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.")
   @JsonProperty(JSON_PROPERTY_TIP_PERCENTAGE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionPreviewRequest.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/TransactionPreviewRequest.java
@@ -290,13 +290,13 @@ public class TransactionPreviewRequest {
   }
 
    /**
-   * An integer between &#x60;0&#x60; and &#x60;255&#x60;, giving the validator tip as a percentage amount. A value of &#x60;1&#x60; corresponds to 1% of the fee.
+   * An integer between &#x60;0&#x60; and &#x60;65535&#x60;, giving the validator tip as a percentage amount. A value of &#x60;1&#x60; corresponds to 1% of the fee.
    * minimum: 0
-   * maximum: 255
+   * maximum: 65535
    * @return tipPercentage
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.")
+  @ApiModelProperty(required = true, value = "An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.")
   @JsonProperty(JSON_PROPERTY_TIP_PERCENTAGE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 

--- a/sdk/typescript/lib/generated/models/CostingParameters.ts
+++ b/sdk/typescript/lib/generated/models/CostingParameters.ts
@@ -66,7 +66,7 @@ export interface CostingParameters {
      */
     xrd_storage_price: string;
     /**
-     * An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+     * An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
      * @type {number}
      * @memberof CostingParameters
      */

--- a/sdk/typescript/lib/generated/models/TransactionHeader.ts
+++ b/sdk/typescript/lib/generated/models/TransactionHeader.ts
@@ -65,7 +65,7 @@ export interface TransactionHeader {
      */
     notary_is_signatory: boolean;
     /**
-     * An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+     * An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
      * @type {number}
      * @memberof TransactionHeader
      */

--- a/sdk/typescript/lib/generated/models/TransactionPreviewRequest.ts
+++ b/sdk/typescript/lib/generated/models/TransactionPreviewRequest.ts
@@ -81,7 +81,7 @@ export interface TransactionPreviewRequest {
      */
     notary_is_signatory?: boolean;
     /**
-     * An integer between `0` and `255`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
+     * An integer between `0` and `65535`, giving the validator tip as a percentage amount. A value of `1` corresponds to 1% of the fee.
      * @type {number}
      * @memberof TransactionPreviewRequest
      */


### PR DESCRIPTION
Addresses https://docs.google.com/spreadsheets/d/1JPiisoLFOhrDBT1-qDj2uvVwIsojKQd8kHzf1CIhaFw/edit#gid=0&range=B13

I haven't found any references to `u8` in the code itself - just the apidocs.