### PR TITLE
tweak: Add test to calculate the start of a target epoch

### DIFF
--- a/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
@@ -131,6 +131,20 @@ fn print_protocol_config_code() {
 }
 
 #[test]
+fn calculate_start_of_epoch() {
+    let calculator = CalculationParameters {
+        expected_epoch_length: Duration::minutes(5),
+        // This data can come from the Core API /core/state/consensus-manager response
+        base_epoch: Epoch::of(69946),
+        base_epoch_effective_start: DateTime::<Utc>::from_str("2024-02-05T11:55:57.229Z").unwrap(), //
+    };
+    println!(
+        "> Time: {}",
+        calculator.estimate_start_of_epoch(Epoch::of(70575))
+    );
+}
+
+#[test]
 fn print_readiness_signals() {
     let base_indent = "        ";
     for (network, config) in generate_network_configs() {

--- a/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
@@ -136,7 +136,7 @@ fn calculate_start_of_epoch() {
         expected_epoch_length: Duration::minutes(5),
         // This data can come from the Core API /core/state/consensus-manager response
         base_epoch: Epoch::of(69946),
-        base_epoch_effective_start: DateTime::<Utc>::from_str("2024-02-05T11:55:57.229Z").unwrap(), //
+        base_epoch_effective_start: DateTime::<Utc>::from_str("2024-02-05T11:55:57.229Z").unwrap(),
     };
     println!(
         "> Time: {}",


### PR DESCRIPTION
Just a small change I had locally to help with calculation of target enactment epoch time before we have that information in the API.