### PR TITLE
Updating sccache dep to avoid compile-time problems during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN apt-get update \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh \
   && sh rustup.sh -y --target 1.71.1-aarch64-unknown-linux-gnu 1.71.1-x86_64-unknown-linux-gnu
 
-RUN "$HOME/.cargo/bin/cargo" install sccache --version 0.3.3
+RUN "$HOME/.cargo/bin/cargo" install sccache --version 0.7.4
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc


### PR DESCRIPTION
A re-creation of https://github.com/radixdlt/babylon-node/pull/789 for `main`.