### PR TITLE
DO-2168 / build on long lasting branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,6 @@ on:
       - develop
       - main
       - release\/*
-      - DO-2168
 
 jobs:
   cancel_running_workflows:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
       - develop
       - main
       - release\/*
+      - DO-2168
 
 jobs:
   cancel_running_workflows:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,6 +186,7 @@ jobs:
         type=sha
       flavor:
         ${{ contains( github.event.pull_request.labels.*.name, 'ARM-TEST') && 'suffix=-amd64' || '' }}
+        ${{ github.event_name != 'pull_request' && 'suffix=-amd64' || '' }}
       context: "."
       dockerfile: "./Dockerfile"
       platforms: "linux/amd64"
@@ -196,7 +197,7 @@ jobs:
       snyk_target_ref: ${{ github.ref_name }}
 
   build_push_container_private_arm:
-    if: contains( github.event.pull_request.labels.*.name, 'ARM-TEST')
+    if: contains( github.event.pull_request.labels.*.name, 'ARM-TEST') || github.event_name != 'pull_request'
     name: (PRIVATE) Docker ARM
     needs:
       - setup_tags
@@ -229,7 +230,7 @@ jobs:
         WGET_VERSION=1.21.3-1+b1
 
   tag_suffix_remover:
-    if: contains( github.event.pull_request.labels.*.name, 'ARM-TEST')
+    if: contains( github.event.pull_request.labels.*.name, 'ARM-TEST') || github.event_name != 'pull_request'
     name: Calculate base tag
     runs-on: ubuntu-latest
     outputs:
@@ -245,7 +246,7 @@ jobs:
           echo BASE_TAG=$(echo ${{needs.build_push_container_private.outputs.default_tag}} | rev |  cut -d- -f2- | rev) >> $GITHUB_OUTPUT
 
   join_multiarch_image_private_dockerhub:
-    if: contains( github.event.pull_request.labels.*.name, 'ARM-TEST')
+    if: contains( github.event.pull_request.labels.*.name, 'ARM-TEST') || github.event_name != 'pull_request'
     name: Join Multiarch Image Private Dockerhub
     needs:
       - build_push_container_private


### PR DESCRIPTION
temporarily added this branch to the allowed branches to build on push to establish the arm image gets build on all push events but not on PR events.

https://github.com/radixdlt/babylon-node/actions/runs/7611841830