### PR TITLE
ci: Fix windows cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,8 @@ jobs:
         with:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
+      - name: Check clang previous version
+        run: clang --version
       - name: Install clang
         run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
       - name: Check clang version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Check clang previous version
         run: clang --version
       - name: Update clang version to 16
-        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
+        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo ls /usr/bin/ | grep clang && sudo ln -s /usr/bin/clang-16 /usr/bin/clang && sudo ln -s /usr/bin/clang++-16 /usr/bin/clang++
       - name: Check clang version
         run: clang --version
       - name: Install cargo-xwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,12 +227,10 @@ jobs:
         with:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
-      - name: Check clang previous version
-        run: clang --version
       - name: Update clang version to 16
-        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-16 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-16 /usr/bin/clang++
-      - name: Check clang version
-        run: clang --version
+        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-16 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-16 /usr/bin/clang++ && sudo apt-get install -y libclang-dev llvm llvm-dev
+      - name: Update clang version to 16
+        run: sudo clang --version
       - name: Install cargo-xwin
         run: cargo install cargo-xwin
       - name: cross compile to windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,8 +229,6 @@ jobs:
           targets: x86_64-pc-windows-msvc
       - name: Update clang version to 16
         run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-16 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-16 /usr/bin/clang++ && sudo apt-get install -y libclang-dev llvm llvm-dev
-      - name: Update clang version to 16
-        run: sudo clang --version
       - name: Install cargo-xwin
         run: cargo install cargo-xwin
       - name: cross compile to windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
       - name: Install clang
-        run: sudo apt-get update -y && sudo apt-get install -y clang-17 libclang-dev llvm llvm-dev
+        run: sudo apt-get update -y && sudo apt-get install -y clang-16 libclang-dev llvm llvm-dev
       - name: Install cargo-xwin
         run: cargo install cargo-xwin
       - name: cross compile to windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Check clang previous version
         run: clang --version
       - name: Update clang version to 16
-        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo ls /usr/bin/ | grep clang && sudo ln -s /usr/bin/clang-16 /usr/bin/clang && sudo ln -s /usr/bin/clang++-16 /usr/bin/clang++
+        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-16 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-16 /usr/bin/clang++
       - name: Check clang version
         run: clang --version
       - name: Install cargo-xwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
       - name: Install clang
-        run: sudo apt-get update -y && sudo apt-get install -y clang libclang-dev llvm llvm-dev
+        run: sudo apt-get update -y && sudo apt-get install -y clang-17 libclang-dev llvm llvm-dev
       - name: Install cargo-xwin
         run: cargo install cargo-xwin
       - name: cross compile to windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
       - name: Install clang
-        run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo apt-get update -y && sudo apt-get install -y libclang-dev llvm llvm-dev
+        run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
       - name: Check clang version
         run: clang --version
       - name: Install cargo-xwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,8 +229,8 @@ jobs:
           targets: x86_64-pc-windows-msvc
       - name: Check clang previous version
         run: clang --version
-      - name: Install clang
-        run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
+      - name: Update clang version to 16
+        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16
       - name: Check clang version
         run: clang --version
       - name: Install cargo-xwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,9 @@ jobs:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
       - name: Install clang
-        run: sudo apt-get update -y && sudo apt-get install -y clang-16 libclang-dev llvm llvm-dev
+        run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo apt-get update -y && sudo apt-get install -y libclang-dev llvm llvm-dev
+      - name: Check clang version
+        run: clang --version
       - name: Install cargo-xwin
         run: cargo install cargo-xwin
       - name: cross compile to windows


### PR DESCRIPTION
## Fix windows cross compilation - [DO-2097]

- Update clang version from 14 (default on ubuntu) to 16.
- Update symbolic links to point to clang-16

[DO-2097]: https://radixdlt.atlassian.net/browse/DO-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