### PR TITLE
Adding `getAccountDepositBehaviour()` call to TS SDK

### DIFF
--- a/sdk/typescript/lib/index.ts
+++ b/sdk/typescript/lib/index.ts
@@ -52,12 +52,12 @@ export class CoreApiClient {
       state: new StateApi(configuration),
       status: new StatusApi(configuration),
       stream: new StreamApi(configuration),
-      transaction: new TransactionApi(configuration),      
+      transaction: new TransactionApi(configuration),
     };
     this.lts = new LTS(this.lowLevel.lts, logicalNetworkName);
     this.LTS = this.lts; // NOTE: this is to keep backwards compatibility
-    this.mempool = new Mempool(this.lowLevel.mempool)
-    this.state = new State(this.lowLevel.state)
+    this.mempool = new Mempool(this.lowLevel.mempool);
+    this.state = new State(this.lowLevel.state);
     this.status = new Status(this.lowLevel.status, logicalNetworkName);
     this.stream = new Stream(this.lowLevel.stream);
     this.transaction = new Transaction(this.lowLevel.transaction);

--- a/sdk/typescript/lib/subapis/lts.ts
+++ b/sdk/typescript/lib/subapis/lts.ts
@@ -3,6 +3,7 @@ import {
   LtsCommittedTransactionOutcome,
   LtsStateAccountAllFungibleResourceBalancesRequest,
   LtsStateAccountAllFungibleResourceBalancesResponse,
+  LtsStateAccountDepositBehaviourResponse,
   LtsStateAccountFungibleResourceBalanceRequest,
   LtsStateAccountFungibleResourceBalanceResponse,
   LtsStreamAccountTransactionOutcomesRequest,
@@ -69,6 +70,26 @@ export class LTS {
       }
     }
     return response;
+  }
+
+  /**
+   * Checks whether the given account is currently configured to accept the deposits of the given
+   * resources - in other words, this method returns whether such `try_deposit()` call would be
+   * successful, and why.
+   *
+   * @returns Details on the account's settings related to accepting deposits.
+   */
+  public async getAccountDepositBehaviour(
+    targetAccountAddress: string,
+    depositedResourceAddresses: Array<string>
+  ): Promise<LtsStateAccountDepositBehaviourResponse> {
+    return this.innerClient.ltsStateAccountDepositBehaviourPost({
+      ltsStateAccountDepositBehaviourRequest: {
+        network: this.logicalNetworkName,
+        account_address: targetAccountAddress,
+        resource_addresses: depositedResourceAddresses,
+      },
+    });
   }
 
   /**

--- a/sdk/typescript/lib/subapis/mempool.ts
+++ b/sdk/typescript/lib/subapis/mempool.ts
@@ -4,5 +4,5 @@ import { MempoolApi } from "../generated";
  * Wraps the lower-level `MempoolApi` - which can be accessed with `innerClient` for advanced use cases.
  */
 export class Mempool {
-    constructor(public innerClient: MempoolApi) {}
+  constructor(public innerClient: MempoolApi) {}
 }

--- a/sdk/typescript/lib/subapis/state.ts
+++ b/sdk/typescript/lib/subapis/state.ts
@@ -4,5 +4,5 @@ import { StateApi } from "../generated";
  * Wraps the lower-level `StateApi` - which can be accessed with `innerClient` for advanced use cases.
  */
 export class State {
-    constructor(public innerClient: StateApi) {}
+  constructor(public innerClient: StateApi) {}
 }

--- a/sdk/typescript/lib/subapis/stream.ts
+++ b/sdk/typescript/lib/subapis/stream.ts
@@ -4,5 +4,5 @@ import { StreamApi } from "../generated";
  * Wraps the lower-level `StreamApi` - which can be accessed with `innerClient` for advanced use cases.
  */
 export class Stream {
-    constructor(public innerClient: StreamApi) {}
+  constructor(public innerClient: StreamApi) {}
 }

--- a/sdk/typescript/lib/subapis/transaction.ts
+++ b/sdk/typescript/lib/subapis/transaction.ts
@@ -4,5 +4,5 @@ import { TransactionApi } from "../generated";
  * Wraps the lower-level `TransactionApi` - which can be accessed with `innerClient` for advanced use cases.
  */
 export class Transaction {
-    constructor(public innerClient: TransactionApi) {}
+  constructor(public innerClient: TransactionApi) {}
 }

--- a/sdk/typescript/tests/lts.test.ts
+++ b/sdk/typescript/tests/lts.test.ts
@@ -45,6 +45,18 @@ test('can get construction metadata', async () => {
     expect(response.ledger_clock.unix_timestamp_ms).toBeGreaterThanOrEqual(Date.now() - 60 * 1000);
 });
 
+test('can get account deposit behaviour', async () => {
+    const coreApiClient = await newCoreApiClient();
+    const xrdResource = "resource_loc1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxvq32hv";
+    let response = await coreApiClient.LTS.getAccountDepositBehaviour(
+        "account_loc168yqmxxkzmrzv9knya9865me9qktk43rqfuwdy9fq9rlk7a682gzva", [xrdResource]
+    );
+    expect(response.default_deposit_rule).toBe("Accept");
+    let xrdResponse = response.resource_specific_behaviours![xrdResource];
+    expect(xrdResponse.is_xrd).toBe(true);
+    expect(xrdResponse.allows_try_deposit).toBe(true);
+});
+
 test('submit unparsable transaction errors', async () => {
     const coreApiClient = await newCoreApiClient();
     const invalidTransactionPayload = "00";


### PR DESCRIPTION
Just for completeness of the "submit transaction" example at https://github.com/radixdlt/typescript-radix-engine-toolkit/blob/a6b420b2719d16ce20d401db240e5518aae25fc9/examples/core-e2e-example/main.ts#L145

Some unrelated files were touched as a result of `npm run lint`.