### PR TITLE
Impl for Programmatic JSON deserializer

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +127,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bech32"
@@ -308,7 +323,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
+ "iana-time-zone",
  "num-traits",
+ "serde",
+ "winapi",
 ]
 
 [[package]]
@@ -384,6 +402,7 @@ dependencies = [
  "sbor",
  "serde",
  "serde_json",
+ "serde_with",
  "state-manager",
  "tokio",
  "tower",
@@ -392,6 +411,12 @@ dependencies = [
  "transaction",
  "utils",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -458,6 +483,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +528,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -836,6 +906,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +956,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1452,6 +1552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +2138,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2455,35 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
+]
+
+[[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -2809,6 +2978,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -41,7 +41,7 @@ prometheus = { version = "0.13.2", default-features = false, features = [] }
 blake2 = { version = "0.10.6", default-features = false }
 serde = { version = "1.0.81", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
-
+serde_with = { version = "2.3.0", features = ["hex"] }
 [profile.dev]
 opt-level = 3
 

--- a/core-rust/core-api-server/Cargo.toml
+++ b/core-rust/core-api-server/Cargo.toml
@@ -25,6 +25,7 @@ prometheus = { workspace = true }
 blake2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_with = { workspace = true }
 itertools = { workspace = true }
 
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }

--- a/core-rust/core-api-server/src/core_api/conversions/errors.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/errors.rs
@@ -115,6 +115,9 @@ pub enum ExtractionError {
     },
     InvalidFieldAlternativesUsage,
     InvalidSemverString,
+    InvalidProgrammaticJson {
+        message: String,
+    },
 }
 
 impl ExtractionError {

--- a/core-rust/core-api-server/src/core_api/mod.rs
+++ b/core-rust/core-api-server/src/core_api/mod.rs
@@ -72,6 +72,7 @@ mod helpers;
 mod metrics;
 mod metrics_layer;
 mod paging;
+mod programmatic_json;
 mod server;
 
 #[allow(unused)]
@@ -86,6 +87,7 @@ pub(crate) use errors::*;
 pub(crate) use extractors::*;
 pub(crate) use helpers::*;
 pub(crate) use paging::*;
+pub(crate) use programmatic_json::*;
 pub(crate) use server::{create_server, CoreApiServerConfig, CoreApiState};
 
 pub(crate) mod models {

--- a/core-rust/core-api-server/src/core_api/programmatic_json.rs
+++ b/core-rust/core-api-server/src/core_api/programmatic_json.rs
@@ -1,0 +1,515 @@
+use radix_engine::types::*;
+
+use sbor::representations::{SerializationMode, SerializationParameters};
+use serde::Deserialize;
+use serde_with::serde_as;
+
+use super::*;
+
+/// Encoder of SBOR values to schema-aware Programmatic JSON format.
+pub struct ProgrammaticJsonEncoder<'a> {
+    address_encoder: &'a AddressBech32Encoder,
+}
+
+impl<'a> ProgrammaticJsonEncoder<'a> {
+    /// Creates an instance which will use the given context (for address encoding).
+    pub fn new(mapping_context: &'a MappingContext) -> Self {
+        Self {
+            address_encoder: &mapping_context.address_encoder,
+        }
+    }
+
+    /// Encodes the given SBOR bytes to Programmatic JSON (returned as `serde` JSON tree), using the
+    /// given schema/type information for human-readable field and type names.
+    pub fn encode(
+        &self,
+        payload_bytes: Vec<u8>,
+        schema: &SchemaV1<ScryptoCustomSchema>,
+        type_id: LocalTypeId,
+    ) -> Result<serde_json::Value, MappingError> {
+        let raw_payload = RawScryptoPayload::new_from_valid_owned(payload_bytes);
+        let serializable = raw_payload.serializable(SerializationParameters::WithSchema {
+            mode: SerializationMode::Programmatic,
+            custom_context: ScryptoValueDisplayContext::with_optional_bech32(Some(
+                self.address_encoder,
+            )),
+            schema,
+            type_id,
+            depth_limit: SCRYPTO_SBOR_V1_MAX_DEPTH,
+        });
+        serde_json::to_value(serializable).map_err(|_error| MappingError::SubstateValue {
+            bytes: raw_payload.payload_bytes().to_vec(),
+            message: "cannot render as programmatic json".to_string(),
+        })
+    }
+}
+
+/// Decoder of Programmatic JSON format to SBOR values.
+pub struct ProgrammaticJsonDecoder<'a> {
+    address_decoder: &'a AddressBech32Decoder,
+}
+
+impl<'a> ProgrammaticJsonDecoder<'a> {
+    /// Creates an instance which will use the given context (for address decoding).
+    pub fn new(extraction_context: &'a ExtractionContext) -> Self {
+        Self {
+            address_decoder: &extraction_context.address_decoder,
+        }
+    }
+
+    /// Encodes the Programmatic JSON (given as `serde` JSON tree) to SBOR bytes.
+    /// Please note that schema/type information is not required for decoding (unlike
+    /// [`ProgrammaticJsonEncoder::encode`]).
+    pub fn decode(&self, json_value: serde_json::Value) -> Result<Vec<u8>, ExtractionError> {
+        let value = serde_json::from_value::<ProgrammaticScryptoValue>(json_value)
+            .map_err(|_error| ExtractionError::InvalidProgrammaticJson {
+                message: "while building SBOR struct from serde value".to_string(),
+            })?
+            .extract_scrypto_value(self.address_decoder)?;
+        scrypto_encode(&value).map_err(|_error| ExtractionError::InvalidProgrammaticJson {
+            message: "while encoding SBOR struct to bytes".to_string(),
+        })
+    }
+}
+
+// IMPLEMENTATION NOTE:
+//
+// At the time of writing this, the Engine did not offer any decoding support for the programmatic
+// JSON format. The rest of our implementation below is based on the RET's approach captured at the
+// exact linked version:
+//
+// https://github.com/radixdlt/radix-engine-toolkit/blob/9eb4b6f14bbad89ea24afbd7f17977cae1c6d6ae/radix-engine-toolkit-core/src/functions/scrypto_sbor.rs#L92
+// (with majority of logic hidden within serde annotation on `ProgrammaticScryptoValue` struct)
+//
+// The adjustments made here:
+// - Removed the `serde`'s `Serialize` support (we use the Engine's impl for serialization and only
+//   want to implement `Deserialize` here).
+// - Re-worked error detection (and surfacing) related to "network HRP mismatch" on addresses
+//   contained within JSON tree:
+//   - Mostly needed to accommodate the Node's usage of `AddressBech32Decoder`.
+//   - This was achieved by "parsing" the `NodeId` to untouched string, i.e. deferring the bech32m
+//     decoding to another step taking place after `serde`.
+// - Added the "roundtrip serialize/deserialize" test (to ensure compatibility with Engine's
+//   serialization) and the "network HRP mismatch" test.
+
+#[serde_as]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(tag = "kind")]
+pub enum ProgrammaticScryptoValue {
+    Bool {
+        value: bool,
+    },
+    I8 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: i8,
+    },
+    I16 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: i16,
+    },
+    I32 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: i32,
+    },
+    I64 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: i64,
+    },
+    I128 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: i128,
+    },
+    U8 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: u8,
+    },
+    U16 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: u16,
+    },
+    U32 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: u32,
+    },
+    U64 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: u64,
+    },
+    U128 {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: u128,
+    },
+    String {
+        value: String,
+    },
+    Enum {
+        #[serde(rename = "variant_id")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        discriminator: u8,
+        fields: Vec<ProgrammaticScryptoValue>,
+    },
+    Array {
+        #[serde(rename = "element_kind")]
+        element_value_kind: ProgrammaticScryptoValueKind,
+        elements: Vec<ProgrammaticScryptoValue>,
+    },
+    Tuple {
+        fields: Vec<ProgrammaticScryptoValue>,
+    },
+    Map {
+        #[serde(rename = "key_kind")]
+        key_value_kind: ProgrammaticScryptoValueKind,
+        #[serde(rename = "value_kind")]
+        value_value_kind: ProgrammaticScryptoValueKind,
+        #[serde_as(as = "Vec<serde_with::FromInto<MapEntry<ProgrammaticScryptoValue>>>")]
+        entries: Vec<(ProgrammaticScryptoValue, ProgrammaticScryptoValue)>,
+    },
+    Reference {
+        value: SerializableNodeId,
+    },
+    Own {
+        value: SerializableNodeId,
+    },
+    Decimal {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: Decimal,
+    },
+    PreciseDecimal {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: PreciseDecimal,
+    },
+    NonFungibleLocalId {
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: NonFungibleLocalId,
+    },
+    Bytes {
+        #[serde(rename = "element_kind")]
+        element_value_kind: ProgrammaticScryptoValueKind,
+
+        #[serde_as(as = "serde_with::hex::Hex")]
+        #[serde(rename = "hex")]
+        value: Vec<u8>,
+    },
+}
+
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ProgrammaticScryptoValueKind {
+    Bool,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    String,
+    Enum,
+    Array,
+    Tuple,
+    Map,
+    Reference,
+    Own,
+    Decimal,
+    PreciseDecimal,
+    NonFungibleLocalId,
+}
+
+impl From<ProgrammaticScryptoValueKind> for ScryptoValueKind {
+    fn from(value: ProgrammaticScryptoValueKind) -> Self {
+        match value {
+            ProgrammaticScryptoValueKind::Bool => Self::Bool,
+            ProgrammaticScryptoValueKind::I8 => Self::I8,
+            ProgrammaticScryptoValueKind::I16 => Self::I16,
+            ProgrammaticScryptoValueKind::I32 => Self::I32,
+            ProgrammaticScryptoValueKind::I64 => Self::I64,
+            ProgrammaticScryptoValueKind::I128 => Self::I128,
+            ProgrammaticScryptoValueKind::U8 => Self::U8,
+            ProgrammaticScryptoValueKind::U16 => Self::U16,
+            ProgrammaticScryptoValueKind::U32 => Self::U32,
+            ProgrammaticScryptoValueKind::U64 => Self::U64,
+            ProgrammaticScryptoValueKind::U128 => Self::U128,
+            ProgrammaticScryptoValueKind::String => Self::String,
+            ProgrammaticScryptoValueKind::Enum => Self::Enum,
+            ProgrammaticScryptoValueKind::Array => Self::Array,
+            ProgrammaticScryptoValueKind::Tuple => Self::Tuple,
+            ProgrammaticScryptoValueKind::Map => Self::Map,
+            ProgrammaticScryptoValueKind::Reference => {
+                Self::Custom(ScryptoCustomValueKind::Reference)
+            }
+            ProgrammaticScryptoValueKind::Own => Self::Custom(ScryptoCustomValueKind::Own),
+            ProgrammaticScryptoValueKind::Decimal => Self::Custom(ScryptoCustomValueKind::Decimal),
+            ProgrammaticScryptoValueKind::PreciseDecimal => {
+                Self::Custom(ScryptoCustomValueKind::PreciseDecimal)
+            }
+            ProgrammaticScryptoValueKind::NonFungibleLocalId => {
+                Self::Custom(ScryptoCustomValueKind::NonFungibleLocalId)
+            }
+        }
+    }
+}
+
+impl From<ScryptoValueKind> for ProgrammaticScryptoValueKind {
+    fn from(value: ScryptoValueKind) -> Self {
+        match value {
+            ScryptoValueKind::Bool => Self::Bool,
+            ScryptoValueKind::I8 => Self::I8,
+            ScryptoValueKind::I16 => Self::I16,
+            ScryptoValueKind::I32 => Self::I32,
+            ScryptoValueKind::I64 => Self::I64,
+            ScryptoValueKind::I128 => Self::I128,
+            ScryptoValueKind::U8 => Self::U8,
+            ScryptoValueKind::U16 => Self::U16,
+            ScryptoValueKind::U32 => Self::U32,
+            ScryptoValueKind::U64 => Self::U64,
+            ScryptoValueKind::U128 => Self::U128,
+            ScryptoValueKind::String => Self::String,
+            ScryptoValueKind::Enum => Self::Enum,
+            ScryptoValueKind::Array => Self::Array,
+            ScryptoValueKind::Tuple => Self::Tuple,
+            ScryptoValueKind::Map => Self::Map,
+            ScryptoValueKind::Custom(ScryptoCustomValueKind::Reference) => Self::Reference,
+            ScryptoValueKind::Custom(ScryptoCustomValueKind::Own) => Self::Own,
+            ScryptoValueKind::Custom(ScryptoCustomValueKind::Decimal) => Self::Decimal,
+            ScryptoValueKind::Custom(ScryptoCustomValueKind::PreciseDecimal) => {
+                Self::PreciseDecimal
+            }
+            ScryptoValueKind::Custom(ScryptoCustomValueKind::NonFungibleLocalId) => {
+                Self::NonFungibleLocalId
+            }
+        }
+    }
+}
+
+impl ProgrammaticScryptoValue {
+    pub fn extract_scrypto_value(
+        &self,
+        address_decoder: &AddressBech32Decoder,
+    ) -> Result<ScryptoValue, ExtractionError> {
+        Ok(match self {
+            Self::Bool { value } => ScryptoValue::Bool { value: *value },
+            Self::I8 { value } => ScryptoValue::I8 { value: *value },
+            Self::I16 { value } => ScryptoValue::I16 { value: *value },
+            Self::I32 { value } => ScryptoValue::I32 { value: *value },
+            Self::I64 { value } => ScryptoValue::I64 { value: *value },
+            Self::I128 { value } => ScryptoValue::I128 { value: *value },
+            Self::U8 { value } => ScryptoValue::U8 { value: *value },
+            Self::U16 { value } => ScryptoValue::U16 { value: *value },
+            Self::U32 { value } => ScryptoValue::U32 { value: *value },
+            Self::U64 { value } => ScryptoValue::U64 { value: *value },
+            Self::U128 { value } => ScryptoValue::U128 { value: *value },
+            Self::String { value } => ScryptoValue::String {
+                value: value.clone(),
+            },
+            Self::Enum {
+                discriminator,
+                fields,
+            } => ScryptoValue::Enum {
+                discriminator: *discriminator,
+                fields: fields
+                    .iter()
+                    .map(|field| field.extract_scrypto_value(address_decoder))
+                    .collect::<Result<Vec<_>, _>>()?,
+            },
+            Self::Array {
+                element_value_kind,
+                elements,
+            } => ScryptoValue::Array {
+                element_value_kind: (*element_value_kind).into(),
+                elements: elements
+                    .iter()
+                    .map(|field| field.extract_scrypto_value(address_decoder))
+                    .collect::<Result<Vec<_>, _>>()?,
+            },
+            Self::Tuple { fields } => ScryptoValue::Tuple {
+                fields: fields
+                    .iter()
+                    .map(|field| field.extract_scrypto_value(address_decoder))
+                    .collect::<Result<Vec<_>, _>>()?,
+            },
+            Self::Map {
+                key_value_kind,
+                value_value_kind,
+                entries,
+            } => ScryptoValue::Map {
+                key_value_kind: (*key_value_kind).into(),
+                value_value_kind: (*value_value_kind).into(),
+                entries: entries
+                    .iter()
+                    .map(|(key, value)| {
+                        Ok::<_, ExtractionError>((
+                            key.extract_scrypto_value(address_decoder)?,
+                            value.extract_scrypto_value(address_decoder)?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            },
+            Self::Reference { value } => ScryptoValue::Custom {
+                value: ScryptoCustomValue::Reference(Reference(value.to_node_id(address_decoder)?)),
+            },
+            Self::Own { value } => ScryptoValue::Custom {
+                value: ScryptoCustomValue::Own(Own(value.to_node_id(address_decoder)?)),
+            },
+            Self::Decimal { value } => ScryptoValue::Custom {
+                value: ScryptoCustomValue::Decimal(*value),
+            },
+            Self::PreciseDecimal { value } => ScryptoValue::Custom {
+                value: ScryptoCustomValue::PreciseDecimal(*value),
+            },
+            Self::NonFungibleLocalId { value } => ScryptoValue::Custom {
+                value: ScryptoCustomValue::NonFungibleLocalId(value.clone()),
+            },
+            Self::Bytes {
+                element_value_kind,
+                value,
+            } => ScryptoValue::Array {
+                element_value_kind: (*element_value_kind).into(),
+                elements: value
+                    .iter()
+                    .map(|value| ScryptoValue::U8 { value: *value })
+                    .collect(),
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+pub struct MapEntry<T> {
+    pub key: T,
+    pub value: T,
+}
+
+impl<T> From<(T, T)> for MapEntry<T> {
+    fn from((key, value): (T, T)) -> Self {
+        Self { key, value }
+    }
+}
+
+impl<T> From<MapEntry<T>> for (T, T) {
+    fn from(value: MapEntry<T>) -> Self {
+        (value.key, value.value)
+    }
+}
+
+#[serde_as]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(transparent)]
+pub struct SerializableNodeId {
+    pub address: String,
+}
+
+impl SerializableNodeId {
+    pub fn to_node_id(
+        &self,
+        address_decoder: &AddressBech32Decoder,
+    ) -> Result<NodeId, ExtractionError> {
+        address_decoder
+            .validate_and_decode(self.address.as_str())
+            .ok()
+            .and_then(|(_entity_type, bytes)| bytes.try_into().ok())
+            .map(NodeId)
+            .ok_or(ExtractionError::InvalidAddress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use radix_engine::blueprints::consensus_manager::{
+        ActiveValidatorSet, ConsensusManagerBlueprint,
+        ConsensusManagerCurrentValidatorSetFieldPayload, ConsensusManagerCurrentValidatorSetV1,
+        Validator, VersionedConsensusManagerCurrentValidatorSet,
+    };
+
+    #[test]
+    fn decodes_exactly_what_was_encoded() {
+        // just some hardcoded knowledge of the struct's schema: (needed by programmatic json format)
+        let schema = ConsensusManagerBlueprint::definition()
+            .schema
+            .schema
+            .into_latest();
+        let type_id = LocalTypeId::SchemaLocalIndex(12);
+        let network = NetworkDefinition::mainnet(); // exact value irrelevant
+
+        // the struct to perform the round-trip with:
+        let original_payload = ConsensusManagerCurrentValidatorSetFieldPayload {
+            content: VersionedConsensusManagerCurrentValidatorSet::V1(
+                ConsensusManagerCurrentValidatorSetV1 {
+                    validator_set: ActiveValidatorSet {
+                        validators_by_stake_desc: indexmap!(
+                            ComponentAddress::new_or_panic(
+                                [EntityType::GlobalValidator as u8; 30]
+                            ) => Validator {
+                                key: Secp256k1PublicKey([7; 33]),
+                                stake: dec!("13.37")
+                            }
+                        ),
+                    },
+                },
+            ),
+        };
+
+        // struct -> sbor_bytes -> serde JSON :
+        let original_bytes = scrypto_encode(&original_payload).unwrap();
+        let json_value = ProgrammaticJsonEncoder::new(&MappingContext::new(&network))
+            .encode(original_bytes.clone(), &schema, type_id)
+            .unwrap();
+
+        // serde JSON -> sbor_bytes -> struct:
+        let retrieved_bytes = ProgrammaticJsonDecoder::new(&ExtractionContext::new(&network))
+            .decode(json_value)
+            .unwrap();
+        let retrieved_payload =
+            scrypto_decode::<ConsensusManagerCurrentValidatorSetFieldPayload>(&retrieved_bytes)
+                .unwrap();
+
+        // assert the struct survived the round-trip:
+        assert_eq!(retrieved_payload, original_payload);
+        assert_eq!(retrieved_bytes, original_bytes); // must pass if the above is successful, but still let's assert
+    }
+
+    #[test]
+    fn non_matching_network_causes_error_when_decoding_address_within_programmatic_json() {
+        // just some hardcoded knowledge of the struct's schema: (needed by programmatic json format)
+        let schema = ConsensusManagerBlueprint::definition()
+            .schema
+            .schema
+            .into_latest();
+        let type_id = LocalTypeId::SchemaLocalIndex(12);
+
+        // the struct with address:
+        let original_payload = ConsensusManagerCurrentValidatorSetFieldPayload {
+            content: VersionedConsensusManagerCurrentValidatorSet::V1(
+                ConsensusManagerCurrentValidatorSetV1 {
+                    validator_set: ActiveValidatorSet {
+                        validators_by_stake_desc: indexmap!(
+                            ComponentAddress::new_or_panic(
+                                [EntityType::GlobalValidator as u8; 30]
+                            ) => Validator {
+                                key: Secp256k1PublicKey([7; 33]),
+                                stake: dec!("13.37")
+                            }
+                        ),
+                    },
+                },
+            ),
+        };
+
+        // serialize and expect error on deserialization:
+        let original_bytes = scrypto_encode(&original_payload).unwrap();
+        let json_value =
+            ProgrammaticJsonEncoder::new(&MappingContext::new(&NetworkDefinition::nebunet()))
+                .encode(original_bytes.clone(), &schema, type_id)
+                .unwrap();
+        let error =
+            ProgrammaticJsonDecoder::new(&ExtractionContext::new(&NetworkDefinition::ansharnet()))
+                .decode(json_value)
+                .err()
+                .unwrap();
+
+        // assert the error's type
+        assert!(matches!(error, ExtractionError::InvalidAddress));
+    }
+}


### PR DESCRIPTION
⚠️ This builds on top of https://github.com/radixdlt/babylon-node/pull/744 and ultimately wants to merge into `feature/browse_api` _(not `develop`!)_.

This is in the "Browse API" PR-chain, but actually it is a pretty generic feature:
- Implemented Programmatic JSON **deser**ializer 
  - We need it now (yeah for Browse API), and Engine does not offer one (they only serialize)
  - The impl is stolen from RET (and then heavily adjusted for Node's specifics; but not beyond recognition)
  - The plan is to either move this impl to Engine (or implement the same on the Engine's side), and we'll then be able to remove this code from Node (and maybe even from RET?)
- created the Programmatic JSON **ser**ializer facade
  - Just so that it can live next to the **deser**ializer
  - ofc it is only facading the Engine's serialization impl
  - it is used to test the **deser**ializer for compatibility with Engine's **ser**ializer (the "round-trip codec test")

Note: The **ser**ializer facade is used right away, but the **deser**ializer is currently unused (and rightfully produces warnings) [except in tests]; it will soon be used by Browse API's "lookup kv store/collection" endpoints.