### PR TITLE
DO-2003 / remote caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -193,6 +193,8 @@ jobs:
       context: "."
       dockerfile: "./Dockerfile"
       platforms: "linux/amd64"
+      cache_tag_suffix: "amd64"
+      use_gh_remote_cache: true
       provenance: "false"
       scan_image: true
       snyk_target_ref: ${{ github.ref_name }}
@@ -221,6 +223,7 @@ jobs:
   #     dockerfile: "./Dockerfile"
   #     platforms: "linux/arm64"
   #     cache_tag_suffix: arm64
+  #     use_gh_remote_cache: true
   #     provenance: "false"
   #     build-args: |
   #       WGET_VERSION=1.21.3-1+b1
@@ -243,6 +246,8 @@ jobs:
       context: "."
       dockerfile: "./Dockerfile"
       platforms: "linux/amd64"
+      cache_tag_suffix: "amd64"
+      use_gh_remote_cache: true
       enable_dockerhub: "true"
       provenance: "false"
     secrets:
@@ -265,8 +270,9 @@ jobs:
       context: "."
       dockerfile: "./Dockerfile"
       platforms: "linux/arm64"
+      cache_tag_suffix: "arm64"
+      use_gh_remote_cache: true
       enable_dockerhub: "true"
-      cache_tag_suffix: arm64
       provenance: "false"
       build-args: |
         WGET_VERSION=1.21.3-1+b1

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@
 # =================================================================================================
 FROM debian:12.1-slim AS java-build-stage
 
+LABEL org.opencontainers.image.source https://github.com/radixdlt/babylon-node
 LABEL org.opencontainers.image.authors="devops@radixdlt.com"
 LABEL org.opencontainers.image.description="Java + Debian 12 (OpenJDK)"
 
@@ -193,6 +194,8 @@ COPY --from=library-build-stage /libcorerust.so /
 # The application container which will actually run the application
 # =================================================================================================
 FROM debian:12.1-slim as app-container
+
+LABEL org.opencontainers.image.source https://github.com/radixdlt/babylon-node
 LABEL org.opencontainers.image.authors="devops@radixdlt.com"
 
 # Install dependencies needed for building the image or running the application


### PR DESCRIPTION
Use github package registry to store the docker image as a cache. This allows for more and larger cache images even for pull requests.