### PR TITLE
Refactor: Extracting the "attached modules reader" out of handlers

### DIFF
--- a/core-rust/node-http-apis/src/engine_state_api/attached_modules.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/attached_modules.rs
@@ -1,0 +1,148 @@
+use std::ops::Deref;
+
+use radix_engine::types::*;
+
+use radix_engine_store_interface::interface::SubstateDatabase;
+
+use radix_engine::system::attached_modules::metadata::MetadataCollection;
+use radix_engine::system::attached_modules::metadata::VersionedMetadataEntry;
+
+use sbor::basic_well_known_types::STRING_TYPE;
+
+use super::*;
+
+lazy_static::lazy_static! {
+    /// A statically-known type information of the [`MetadataCollection::EntryKeyValue`].
+    static ref METADATA_COLLECTION_META: ObjectCollectionMeta = {
+        let (local_type_id, versioned_schema) =
+            generate_full_schema_from_single_type::<VersionedMetadataEntry, ScryptoCustomSchema>();
+        let LocalTypeId::SchemaLocalIndex(index) = local_type_id else {
+            panic!("VersionedMetadataEntry is a custom type");
+        };
+        // Create a dummy reference: required by the `SchemaBasedTypeReference` helper type, but not
+        // actually used (since we have the actual `SchemaV1` instance and type index).
+        let schema_reference = SchemaReference {
+            node_id: NodeId::new(EntityType::GlobalPackage as u8, &[0u8; NodeId::RID_LENGTH]),
+            schema_hash: SchemaHash(Hash::from_bytes([0; Hash::LENGTH])),
+        };
+        ObjectCollectionMeta {
+            index: RichIndex::of(MetadataCollection::EntryKeyValue.collection_index() as usize),
+            kind: ObjectCollectionKind::KeyValueStore,
+            resolved_key_type: ResolvedTypeMeta {
+                type_reference: ResolvedTypeReference::WellKnown(STRING_TYPE),
+                schema: SchemaV1::empty(),
+            },
+            resolved_value_type: ResolvedTypeMeta {
+                type_reference: ResolvedTypeReference::SchemaBased(SchemaBasedTypeReference {
+                    schema_reference,
+                    index,
+                }),
+                schema: versioned_schema.into_latest(),
+            },
+        }
+    };
+}
+
+/// A lister and loader of Object's attached Metadata entries.
+///
+/// Note: as evident by its sole [`EngineStateDataLoader`] dependency, this loader operates at an
+/// abstraction layer higher than the rest of the Engine State API (i.e. it interprets the data that
+/// can be read using other, lower-level means).
+pub struct ObjectMetadataLoader<'s, S: SubstateDatabase> {
+    loader: EngineStateDataLoader<'s, S>,
+}
+
+impl<'s, S: SubstateDatabase> ObjectMetadataLoader<'s, S> {
+    /// Creates an instance reading from the given database.
+    pub fn new(database: &'s S) -> Self {
+        Self {
+            loader: EngineStateDataLoader::new(database),
+        }
+    }
+
+    /// Returns an iterator of keys within the Metadata module attached to the given object,
+    /// starting at the given key.
+    pub fn iter_keys(
+        &self,
+        object_node_id: &NodeId,
+        from_key: Option<&MetadataKey>,
+    ) -> Result<impl Iterator<Item = MetadataKey> + '_, AttachedModuleBrowsingError> {
+        Ok(self
+            .loader
+            .iter_object_collection_keys(
+                object_node_id,
+                ModuleId::Metadata,
+                METADATA_COLLECTION_META.deref(),
+                from_key
+                    .map(|key| {
+                        RawCollectionKey::Unsorted(ScryptoValue::String {
+                            value: key.string.clone(),
+                        })
+                    })
+                    .as_ref(),
+            )?
+            .map(|key| to_metadata_key(key)))
+    }
+
+    /// Loads a value of the given Metadata entry.
+    pub fn load_entry(
+        &self,
+        object_node_id: &NodeId,
+        key: &MetadataKey,
+    ) -> Result<MetadataValue, AttachedModuleBrowsingError> {
+        let entry_data = self.loader.load_collection_entry(
+            object_node_id,
+            ModuleId::Metadata,
+            METADATA_COLLECTION_META.deref(),
+            &RawCollectionKey::Unsorted(ScryptoValue::String {
+                value: key.string.clone(),
+            }),
+        )?;
+        Ok(
+            scrypto_decode::<VersionedMetadataEntry>(entry_data.as_bytes())
+                .map_err(AttachedModuleBrowsingError::SborDecode)?
+                .into_latest(),
+        )
+    }
+}
+
+fn to_metadata_key(key: ObjectCollectionKey) -> MetadataKey {
+    let ObjectCollectionKey::KeyValueStore(sbor_data) = key else {
+        panic!("metadata collection must be Key-Value; got {:?}", key)
+    };
+    MetadataKey {
+        string: scrypto_decode(sbor_data.as_bytes()).expect("metadata keys must be strings"),
+    }
+}
+
+/// A type-safe Metadata key; always a string.
+#[derive(Debug, Clone, PartialEq, Eq, Sbor)]
+pub struct MetadataKey {
+    pub string: String,
+}
+
+/// An error that can be encountered while browsing Object's attached modules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttachedModuleBrowsingError {
+    UnderlyingError(EngineStateBrowsingError),
+    SborDecode(DecodeError),
+}
+
+impl From<EngineStateBrowsingError> for AttachedModuleBrowsingError {
+    fn from(error: EngineStateBrowsingError) -> Self {
+        AttachedModuleBrowsingError::UnderlyingError(error)
+    }
+}
+
+impl From<AttachedModuleBrowsingError> for ResponseError {
+    fn from(error: AttachedModuleBrowsingError) -> Self {
+        match error {
+            AttachedModuleBrowsingError::UnderlyingError(error) => ResponseError::from(error),
+            AttachedModuleBrowsingError::SborDecode(error) => ResponseError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Could not decode value from database",
+            )
+            .with_internal_message(format!("{:?}", error)),
+        }
+    }
+}

