### PR TITLE
Another approach to fixing the invalid key range calculation of a deleted partition

### DIFF
--- a/core-rust/state-manager/src/store/typed_cf_api.rs
+++ b/core-rust/state-manager/src/store/typed_cf_api.rs
@@ -227,6 +227,16 @@ impl<'db, 'wb, K, V, KC: DbCodec<K> + 'db, VC: DbCodec<V> + 'db, CF: TypedCf<K, 
             .delete(self.cf_handle, self.key_codec.encode(key));
     }
 
+    /// Deletes the entries from the given key range.
+    /// Follows the classic convention of "from inclusive, to exclusive".
+    pub fn delete_range(&self, from_key: &K, to_key: &K) {
+        self.write_buffer.delete_range(
+            self.cf_handle,
+            self.key_codec.encode(from_key),
+            self.key_codec.encode(to_key),
+        );
+    }
+
     /// Returns an iterator based on the [`IteratorMode`] (which already contains encoded key).
     ///
     /// This is an internal shared implementation detail for different iteration flavors.
@@ -245,47 +255,6 @@ impl<'db, 'wb, K, V, KC: DbCodec<K> + 'db, VC: DbCodec<V> + 'db, CF: TypedCf<K, 
                     )
                 }),
         )
-    }
-}
-
-impl<
-        'db,
-        'wb,
-        K,
-        V,
-        KC: DbCodec<K> + PrefixableDbCodec + 'db,
-        VC: DbCodec<V> + 'db,
-        CF: TypedCf<K, V, KC, VC>,
-    > TypedCfApi<'db, 'wb, K, V, KC, VC, CF>
-{
-    /// Deletes the entries from the given key range.
-    pub fn delete_all_under_prefix(&self, prefix: &KC::Prefix) {
-        let (from, to) = self.key_codec.encode_prefix_to_range(prefix);
-        // Frustratingly, RocksDB doesn't allow an open range, so we have to work around that
-        let to = to.unwrap_or_else(|| self.key_codec.encode_key_greater_than_all_possible(prefix));
-        self.write_buffer.delete_range(self.cf_handle, from, to);
-    }
-}
-
-#[allow(dead_code)] // This will no longer be dead code once merged into develop
-impl<
-        'db,
-        'wb,
-        K,
-        V,
-        KC: DbCodec<K> + OrderPreservingDbCodec + 'db,
-        VC: DbCodec<V> + 'db,
-        CF: TypedCf<K, V, KC, VC>,
-    > TypedCfApi<'db, 'wb, K, V, KC, VC, CF>
-{
-    /// Deletes the entries from the given key range.
-    /// Follows the classic convention of "from inclusive, to exclusive".
-    pub fn delete_range(&self, from_key: &K, to_key: &K) {
-        self.write_buffer.delete_range(
-            self.cf_handle,
-            self.key_codec.encode(from_key),
-            self.key_codec.encode(to_key),
-        );
     }
 }
 
@@ -368,19 +337,6 @@ pub trait DbCodec<T> {
     fn encode(&self, value: &T) -> Vec<u8>;
     /// Decodes the bytes into value.
     fn decode(&self, bytes: &[u8]) -> T;
-}
-
-/// A marker trait which must only be implemented on Codecs which preserve lexicographic ordering.
-pub trait OrderPreservingDbCodec {}
-
-/// A trait where an encoding allows for some prefixes to be preserved in the encoded space.
-/// This is for example used for range deletes.
-pub trait PrefixableDbCodec {
-    type Prefix;
-
-    fn encode_prefix_to_range(&self, prefix: &Self::Prefix) -> (Vec<u8>, Option<Vec<u8>>);
-
-    fn encode_key_greater_than_all_possible(&self, example_prefix: &Self::Prefix) -> Vec<u8>;
 }
 
 /// A reusable versioning decorator for [`DbCodec`]s.


### PR DESCRIPTION
This achieves the same as https://github.com/radixdlt/babylon-node/pull/757 but in a more "local" way + added context in docs.