### PR TITLE
DO-2077 / Use selfhosted runner for docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -173,7 +173,7 @@ jobs:
       - setup_tags
     uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@main
     with:
-      runs_on: ubuntu-latest
+      runs_on: selfhosted-ubuntu-22.04
       image_registry: "docker.io"
       image_organization: "radixdlt"
       image_name: "private-babylon-node"
@@ -268,7 +268,7 @@ jobs:
     name: (DockerHub) Docker AMD
     uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@main
     with:
-      runs_on: ubuntu-latest
+      runs_on: selfhosted-ubuntu-22.04
       image_registry: "docker.io"
       image_organization: "radixdlt"
       image_name: "babylon-node"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,16 +59,6 @@ jobs:
         with:
           version: latest
           endpoint: builders
-      # - name: Install and Configure Buildx
-      #   run: |
-      #     wget https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-amd64
-      #     echo "---- Configure Docker plugins ----"
-      #     mkdir -p /home/ubuntu/.docker/cli-plugins/
-      #     mv buildx-v0.10.4.linux-amd64 /home/ubuntu/.docker/cli-plugins/docker-buildx
-      #     chmod +x /home/ubuntu/.docker/cli-plugins/docker-buildx
-      #     echo "---- Create build context ----"
-      #     docker context create babylon-node
-      #     docker buildx create babylon-node --use
       - name: Join multiarch images
         run: |
           docker buildx imagetools create -t docker.io/radixdlt/babylon-node:${{ github.event.release.tag_name }} \
@@ -151,16 +141,6 @@ jobs:
         with:
           version: latest
           endpoint: builders
-      # - name: Install and Configure Buildx
-      #   run: |
-      #     wget https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-amd64
-      #     echo "---- Configure Docker plugins ----"
-      #     mkdir -p /home/ubuntu/.docker/cli-plugins/
-      #     mv buildx-v0.10.4.linux-amd64 /home/ubuntu/.docker/cli-plugins/docker-buildx
-      #     chmod +x /home/ubuntu/.docker/cli-plugins/docker-buildx
-      #     echo "---- Create build context ----"
-      #     docker context create babylon-node
-      #     docker buildx create babylon-node --use
       - name: Create deb package
         run: |
           sudo apt-get update && sudo apt-get install -y make

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -145,7 +145,7 @@ jobs:
           key: babylon-node-default-${{ hashFiles('./Dockerfile') }}
       - name: Set up Docker Context for Buildx
         run: |
-          docker context create builders
+          docker context create builders | true
       - name: Set up Docker Buildx
         uses: RDXWorks-actions/setup-buildx-action@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -388,3 +388,4 @@ jobs:
 #             "babylonNodeBranch": "${{ env.BABYLON_NODE_BRANCH }}"
 #           }
 #         job_timeout: "3600"
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
 
   build_deb:
     name: Build debian package
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,7 +69,7 @@ jobs:
 
   build_deb:
     name: Build debian package
-    runs-on: babylon-runner
+    runs-on: selfhosted-ubuntu-22.04
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,16 +51,24 @@ jobs:
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
-      - name: Install and Configure Buildx
+      - name: Set up Docker Context for Buildx
         run: |
-          wget https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-amd64
-          echo "---- Configure Docker plugins ----"
-          mkdir -p /home/runner/.docker/cli-plugins/
-          mv buildx-v0.10.4.linux-amd64 /home/runner/.docker/cli-plugins/docker-buildx
-          chmod +x /home/runner/.docker/cli-plugins/docker-buildx
-          echo "---- Create build context ----"
-          docker context create babylon-node
-          docker buildx create babylon-node --use
+          docker context create builders
+      - name: Set up Docker Buildx
+        uses: RDXWorks-actions/setup-buildx-action@master
+        with:
+          version: latest
+          endpoint: builders
+      # - name: Install and Configure Buildx
+      #   run: |
+      #     wget https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-amd64
+      #     echo "---- Configure Docker plugins ----"
+      #     mkdir -p /home/ubuntu/.docker/cli-plugins/
+      #     mv buildx-v0.10.4.linux-amd64 /home/ubuntu/.docker/cli-plugins/docker-buildx
+      #     chmod +x /home/ubuntu/.docker/cli-plugins/docker-buildx
+      #     echo "---- Create build context ----"
+      #     docker context create babylon-node
+      #     docker buildx create babylon-node --use
       - name: Join multiarch images
         run: |
           docker buildx imagetools create -t docker.io/radixdlt/babylon-node:${{ github.event.release.tag_name }} \
@@ -135,16 +143,24 @@ jobs:
         with:
           path: /tmp/outputs/cache/docker
           key: babylon-node-default-${{ hashFiles('./Dockerfile') }}
-      - name: Install and Configure Buildx
+      - name: Set up Docker Context for Buildx
         run: |
-          wget https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-amd64
-          echo "---- Configure Docker plugins ----"
-          mkdir -p /home/runner/.docker/cli-plugins/
-          mv buildx-v0.10.4.linux-amd64 /home/runner/.docker/cli-plugins/docker-buildx
-          chmod +x /home/runner/.docker/cli-plugins/docker-buildx
-          echo "---- Create build context ----"
-          docker context create babylon-node
-          docker buildx create babylon-node --use
+          docker context create builders
+      - name: Set up Docker Buildx
+        uses: RDXWorks-actions/setup-buildx-action@master
+        with:
+          version: latest
+          endpoint: builders
+      # - name: Install and Configure Buildx
+      #   run: |
+      #     wget https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-amd64
+      #     echo "---- Configure Docker plugins ----"
+      #     mkdir -p /home/ubuntu/.docker/cli-plugins/
+      #     mv buildx-v0.10.4.linux-amd64 /home/ubuntu/.docker/cli-plugins/docker-buildx
+      #     chmod +x /home/ubuntu/.docker/cli-plugins/docker-buildx
+      #     echo "---- Create build context ----"
+      #     docker context create babylon-node
+      #     docker buildx create babylon-node --use
       - name: Create deb package
         run: |
           sudo apt-get update && sudo apt-get install -y make

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   cancel_running_workflows:
     name: Cancel running workflows
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: cancel running workflows
         uses: RDXWorks-actions/cancel-workflow-action@main
@@ -26,7 +26,7 @@ jobs:
       contents: read
       pull-requests: read
     name: Join Multiarch Image Dockerhub
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-latest
     needs:
       - build_push_container_dockerhub
       - build_push_container_dockerhub_arm
@@ -67,7 +67,7 @@ jobs:
 
   build_deb:
     name: Build debian package
-    runs-on: selfhosted-ubuntu-22.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
@@ -153,7 +153,7 @@ jobs:
 
   setup_tags:
     name: Setup Docker tags
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.setup_tags.outputs.tag }}
     steps:
@@ -169,7 +169,7 @@ jobs:
       - setup_tags
     uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@main
     with:
-      runs_on: selfhosted-ubuntu-22.04
+      runs_on: ubuntu-latest
       image_registry: "docker.io"
       image_organization: "radixdlt"
       image_name: "private-babylon-node"
@@ -229,7 +229,7 @@ jobs:
   tag_suffix_remover:
     if: contains( github.event.pull_request.labels.*.name, 'ARM-TEST')
     name: Calculate base tag
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       BASE_TAG: ${{ steps.tag_suffix_remover.outputs.BASE_TAG }}
     needs:
@@ -264,7 +264,7 @@ jobs:
     name: (DockerHub) Docker AMD
     uses: radixdlt/public-iac-resuable-artifacts/.github/workflows/docker-build.yml@main
     with:
-      runs_on: selfhosted-ubuntu-22.04
+      runs_on: ubuntu-latest
       image_registry: "docker.io"
       image_organization: "radixdlt"
       image_name: "babylon-node"
@@ -311,7 +311,7 @@ jobs:
 
   snyk_container_monitor:
     name: Snyk monitor container
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-latest
     needs:
       - build_push_container_dockerhub
       - build_push_container_dockerhub_arm
@@ -335,7 +335,7 @@ jobs:
 
   snyk_monitor:
     name: Snyk monitor
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-latest
     needs:
       - build_push_container_dockerhub
     permissions:
@@ -366,7 +366,7 @@ jobs:
 #   needs:
 #     - build_deb
 #     - build_push_container
-#   runs-on: selfhosted-ubuntu-22.04
+#   runs-on: ubuntu-latest
 #   steps:
 #     - name: Get docker image tag
 #       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Set up Docker Context for Buildx
         run: |
-          docker context create builders
+          docker context create builders | true
       - name: Set up Docker Buildx
         uses: RDXWorks-actions/setup-buildx-action@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   cancel_running_workflows:
     name: Cancel running workflows
-    runs-on: ubuntu-22.04
+    runs-on: selfhosted-ubuntu-22.04
     steps:
       - name: cancel running workflows
         uses: RDXWorks-actions/cancel-workflow-action@main
@@ -26,7 +26,7 @@ jobs:
       contents: read
       pull-requests: read
     name: Join Multiarch Image Dockerhub
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     needs:
       - build_push_container_dockerhub
       - build_push_container_dockerhub_arm
@@ -157,7 +157,7 @@ jobs:
 
   setup_tags:
     name: Setup Docker tags
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     outputs:
       tag: ${{ steps.setup_tags.outputs.tag }}
     steps:
@@ -233,7 +233,7 @@ jobs:
   tag_suffix_remover:
     if: contains( github.event.pull_request.labels.*.name, 'ARM-TEST')
     name: Calculate base tag
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     outputs:
       BASE_TAG: ${{ steps.tag_suffix_remover.outputs.BASE_TAG }}
     needs:
@@ -315,7 +315,7 @@ jobs:
 
   snyk_container_monitor:
     name: Snyk monitor container
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     needs:
       - build_push_container_dockerhub
       - build_push_container_dockerhub_arm
@@ -339,7 +339,7 @@ jobs:
 
   snyk_monitor:
     name: Snyk monitor
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     needs:
       - build_push_container_dockerhub
     permissions:
@@ -370,7 +370,7 @@ jobs:
 #   needs:
 #     - build_deb
 #     - build_push_container
-#   runs-on: ubuntu-22.04
+#   runs-on: selfhosted-ubuntu-22.04
 #   steps:
 #     - name: Get docker image tag
 #       run: |


### PR DESCRIPTION
## Description

Use selfhosted runners for docker builds. This is to reduce costs. The initial wait time could be longer. The currently used github runners cost 6 times more excluding data transfer costs (yet to be analysed).

## Cost comparisson



Category | Github Cost | AWS Cost
-- | -- | --
Cost per minute | $0.016 | $0.0026
Minutes | 14-30 minutes | 14-30 minutes 
Traffic | 0.3GB - 10GB | 0.3GB - 10GB
Cost per GB | $0.00 | $0.01
Cost Minutes | $0,24 - $0,48 | $0,039 - $0,078
Cost Transfer | $0,00 | $0,003 - $0,10
Cost Total | $0,24 - $0,48 | $0,042 - $0,178


