### PR TITLE
Add keygen binary to node dist

### DIFF
--- a/common/src/main/java/com/radixdlt/crypto/RadixKeyStore.java
+++ b/common/src/main/java/com/radixdlt/crypto/RadixKeyStore.java
@@ -110,11 +110,9 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
  * store,
  *
  * <p><b>Implementation note:</b><br>
- * This store uses a PKCS#12 representation for the underlying storage, and the store requires a
- * non-empty password to protect it. In order to ease unattended use, note that where a password is
- * required, a {@code null}, or zero length password may be provided, in which case the default 5
- * character password, "radix" is used. Clearly this is insecure, and clients should make an effort
- * to specify passwords in a secure way.
+ * This store uses a PKCS#12 representation for the underlying storage.
+ * It's required to supply a non-null password for the keystore, but it can be empty.
+ * An empty password will be used as-is, without any replacement default.
  */
 @SecurityCritical(SecurityKind.KEY_STORE)
 public final class RadixKeyStore implements Closeable {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -210,6 +210,7 @@ dependencies {
     implementation project(':olympia-engine')
     implementation project(':common')
     implementation project(':core-rust-bridge')
+    implementation project(':keygen')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     implementation 'io.swagger:swagger-annotations:1.5.0'
@@ -376,4 +377,8 @@ task deb4docker(dependsOn: buildDeb) {
         }
         println "SUCCESS: deb package copied for the docker build to: $destinationLocation"
     }
+}
+
+applicationDistribution.from(new File(project(':keygen').buildDir, "scripts")) {
+    into "bin"
 }


### PR DESCRIPTION
This PR adds a `keygen` (Unix) and `keygen.bat` (Windows) binaries from the `:keygen` subproject to `:core`'s output distribution zip. It also adds `keygen` as a dependency to `core`.

The resultant dist zip will contain all four files in its `bin` folder:

```
├── bin
│   ├── core
│   ├── core.bat
│   ├── keygen
│   └── keygen.bat
└── lib
```

This will remove the need to use a keygen docker image when setting up a node (e.g. if one doesn't want to use docker).
