### PR TITLE
DO-2037 / use selfhosted runners for ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   snyk-scan-deps-licences:
     name: Snyk deps/licences scan
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     permissions:
       id-token: write
       pull-requests: read
@@ -37,7 +37,7 @@ jobs:
           args: --all-projects --org=${{ env.SNYK_NETWORK_ORG_ID }} --severity-threshold=critical
   snyk-scan-code:
     name: Snyk code scan
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     permissions:
       id-token: write
       pull-requests: read
@@ -60,7 +60,7 @@ jobs:
           command: code test
   snyk-sbom:
     name: Snyk SBOM
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     permissions:
       id-token: write
       pull-requests: read
@@ -83,7 +83,7 @@ jobs:
           command: sbom
   build:
     name: Unit tests and sonarqube
-    runs-on: babylon-runner
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     permissions:
       id-token: write
       contents: read
@@ -146,7 +146,7 @@ jobs:
         run: ./gradlew sonarqube
   local-dev-sm-docker-build:
     name: Test core-rust docker build for local development
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:
@@ -170,7 +170,7 @@ jobs:
         run: ./gradlew :core-rust:buildRustForDocker
   steadystate-integration:
     name: Steady state integration tests
-    runs-on: babylon-runner
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:
@@ -198,7 +198,7 @@ jobs:
         run: ./gradlew clean runSteadyStateIntegrationTests --info --refresh-dependencies
   targeted-integration:
     name: Targeted integration tests
-    runs-on: babylon-runner
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:
@@ -226,7 +226,7 @@ jobs:
         run: ./gradlew clean runTargetedIntegrationTests --info --refresh-dependencies --parallel
   cross-xwin:
     name: Cross compile to Windows
-    runs-on: ubuntu-latest
+    runs-on: selfhosted-ubuntu-22.04
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         run: ./gradlew sonarqube
   local-dev-sm-docker-build:
     name: Test core-rust docker build for local development
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
       deployments: write
     steps:
       - uses: RDXWorks-actions/checkout@main
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: radixdlt/public-iac-resuable-artifacts/fetch-secrets@main
         with:
           role_name: ${{ secrets.AWS_ROLE_NAME_SNYK_SECRET }}
@@ -47,8 +45,6 @@ jobs:
       deployments: write
     steps:
       - uses: RDXWorks-actions/checkout@main
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: radixdlt/public-iac-resuable-artifacts/fetch-secrets@main
         with:
           role_name: ${{ secrets.AWS_ROLE_NAME_SNYK_SECRET }}
@@ -72,8 +68,6 @@ jobs:
       deployments: write
     steps:
       - uses: RDXWorks-actions/checkout@main
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: radixdlt/public-iac-resuable-artifacts/fetch-secrets@main
         with:
           role_name: ${{ secrets.AWS_ROLE_NAME_SNYK_SECRET }}
@@ -98,8 +92,6 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable
@@ -160,8 +152,6 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable
@@ -180,14 +170,12 @@ jobs:
         run: ./gradlew :core-rust:buildRustForDocker
   steadystate-integration:
     name: Steady state integration tests
-    runs-on: selfhosted-ubuntu-22.04-16-cores
+    runs-on: selfhosted-ubuntu-22.04
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable
@@ -216,8 +204,6 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable
@@ -245,8 +231,6 @@ jobs:
       - uses: RDXWorks-actions/checkout@main
         with:
           fetch-depth: 1
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   snyk-scan-deps-licences:
     name: Snyk deps/licences scan
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       pull-requests: read
@@ -37,7 +37,7 @@ jobs:
           args: --all-projects --org=${{ env.SNYK_NETWORK_ORG_ID }} --severity-threshold=critical
   snyk-scan-code:
     name: Snyk code scan
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read
@@ -60,7 +60,7 @@ jobs:
           command: code test
   snyk-sbom:
     name: Snyk SBOM
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read
@@ -146,7 +146,7 @@ jobs:
         run: ./gradlew sonarqube
   local-dev-sm-docker-build:
     name: Test core-rust docker build for local development
-    runs-on: selfhosted-ubuntu-22.04-16-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   snyk-scan-deps-licences:
     name: Snyk deps/licences scan
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       pull-requests: read
@@ -226,7 +226,7 @@ jobs:
         run: ./gradlew clean runTargetedIntegrationTests --info --refresh-dependencies --parallel
   cross-xwin:
     name: Cross compile to Windows
-    runs-on: selfhosted-ubuntu-22.04-16-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       deployments: write
     steps:
       - uses: RDXWorks-actions/checkout@main
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
       - uses: radixdlt/public-iac-resuable-artifacts/fetch-secrets@main
         with:
           role_name: ${{ secrets.AWS_ROLE_NAME_SNYK_SECRET }}
