### PR TITLE
Update clang to version 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,8 @@ jobs:
         with:
           toolchain: stable
           targets: x86_64-pc-windows-msvc
-      - name: Install clang
-        run: sudo apt-get update -y && sudo apt-get install -y clang libclang-dev llvm llvm-dev
+      - name: Update clang version to 16
+        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-16 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-16 /usr/bin/clang++ && sudo apt-get install -y libclang-dev llvm llvm-dev
       - name: Install cargo-xwin
         run: cargo install cargo-xwin
       - name: cross compile to windows


### PR DESCRIPTION
## Fix windows cross compilation - [DO-2097]

- Update clang version from 14 (default on ubuntu) to 16.
- Update symbolic links to point to clang-16

[DO-2097]: https://radixdlt.atlassian.net/browse/DO-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