### PR TITLE
Making Scheduler facade configurable + Adding metrics capability to it

### DIFF
--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -1454,7 +1454,7 @@ mod tests {
             None,
             &lock_factory,
             &metrics_registry,
-            &Scheduler::for_testing(),
+            &Scheduler::new("testing"),
         );
 
         let proof = state_manager

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -1344,7 +1344,7 @@ mod tests {
     };
     use node_common::config::limits::VertexLimitsConfig;
     use node_common::locks::LockFactory;
-    use node_common::scheduler::NoopScheduler;
+    use node_common::scheduler::Scheduler;
     use prometheus::Registry;
     use radix_engine_common::prelude::NetworkDefinition;
     use radix_engine_common::types::{Epoch, Round};
@@ -1454,7 +1454,7 @@ mod tests {
             None,
             &lock_factory,
             &metrics_registry,
-            &NoopScheduler,
+            &Scheduler::for_testing(),
         );
 
         let proof = state_manager

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -143,7 +143,7 @@ impl StateManager {
         mempool_relay_dispatcher: Option<MempoolRelayDispatcher>,
         lock_factory: &LockFactory,
         metrics_registry: &Registry,
-        scheduler: &impl Scheduler,
+        scheduler: &Scheduler,
     ) -> Self {
         let mempool_config = match config.mempool_config {
             Some(mempool_config) => mempool_config,
@@ -239,16 +239,20 @@ impl StateManager {
         // Register the periodic background task for collecting the costly raw DB metrics...
         let raw_db_metrics_collector =
             RawDbMetricsCollector::new(database.clone(), metrics_registry);
-        scheduler.start_periodic(RAW_DB_MEASUREMENT_INTERVAL, move || {
-            raw_db_metrics_collector.run()
-        });
+        scheduler
+            .named("raw_db_measurement")
+            .start_periodic(RAW_DB_MEASUREMENT_INTERVAL, move || {
+                raw_db_metrics_collector.run()
+            });
 
         // ... and for deleting the stale state hash tree nodes (a.k.a. "JMT GC"):
         let state_hash_tree_gc =
             StateHashTreeGc::new(database.clone(), config.state_hash_tree_gc_config);
-        scheduler.start_periodic(state_hash_tree_gc.interval(), move || {
-            state_hash_tree_gc.run()
-        });
+        scheduler
+            .named("state_hash_tree_gc")
+            .start_periodic(state_hash_tree_gc.interval(), move || {
+                state_hash_tree_gc.run()
+            });
 
         Self {
             state_computer,

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -65,7 +65,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use node_common::scheduler::Scheduler;
+use node_common::scheduler::{Metrics, Scheduler, Spawner, Tracker};
 use node_common::{
     config::{limits::VertexLimitsConfig, MempoolConfig},
     locks::*,
@@ -143,7 +143,7 @@ impl StateManager {
         mempool_relay_dispatcher: Option<MempoolRelayDispatcher>,
         lock_factory: &LockFactory,
         metrics_registry: &Registry,
-        scheduler: &Scheduler,
+        scheduler: &Scheduler<impl Spawner, impl Tracker, impl Metrics>,
     ) -> Self {
         let mempool_config = match config.mempool_config {
             Some(mempool_config) => mempool_config,

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -135,7 +135,7 @@ mod tests {
 
     use crate::{PreviewRequest, StateManager, StateManagerConfig};
     use node_common::locks::LockFactory;
-    use node_common::scheduler::NoopScheduler;
+    use node_common::scheduler::Scheduler;
     use prometheus::Registry;
     use transaction::builder::ManifestBuilder;
     use transaction::model::{MessageV1, PreviewFlags};
@@ -150,7 +150,7 @@ mod tests {
             None,
             &lock_factory,
             &metrics_registry,
-            &NoopScheduler,
+            &Scheduler::for_testing(),
         );
 
         state_manager

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -150,7 +150,7 @@ mod tests {
             None,
             &lock_factory,
             &metrics_registry,
-            &Scheduler::for_testing(),
+            &Scheduler::new("testing"),
         );
 
         state_manager


### PR DESCRIPTION
This is a sibling of https://github.com/radixdlt/babylon-node/pull/722 but for our `Scheduler` facade.

Unsurprisingly, the configuration API shape follows the approach we took in `LockFactory` facade. One notable difference comes from the “task tracker” (i.e. having to keep handles to the tasks in order to stop them at the right time).

The new metrics preview:
```
# HELP rn_scheduler_task_execute_seconds Time spent executing a single run of a specific task.
# TYPE rn_scheduler_task_execute_seconds histogram
rn_scheduler_task_execute_seconds_bucket{task="rn.raw_db_measurement",le="0.001"} 25
rn_scheduler_task_execute_seconds_bucket{task="rn.raw_db_measurement",le="0.005"} 26
rn_scheduler_task_execute_seconds_bucket{task="rn.raw_db_measurement",le="0.02"} 26
rn_scheduler_task_execute_seconds_bucket{task="rn.raw_db_measurement",le="0.1"} 26
rn_scheduler_task_execute_seconds_bucket{task="rn.raw_db_measurement",le="0.5"} 26
rn_scheduler_task_execute_seconds_bucket{task="rn.raw_db_measurement",le="2"} 26
rn_scheduler_task_execute_seconds_bucket{task="rn.raw_db_measurement",le="5"} 26
rn_scheduler_task_execute_seconds_bucket{task="rn.raw_db_measurement",le="+Inf"} 26
rn_scheduler_task_execute_seconds_sum{task="rn.raw_db_measurement"} 0.005004584
rn_scheduler_task_execute_seconds_count{task="rn.raw_db_measurement"} 26
rn_scheduler_task_execute_seconds_bucket{task="rn.state_hash_tree_gc",le="0.001"} 0
rn_scheduler_task_execute_seconds_bucket{task="rn.state_hash_tree_gc",le="0.005"} 0
rn_scheduler_task_execute_seconds_bucket{task="rn.state_hash_tree_gc",le="0.02"} 0
rn_scheduler_task_execute_seconds_bucket{task="rn.state_hash_tree_gc",le="0.1"} 0
rn_scheduler_task_execute_seconds_bucket{task="rn.state_hash_tree_gc",le="0.5"} 5
rn_scheduler_task_execute_seconds_bucket{task="rn.state_hash_tree_gc",le="2"} 5
rn_scheduler_task_execute_seconds_bucket{task="rn.state_hash_tree_gc",le="5"} 5
rn_scheduler_task_execute_seconds_bucket{task="rn.state_hash_tree_gc",le="+Inf"} 5
rn_scheduler_task_execute_seconds_sum{task="rn.state_hash_tree_gc"} 1.633424375
rn_scheduler_task_execute_seconds_count{task="rn.state_hash_tree_gc"} 5
```