--- a/core-rust/node-http-apis/src/engine_state_api/handlers/object_metadata_iterator.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/handlers/object_metadata_iterator.rs
@@ -1,6 +1,5 @@
 use crate::engine_state_api::*;
 
-use radix_engine::system::attached_modules::metadata::MetadataCollection;
 use radix_engine::types::*;
 
 use crate::engine_state_api::handlers::HandlerPagingSupport;
@@ -22,17 +21,9 @@ pub(crate) async fn handle_object_metadata_iterator(
         .map_err(|err| err.into_response_error("entity_address"))?;
 
     let database = state.state_manager.database.read_current();
+    let loader = ObjectMetadataLoader::new(database.deref());
 
-    let meta_loader = EngineStateMetaLoader::new(database.deref());
-    let metadata_state_meta =
-        meta_loader.load_object_module_state_meta(&node_id, ModuleId::Metadata)?;
-    let entries_meta = metadata_state_meta
-        .collection_by_index(MetadataCollection::EntryKeyValue.collection_index())?;
-    let data_loader = EngineStateDataLoader::new(database.deref());
-
-    let page = paging_support.get_page(|from| {
-        data_loader.iter_object_collection_keys(&node_id, ModuleId::Metadata, entries_meta, from)
-    })?;
+    let page = paging_support.get_page(|from| loader.iter_keys(&node_id, from))?;
 
     let header = read_current_ledger_header(database.deref());
 
@@ -41,26 +32,18 @@ pub(crate) async fn handle_object_metadata_iterator(
         page: page
             .items
             .into_iter()
-            .map(|key| to_api_metadata_entry_key(&mapping_context, key))
-            .collect::<Result<Vec<_>, _>>()?,
+            .map(to_api_metadata_entry_key)
+            .collect(),
         continuation_token: page.continuation_token,
     }))
 }
 
-fn to_api_metadata_entry_key(
-    _context: &MappingContext,
-    key: ObjectCollectionKey,
-) -> Result<models::MetadataEntryKey, EngineStateBrowsingError> {
-    let ObjectCollectionKey::KeyValueStore(sbor_data) = key else {
-        return Err(EngineStateBrowsingError::EngineInvariantBroken(
-            "metadata collection must be Key-Value".to_string(),
-        ));
-    };
-    Ok(models::MetadataEntryKey {
-        key: scrypto_decode(sbor_data.as_bytes()).map_err(|_err| {
-            EngineStateBrowsingError::EngineInvariantBroken(
-                "metadata keys must be strings".to_string(),
-            )
-        })?,
-    })
+fn to_api_metadata_entry_key(key: MetadataKey) -> models::MetadataEntryKey {
+    models::MetadataEntryKey { key: key.string }
+}
+
+impl HasKey<MetadataKey> for MetadataKey {
+    fn as_key(&self) -> MetadataKey {
+        self.clone()
+    }
 }

--- a/core-rust/node-http-apis/src/engine_state_api/mod.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/mod.rs
@@ -62,6 +62,7 @@
  * permissions under this License.
  */
 
+mod attached_modules;
 mod conversions;
 mod errors;
 mod extractors;
@@ -79,6 +80,7 @@ mod server;
 #[allow(clippy::all)]
 mod generated;
 
+pub(crate) use attached_modules::*;
 pub(crate) use conversions::*;
 pub(crate) use errors::*;
 pub(crate) use extractors::*;

--- a/core-rust/node-http-apis/src/engine_state_api/readers.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/readers.rs
@@ -26,7 +26,6 @@ use crate::engine_state_api::models::ErrorDetails;
 use state_manager::store::traits::indices::{
     CreationId, EntityBlueprintId, EntityBlueprintIdV1, ReNodeListingIndex,
 };
-use state_manager::store::traits::SubstateNodeAncestryStore;
 
 use super::*;
 
@@ -49,7 +48,7 @@ pub struct EngineStateMetaLoader<'s, S: SubstateDatabase> {
     reader: SystemDatabaseReader<'s, S>,
 }
 
-impl<'s, S: SubstateDatabase + SubstateNodeAncestryStore> EngineStateMetaLoader<'s, S> {
+impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
     /// Creates an instance reading from the given database.
     pub fn new(database: &'s S) -> Self {
         Self {
@@ -1491,6 +1490,7 @@ pub enum RawCollectionKey {
 }
 
 /// An [`SborData`] in a wrapper depending on the object collection kind.
+#[derive(Debug)]
 pub enum ObjectCollectionKey<'t> {
     KeyValueStore(SborData<'t>),
     Index(SborData<'t>),
@@ -1498,6 +1498,7 @@ pub enum ObjectCollectionKey<'t> {
 }
 
 /// A top-level SBOR value aware of its schema.
+#[derive(Debug)]
 pub struct SborData<'t> {
     payload_bytes: Vec<u8>,
     schema: &'t SchemaV1<ScryptoCustomSchema>,


### PR DESCRIPTION
⚠️ This builds on top of https://github.com/radixdlt/babylon-node/pull/838

A simple refactor which clarifies that the new `object/attached_modules/*` endpoint family in fact belongs to a slightly-higher-level of abstraction.

_(there are not too many of such endpoints, so creating a separate API is not very much justified, but we may still at some point decide that it belongs more in the Application State API - I am currently not convinced either way)_