### PR TITLE
Properly return the Object Field's transient value

### DIFF
--- a/core-rust/node-http-apis/src/engine_state_api/handlers/entity_info.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/handlers/entity_info.rs
@@ -158,6 +158,7 @@ fn to_api_object_field_info(
     let ObjectFieldMeta {
         index,
         resolved_type,
+        ..
     } = object_field_meta;
     Ok(models::ObjectFieldInfo {
         index: to_api_u8_as_i32(index.number),

--- a/core-rust/state-manager/src/metrics.rs
+++ b/core-rust/state-manager/src/metrics.rs
@@ -442,7 +442,7 @@ impl RawDbMetrics {
                 .set(i64::try_from(statistic.sst_count).unwrap_or_default());
             self.max_level
                 .with_label(&statistic.category_name)
-                .set(i64::try_from(statistic.max_level).unwrap_or_default());
+                .set(i64::from(statistic.max_level));
         }
     }
 }


### PR DESCRIPTION
This addresses the issue reported by @les-sheppard and described at https://rdxworks.slack.com/archives/C01M90Y2448/p1704993737813589.

The final approach I took is: "we treat transient fields as if they existed and had values, because that's the way transactions see them too". Hence:
- A transient field is returned in the list of fields of the blueprint (i.e. from [/blueprint/info](https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/3189211214/RNP-12+-+Browse+API+-+Slice+1#3.-Blueprint-Details))
  - And it contains a pretty explicit `transience: { default_value: XXX }` info there.
  - Nothing controversial here I believe.
- A transient field is also returned in the list of object's instance actual fields (i.e. from [/entity/info](https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/3189211214/RNP-12+-+Browse+API+-+Slice+1#2.-Entity-Information))
  - Note: this list can be, in principle, different from the blueprint's list: e.g. it does not include fields whose condition is not met.
  - However, as noted above, we treat transient fields as present, so they are listed here.
- A transient field's default value is returned by the [/object/field](https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/3189211214/RNP-12+-+Browse+API+-+Slice+1#4.-Object-Field-Lookup)
  - This is really _the_ value this field has between transactions 🤷 