@@ -45,6 +47,8 @@ jobs:
       deployments: write
     steps:
       - uses: RDXWorks-actions/checkout@main
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
       - uses: radixdlt/public-iac-resuable-artifacts/fetch-secrets@main
         with:
           role_name: ${{ secrets.AWS_ROLE_NAME_SNYK_SECRET }}
@@ -68,6 +72,8 @@ jobs:
       deployments: write
     steps:
       - uses: RDXWorks-actions/checkout@main
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
       - uses: radixdlt/public-iac-resuable-artifacts/fetch-secrets@main
         with:
           role_name: ${{ secrets.AWS_ROLE_NAME_SNYK_SECRET }}
@@ -92,6 +98,8 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable
@@ -152,6 +160,8 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable
@@ -176,6 +186,8 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable
@@ -204,6 +216,8 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable
@@ -231,6 +245,8 @@ jobs:
       - uses: RDXWorks-actions/checkout@main
         with:
           fetch-depth: 1
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v1
       - uses: RDXWorks-actions/rust-toolchain@master
         with:
           toolchain: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           command: sbom
   build:
     name: Unit tests and sonarqube
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     permissions:
       id-token: write
       contents: read
@@ -146,7 +146,7 @@ jobs:
         run: ./gradlew sonarqube
   local-dev-sm-docker-build:
     name: Test core-rust docker build for local development
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:
@@ -170,7 +170,7 @@ jobs:
         run: ./gradlew :core-rust:buildRustForDocker
   steadystate-integration:
     name: Steady state integration tests
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:
@@ -198,7 +198,7 @@ jobs:
         run: ./gradlew clean runSteadyStateIntegrationTests --info --refresh-dependencies
   targeted-integration:
     name: Targeted integration tests
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:
@@ -226,7 +226,7 @@ jobs:
         run: ./gradlew clean runTargetedIntegrationTests --info --refresh-dependencies --parallel
   cross-xwin:
     name: Cross compile to Windows
-    runs-on: selfhosted-ubuntu-22.04
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           command: sbom
   build:
     name: Unit tests and sonarqube
-    runs-on: selfhosted-ubuntu-22.04-16-cores
+    runs-on: selfhosted-ubuntu-22.04
     permissions:
       id-token: write
       contents: read
@@ -146,7 +146,7 @@ jobs:
         run: ./gradlew sonarqube
   local-dev-sm-docker-build:
     name: Test core-rust docker build for local development
-    runs-on: selfhosted-ubuntu-22.04-16-cores
+    runs-on: selfhosted-ubuntu-22.04
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:
@@ -198,7 +198,7 @@ jobs:
         run: ./gradlew clean runSteadyStateIntegrationTests --info --refresh-dependencies
   targeted-integration:
     name: Targeted integration tests
-    runs-on: selfhosted-ubuntu-22.04-16-cores
+    runs-on: selfhosted-ubuntu-22.04
     steps:
       - uses: RDXWorks-actions/checkout@main
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,7 +69,7 @@ jobs:
 
   build_deb:
     name: Build debian package
-    runs-on: babylon-runner
+    runs-on: selfhosted-ubuntu-22.04-16-cores
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -135,16 +135,14 @@ jobs:
         with:
           path: /tmp/outputs/cache/docker
           key: babylon-node-default-${{ hashFiles('./Dockerfile') }}
-      - name: Install and Configure Buildx
+      - name: Set up Docker Context for Buildx
         run: |
-          wget https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.10.4.linux-amd64
-          echo "---- Configure Docker plugins ----"
-          mkdir -p /home/runner/.docker/cli-plugins/
-          mv buildx-v0.10.4.linux-amd64 /home/runner/.docker/cli-plugins/docker-buildx
-          chmod +x /home/runner/.docker/cli-plugins/docker-buildx
-          echo "---- Create build context ----"
-          docker context create babylon-node
-          docker buildx create babylon-node --use
+          docker context create builders | true
+      - name: Set up Docker Buildx
+        uses: RDXWorks-actions/setup-buildx-action@master
+        with:
+          version: latest
+          endpoint: builders
       - name: Create deb package
         run: |
           sudo apt-get update && sudo apt-get install -y make


### PR DESCRIPTION
## Description

Use self-hosted EC2 runners for all workflows in the ci.yml.
This aims to reduce costs and give appropriate resource requests to the individual workflows.
Compared to the current self-hosted k8s runners we should see some benefits

Pro k8s | Con k8s
-- | --
Multi jobs on 1 machine | Mixed resources. Random oom-kill
Relatively low waiting time before job gets picked up | 10min idle time before shutdown. Wasted money
  | Runs in docker, extra abstraction, might slow down, changes available tooling
  | Same runner type for each job. Same request/limit. Inefficient utilisation. Often less than 20%
