### PR TITLE
Simplifying the paging specification (and paging policy impl)

### DIFF
--- a/core-rust/node-http-apis/engine-state-api-schema.yaml
+++ b/core-rust/node-http-apis/engine-state-api-schema.yaml
@@ -352,13 +352,8 @@ components:
       type: integer
       format: int32
       minimum: 1
-      maximum: 1000
-      description: |
-        A maximum number of items to be included in the paged listing response.
-        By default, each paged listing endpoint imposes its own limit on the number of returned
-        items (which may even be driven dynamically by system load, etc). This client-provided
-        maximum page size simply adds a further constraint (i.e. can only lower down the number
-        of returned items).
+      maximum: 100
+      description: A maximum number of items to be included in the paged listing response.
 
 ###########################################################
 # SHARED MODELS                                           #

--- a/core-rust/node-http-apis/src/engine_state_api/conversions/numerics.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/conversions/numerics.rs
@@ -15,7 +15,7 @@ const MAX_API_ROUND: u64 = 10000000000;
 const MAX_API_STATE_VERSION: u64 = 100000000000000;
 const MIN_API_TIMESTAMP_MS: i64 = 0;
 const MAX_API_TIMESTAMP_MS: i64 = 100000000000000; // For comparison, current timestamp is 1673822843000 (about 1/100th the size)
-const MAX_USER_SPECIFIED_PAGE_SIZE: u16 = 1000; // Must match the OpenAPI's `MaxPageSize.maximum`
+const DEFAULT_MAX_PAGE_SIZE: usize = 100; // Must match the OpenAPI's `MaxPageSize.maximum`
 
 #[tracing::instrument(skip_all)]
 pub fn to_api_epoch(_mapping_context: &MappingContext, epoch: Epoch) -> Result<i64, MappingError> {
@@ -115,13 +115,16 @@ pub fn to_api_instant_from_safe_timestamp(
     })
 }
 
-pub fn extract_api_max_page_size(max_page_size: i32) -> Result<usize, ExtractionError> {
+pub fn extract_api_max_page_size(max_page_size: Option<i32>) -> Result<usize, ExtractionError> {
+    let Some(max_page_size) = max_page_size else {
+        return Ok(DEFAULT_MAX_PAGE_SIZE);
+    };
     if max_page_size <= 0 {
         return Err(ExtractionError::InvalidInteger {
             message: "Max page size must be positive".to_owned(),
         });
     }
-    if max_page_size > MAX_USER_SPECIFIED_PAGE_SIZE as i32 {
+    if max_page_size > DEFAULT_MAX_PAGE_SIZE as i32 {
         return Err(ExtractionError::InvalidInteger {
             message: "Max page size too large".to_owned(),
         });

--- a/core-rust/node-http-apis/src/engine_state_api/handlers/mod.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/handlers/mod.rs
@@ -17,30 +17,3 @@ pub(crate) use kv_store_iterator::*;
 pub(crate) use object_collection_entry::*;
 pub(crate) use object_collection_iterator::*;
 pub(crate) use object_field::*;
-
-use crate::engine_state_api::{PagingPolicies, PagingPolicy};
-use std::time::Duration;
-
-/// A default maximum page size (can be further limited by each request).
-const DEFAULT_MAX_PAGE_SIZE: usize = 10000;
-
-/// A maximum wallclock time spent on iteration.
-const MAX_ITERATION_DURATION: Duration = Duration::from_millis(100);
-
-/// A *minimum* number of elements which must be reached even if [`MAX_ITERATION_DURATION`] is
-/// exceeded. This only prevents unreasonably small (or empty) pages.
-const MIN_PAGE_SIZE_DESPITE_MAX_DURATION: usize = 10;
-
-/// Creates a default paging policy, which:
-/// - returns at most [`DEFAULT_MAX_PAGE_SIZE`] items (or `requested_max_page_size` items, if given);
-/// - cuts the iteration short if it takes more than [`MAX_ITERATION_DURATION`], but ensures that
-///   at least [`MIN_PAGE_SIZE_DESPITE_MAX_DURATION`] items are returned.
-pub fn default_paging_policy<T>(requested_max_page_size: Option<usize>) -> impl PagingPolicy<T> {
-    PagingPolicies::until_first_disallowed(
-        PagingPolicies::max_page_size(requested_max_page_size.unwrap_or(DEFAULT_MAX_PAGE_SIZE)),
-        PagingPolicies::max_duration_but_min_page_size(
-            MAX_ITERATION_DURATION,
-            MIN_PAGE_SIZE_DESPITE_MAX_DURATION,
-        ),
-    )
-}


### PR DESCRIPTION
As discussed with @les-sheppard:

The page size driven by request's handling (wallclock) time was nice to the DB lock, but confusing to consumers.
We prefer to have a lower limit (i.e. 100, which should never hold the DB lock for too long) but simpler rules (i.e. "if you don't specify any page size, you get our max allowed, 100").