### PR TITLE
Bump scrypto dep to `develop-839137f1` + Fix imports for good

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -207,6 +207,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blueprint-schema-init"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
+dependencies = [
+ "bitflags 1.3.2",
+ "radix-engine-common",
+ "sbor",
+ "serde",
+]
+
+[[package]]
 name = "bnum"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +377,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "blake2",
+ "blueprint-schema-init",
  "chrono",
  "futures",
  "futures-util",
@@ -378,13 +390,13 @@ dependencies = [
  "radix-engine",
  "radix-engine-common",
  "radix-engine-interface",
- "radix-engine-queries",
- "radix-engine-store-interface",
- "radix-engine-stores",
  "sbor",
  "serde",
  "serde_json",
  "state-manager",
+ "substate-store-impls",
+ "substate-store-interface",
+ "substate-store-queries",
  "tokio",
  "tower",
  "tower-http",
@@ -949,11 +961,11 @@ dependencies = [
  "radix-engine",
  "radix-engine-common",
  "radix-engine-interface",
- "radix-engine-queries",
- "radix-engine-store-interface",
- "radix-engine-stores",
  "sbor",
  "state-manager",
+ "substate-store-impls",
+ "substate-store-interface",
+ "substate-store-queries",
  "transaction",
  "transaction-scenarios",
  "utils",
@@ -1174,11 +1186,10 @@ dependencies = [
 
 [[package]]
 name = "native-sdk"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "radix-engine-common",
- "radix-engine-derive",
  "radix-engine-interface",
  "sbor",
  "utils",
@@ -1198,10 +1209,10 @@ dependencies = [
  "radix-engine",
  "radix-engine-common",
  "radix-engine-interface",
- "radix-engine-queries",
- "radix-engine-store-interface",
- "radix-engine-stores",
  "sbor",
+ "substate-store-impls",
+ "substate-store-interface",
+ "substate-store-queries",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1521,10 +1532,11 @@ dependencies = [
 
 [[package]]
 name = "radix-engine"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "bitflags 1.3.2",
+ "blueprint-schema-init",
  "colored",
  "const-sha1",
  "hex",
@@ -1536,11 +1548,11 @@ dependencies = [
  "radix-engine-common",
  "radix-engine-interface",
  "radix-engine-macros",
- "radix-engine-store-interface",
  "resources-tracker-macro",
  "sbor",
  "serde_json",
  "strum",
+ "substate-store-interface",
  "syn 1.0.93",
  "transaction",
  "utils",
@@ -1551,8 +1563,8 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-common"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "bech32",
  "blake2",
@@ -1576,8 +1588,8 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-derive"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1587,20 +1599,19 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "bitflags 1.3.2",
+ "blueprint-schema-init",
  "const-sha1",
  "hex",
  "lazy_static",
  "paste",
  "radix-engine-common",
- "radix-engine-derive",
  "radix-engine-macros",
  "regex",
  "sbor",
- "scrypto-schema",
  "serde",
  "serde_json",
  "strum",
@@ -1609,8 +1620,8 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-macros"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -1621,54 +1632,10 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-profiling"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "fixedstr",
-]
-
-[[package]]
-name = "radix-engine-queries"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
-dependencies = [
- "hex",
- "itertools 0.10.5",
- "paste",
- "radix-engine",
- "radix-engine-interface",
- "radix-engine-store-interface",
- "sbor",
- "transaction",
- "utils",
-]
-
-[[package]]
-name = "radix-engine-store-interface"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
-dependencies = [
- "hex",
- "itertools 0.10.5",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-interface",
- "sbor",
- "utils",
-]
-
-[[package]]
-name = "radix-engine-stores"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
-dependencies = [
- "hex",
- "itertools 0.10.5",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-store-interface",
- "sbor",
- "utils",
 ]
 
 [[package]]
@@ -1791,8 +1758,8 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "resources-tracker-macro"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1867,8 +1834,8 @@ dependencies = [
 
 [[package]]
 name = "sbor"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "const-sha1",
  "hex",
@@ -1881,8 +1848,8 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -1890,8 +1857,8 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "const-sha1",
  "itertools 0.10.5",
@@ -1914,54 +1881,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypto"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
-dependencies = [
- "bech32",
- "const-sha1",
- "hex",
- "num-bigint",
- "num-traits",
- "paste",
- "radix-engine-common",
- "radix-engine-derive",
- "radix-engine-interface",
- "sbor",
- "scrypto-derive",
- "scrypto-schema",
- "strum",
- "utils",
-]
-
-[[package]]
-name = "scrypto-derive"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
-dependencies = [
- "proc-macro2",
- "quote",
- "radix-engine-common",
- "regex",
- "sbor",
- "scrypto-schema",
- "serde",
- "serde_json",
- "syn 1.0.93",
-]
-
-[[package]]
-name = "scrypto-schema"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
-dependencies = [
- "bitflags 1.3.2",
- "radix-engine-common",
- "sbor",
- "serde",
-]
 
 [[package]]
 name = "secp256k1"
@@ -2189,13 +2108,13 @@ dependencies = [
  "radix-engine",
  "radix-engine-common",
  "radix-engine-interface",
- "radix-engine-queries",
- "radix-engine-store-interface",
- "radix-engine-stores",
  "rand 0.8.5",
  "rocksdb",
  "sbor",
  "slotmap",
+ "substate-store-impls",
+ "substate-store-interface",
+ "substate-store-queries",
  "tempfile",
  "tokio",
  "tracing",
@@ -2224,6 +2143,48 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "substate-store-impls"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
+dependencies = [
+ "hex",
+ "itertools 0.10.5",
+ "radix-engine-common",
+ "sbor",
+ "substate-store-interface",
+ "utils",
+]
+
+[[package]]
+name = "substate-store-interface"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
+dependencies = [
+ "hex",
+ "itertools 0.10.5",
+ "radix-engine-common",
+ "sbor",
+ "utils",
+]
+
+[[package]]
+name = "substate-store-queries"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
+dependencies = [
+ "hex",
+ "itertools 0.10.5",
+ "paste",
+ "radix-engine",
+ "radix-engine-common",
+ "radix-engine-interface",
+ "sbor",
+ "substate-store-interface",
+ "transaction",
+ "utils",
 ]
 
 [[package]]
@@ -2517,8 +2478,8 @@ dependencies = [
 
 [[package]]
 name = "transaction"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "bech32",
  "hex",
@@ -2532,17 +2493,18 @@ dependencies = [
 
 [[package]]
 name = "transaction-scenarios"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
+ "blueprint-schema-init",
  "hex",
  "itertools 0.10.5",
  "radix-engine",
+ "radix-engine-common",
  "radix-engine-interface",
- "radix-engine-store-interface",
- "radix-engine-stores",
  "sbor",
- "scrypto",
+ "substate-store-impls",
+ "substate-store-interface",
  "transaction",
  "utils",
  "walkdir",
@@ -2589,8 +2551,8 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "utils"
-version = "1.1.0-rc1"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=anemone-e212f2ea#e212f2ea33f05f7980ef6b4026edf60e162aaae3"
+version = "1.2.0-dev"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-839137f1#839137f1b34f45273c51429459221080b4d41b1d"
 dependencies = [
  "indexmap 2.0.0-pre",
  "serde",

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -22,16 +22,17 @@ resolver = "2"
 #   $ git push origin "release_name-BLAH"
 # * Then use tag="release_name-BLAH" in the below dependencies.
 # 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea", features = ["serde"] }
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea" }
-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea" }
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea", features = ["serde"] }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea" }
-radix-engine-stores = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea" }
-radix-engine-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea" }
-radix-engine-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea" }
-utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "anemone-e212f2ea", features = ["serde"] }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1", features = ["serde"] }
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1" }
+transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1" }
+radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1", features = ["serde"] }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1" }
+substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1" }
+substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1" }
+substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1" }
+utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1", features = ["serde"] }
+blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-839137f1", features = ["serde"] }
 
 itertools = { version = "0.11.0" }
 jni = { version = "0.19.0" }

--- a/core-rust/core-api-server/Cargo.toml
+++ b/core-rust/core-api-server/Cargo.toml
@@ -12,9 +12,10 @@ transaction = { workspace = true }
 radix-engine-common = { workspace = true }
 radix-engine-interface = { workspace = true }
 radix-engine = { workspace = true }
-radix-engine-stores = { workspace = true }
-radix-engine-store-interface = { workspace = true }
-radix-engine-queries = { workspace = true }
+substate-store-impls = { workspace = true }
+substate-store-interface = { workspace = true }
+substate-store-queries = { workspace = true }
+blueprint-schema-init = { workspace = true }
 utils = { workspace = true }
 
 # Non-Radix Engine Dependencies:

--- a/core-rust/core-api-server/src/core_api/conversions/addressing.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/addressing.rs
@@ -1,20 +1,7 @@
 use crate::core_api::models;
 use crate::core_api::*;
+use crate::scrypto_prelude::*;
 use models::SubstateType;
-use radix_engine::blueprints::account::{AccountField, AccountTypedSubstateKey};
-use radix_engine::blueprints::pool::v1::substates::multi_resource_pool::{
-    MultiResourcePoolField, MultiResourcePoolTypedSubstateKey,
-};
-use radix_engine::blueprints::pool::v1::substates::one_resource_pool::{
-    OneResourcePoolField, OneResourcePoolTypedSubstateKey,
-};
-use radix_engine::blueprints::pool::v1::substates::two_resource_pool::{
-    TwoResourcePoolField, TwoResourcePoolTypedSubstateKey,
-};
-use radix_engine::types::*;
-
-use radix_engine_queries::typed_substate_layout::*;
-use radix_engine_store_interface::db_key_mapper::*;
 
 pub fn to_api_global_address(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/addressing.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/addressing.rs
@@ -1,6 +1,6 @@
 use crate::core_api::models;
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use models::SubstateType;
 
 pub fn to_api_global_address(

--- a/core-rust/core-api-server/src/core_api/conversions/common.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/common.rs
@@ -1,6 +1,4 @@
-use radix_engine::types::*;
-
-use sbor::representations::*;
+use crate::scrypto_prelude::*;
 use state_manager::LedgerHeader;
 
 use crate::core_api::handlers::to_api_epoch_round;

--- a/core-rust/core-api-server/src/core_api/conversions/common.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/common.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use state_manager::LedgerHeader;
 
 use crate::core_api::handlers::to_api_epoch_round;

--- a/core-rust/core-api-server/src/core_api/conversions/context.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/context.rs
@@ -1,6 +1,4 @@
-use radix_engine::types::{AddressBech32Decoder, AddressBech32Encoder};
-use radix_engine_interface::network::NetworkDefinition;
-use transaction::model::{TransactionHashBech32Decoder, TransactionHashBech32Encoder};
+use crate::scrypto_prelude::*;
 
 use crate::core_api::models;
 

--- a/core-rust/core-api-server/src/core_api/conversions/context.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/context.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::core_api::models;
 

--- a/core-rust/core-api-server/src/core_api/conversions/errors.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/errors.rs
@@ -1,11 +1,6 @@
-use radix_engine::types::NonFungibleIdType;
-use radix_engine_common::{address::AddressBech32EncodeError, types::PartitionNumber};
-use radix_engine_interface::data::scrypto::model::ParseNonFungibleLocalIdError;
-use sbor::{DecodeError, EncodeError};
+use crate::scrypto_prelude::*;
 use state_manager::StateVersion;
 use tracing::warn;
-use transaction::errors::TransactionValidationError;
-use transaction::model::TransactionHashBech32EncodeError;
 
 use crate::core_api::*;
 

--- a/core-rust/core-api-server/src/core_api/conversions/errors.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/errors.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use state_manager::StateVersion;
 use tracing::warn;
 

--- a/core-rust/core-api-server/src/core_api/conversions/hashes.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/hashes.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use state_manager::{transaction::*, ReceiptTreeHash, StateHash, TransactionTreeHash};
 
 use crate::core_api::*;

--- a/core-rust/core-api-server/src/core_api/conversions/hashes.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/hashes.rs
@@ -1,6 +1,5 @@
-use radix_engine_interface::blueprints::package::CodeHash;
+use crate::scrypto_prelude::*;
 use state_manager::{transaction::*, ReceiptTreeHash, StateHash, TransactionTreeHash};
-use transaction::prelude::*;
 
 use crate::core_api::*;
 

--- a/core-rust/core-api-server/src/core_api/conversions/keys_and_sigs.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/keys_and_sigs.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::core_api::*;
 

--- a/core-rust/core-api-server/src/core_api/conversions/keys_and_sigs.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/keys_and_sigs.rs
@@ -1,7 +1,4 @@
-use radix_engine::types::PublicKey;
-use radix_engine_interface::crypto::{Ed25519PublicKey, Secp256k1PublicKey};
-use transaction::model::{SignatureV1, SignatureWithPublicKeyV1};
-use transaction::prelude::{Ed25519Signature, Secp256k1Signature};
+use crate::scrypto_prelude::*;
 
 use crate::core_api::*;
 

--- a/core-rust/core-api-server/src/core_api/conversions/lts.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/lts.rs
@@ -1,18 +1,9 @@
-use models::*;
-use radix_engine::{
-    system::system_modules::costing::RoyaltyRecipient,
-    transaction::BalanceChange,
-    types::{Decimal, GlobalAddress, IndexMap, ResourceAddress},
-};
-
+use crate::scrypto_prelude::*;
 use state_manager::store::{traits::SubstateNodeAncestryStore, StateManagerDatabase};
 use state_manager::{
     CommittedTransactionIdentifiers, LedgerTransactionOutcome, LocalTransactionReceipt,
     StateVersion, TransactionTreeHash,
 };
-
-use radix_engine::transaction::{FeeDestination, FeeSource, TransactionFeeSummary};
-use transaction::prelude::*;
 
 use crate::core_api::*;
 
@@ -89,14 +80,14 @@ pub fn to_api_lts_committed_transaction_outcome(
 pub fn to_api_lts_entity_non_fungible_balance_changes(
     context: &MappingContext,
     global_balance_summary: &IndexMap<GlobalAddress, IndexMap<ResourceAddress, BalanceChange>>,
-) -> Result<Vec<LtsEntityNonFungibleBalanceChanges>, MappingError> {
+) -> Result<Vec<models::LtsEntityNonFungibleBalanceChanges>, MappingError> {
     let mut changes = Vec::new();
     for (address, balance_changes) in global_balance_summary.iter() {
         for (resource, balance_change) in balance_changes.iter() {
             match balance_change {
                 BalanceChange::Fungible(_) => {}
                 BalanceChange::NonFungible { added, removed } => {
-                    changes.push(LtsEntityNonFungibleBalanceChanges {
+                    changes.push(models::LtsEntityNonFungibleBalanceChanges {
                         entity_address: to_api_global_address(context, address)?,
                         resource_address: to_api_resource_address(context, resource)?,
                         added: added

--- a/core-rust/core-api-server/src/core_api/conversions/lts.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/lts.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use state_manager::store::{traits::SubstateNodeAncestryStore, StateManagerDatabase};
 use state_manager::{
     CommittedTransactionIdentifiers, LedgerTransactionOutcome, LocalTransactionReceipt,

--- a/core-rust/core-api-server/src/core_api/conversions/numerics.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/numerics.rs
@@ -1,9 +1,6 @@
 use std::any::type_name;
 
-use radix_engine_common::math::*;
-use radix_engine_interface::blueprints::package::BlueprintVersion;
-use radix_engine_interface::prelude::*;
-use sbor::WellKnownTypeId;
+use crate::scrypto_prelude::*;
 use state_manager::store::traits::scenario::ScenarioSequenceNumber;
 use state_manager::StateVersion;
 

--- a/core-rust/core-api-server/src/core_api/conversions/numerics.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/numerics.rs
@@ -1,6 +1,6 @@
 use std::any::type_name;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use state_manager::store::traits::scenario::ScenarioSequenceNumber;
 use state_manager::StateVersion;
 

--- a/core-rust/core-api-server/src/core_api/conversions/pagination.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/pagination.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub struct SizeRange {
     pub min: usize,

--- a/core-rust/core-api-server/src/core_api/conversions/pagination.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/pagination.rs
@@ -1,6 +1,5 @@
-use radix_engine::types::*;
-
 use crate::core_api::*;
+use crate::scrypto_prelude::*;
 
 pub struct SizeRange {
     pub min: usize,

--- a/core-rust/core-api-server/src/core_api/conversions/receipt.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/receipt.rs
@@ -2,21 +2,8 @@
 
 use super::addressing::*;
 use crate::core_api::*;
-use radix_engine::blueprints::models::KeyValueKeyPayload;
-use radix_engine::types::*;
-
-use radix_engine::system::system_modules::costing::*;
-use radix_engine::transaction::{
-    CostingParameters, EventSystemStructure, FeeDestination, FeeSource,
-    IndexPartitionEntryStructure, KeyValuePartitionEntryStructure, KeyValueStoreEntryStructure,
-    ObjectInstanceTypeReference, ObjectSubstateTypeReference, PackageTypeReference,
-    SortedIndexPartitionEntryStructure, StateUpdateSummary, SubstateSystemStructure,
-    SystemFieldKind, SystemFieldStructure, TransactionFeeSummary,
-};
-use radix_engine_queries::typed_substate_layout::*;
-use radix_engine_store_interface::db_key_mapper::{MappedSubstateDatabase, SpreadPrefixKeyMapper};
+use crate::scrypto_prelude::*;
 use state_manager::store::StateManagerDatabase;
-use transaction::prelude::TransactionCostingParameters;
 
 use state_manager::{
     ApplicationEvent, BySubstate, DetailedTransactionOutcome, LedgerStateChanges,

--- a/core-rust/core-api-server/src/core_api/conversions/receipt.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/receipt.rs
@@ -2,7 +2,7 @@
 
 use super::addressing::*;
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use state_manager::store::StateManagerDatabase;
 
 use state_manager::{

--- a/core-rust/core-api-server/src/core_api/conversions/substates/access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/access_controller.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_access_controller_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/access_controller.rs
@@ -1,10 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-
-use radix_engine::types::*;
-use radix_engine_interface::blueprints::access_controller::{RecoveryProposal, RuleSet};
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_access_controller_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/access_rules_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/access_rules_module.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_owner_role_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/access_rules_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/access_rules_module.rs
@@ -1,10 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use radix_engine::system::system_substates::KeyValueEntrySubstate;
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_owner_role_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/account.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/account.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_account_state_substate(
     _context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/account.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/account.rs
@@ -1,16 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use radix_engine::blueprints::account::{
-    AccountAuthorizedDepositorEntrySubstate, AccountAuthorizedDepositorKeyPayload,
-    AccountDepositRuleFieldSubstate, AccountResourcePreferenceEntrySubstate,
-    AccountResourcePreferenceKeyPayload, AccountResourceVaultEntrySubstate,
-    AccountResourceVaultKeyPayload, AccountSubstate, AccountTypedSubstateKey,
-};
-
-use radix_engine::types::*;
-use radix_engine_interface::blueprints::account::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_account_state_substate(
     _context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/consensus_manager.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/consensus_manager.rs
@@ -1,12 +1,7 @@
-use radix_engine::blueprints::models::SortedIndexKeyPayload;
-
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use radix_engine_interface::blueprints::consensus_manager::*;
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_registered_validators_by_stake_index_entry_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/consensus_manager.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/consensus_manager.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_registered_validators_by_stake_index_entry_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/generic.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/generic.rs
@@ -1,10 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use radix_engine::system::system_substates::{FieldSubstate, KeyValueEntrySubstate};
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_generic_scrypto_component_state_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/generic.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/generic.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_generic_scrypto_component_state_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/metadata_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/metadata_module.rs
@@ -1,9 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_metadata_value_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/metadata_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/metadata_module.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_metadata_value_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/mod.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/mod.rs
@@ -31,7 +31,7 @@ pub use type_info_module::*;
 //====================================
 
 use super::MappingError;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 macro_rules! assert_key_type {
     (

--- a/core-rust/core-api-server/src/core_api/conversions/substates/mod.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/mod.rs
@@ -31,7 +31,7 @@ pub use type_info_module::*;
 //====================================
 
 use super::MappingError;
-use radix_engine::system::system_substates::{KeyValueEntrySubstate, LockStatus};
+use crate::scrypto_prelude::*;
 
 macro_rules! assert_key_type {
     (

--- a/core-rust/core-api-server/src/core_api/conversions/substates/package.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/package.rs
@@ -1,11 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use radix_engine::system::system_substates::KeyValueEntrySubstate;
-use radix_engine::transaction::PackageTypeReference;
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_package_royalty_accumulator_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/package.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/package.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_package_royalty_accumulator_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/pools.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/pools.rs
@@ -1,17 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use radix_engine::blueprints::pool::v1::substates::multi_resource_pool::{
-    MultiResourcePoolState, MultiResourcePoolStateFieldSubstate,
-};
-use radix_engine::blueprints::pool::v1::substates::one_resource_pool::{
-    OneResourcePoolState, OneResourcePoolStateFieldSubstate,
-};
-use radix_engine::blueprints::pool::v1::substates::two_resource_pool::{
-    TwoResourcePoolState, TwoResourcePoolStateFieldSubstate,
-};
-
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_one_resource_pool_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/pools.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/pools.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_one_resource_pool_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/resource.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/resource.rs
@@ -1,9 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_fungible_vault_balance_substate(
     _context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/resource.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/resource.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_fungible_vault_balance_substate(
     _context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/royalty_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/royalty_module.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_component_royalty_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/royalty_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/royalty_module.rs
@@ -1,9 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_component_royalty_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/substate.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/substate.rs
@@ -2,7 +2,7 @@ use super::super::*;
 use super::*;
 use crate::core_api::models;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/substate.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/substate.rs
@@ -1,24 +1,8 @@
 use super::super::*;
-use crate::core_api::models;
-use radix_engine::blueprints::account::{
-    AccountTypedFieldSubstateValue, AccountTypedSubstateValue,
-};
-use radix_engine::blueprints::pool::v1::substates::multi_resource_pool::{
-    MultiResourcePoolTypedFieldSubstateValue, MultiResourcePoolTypedSubstateValue,
-};
-use radix_engine::blueprints::pool::v1::substates::one_resource_pool::{
-    OneResourcePoolTypedFieldSubstateValue, OneResourcePoolTypedSubstateValue,
-};
-use radix_engine::blueprints::pool::v1::substates::two_resource_pool::{
-    TwoResourcePoolTypedFieldSubstateValue, TwoResourcePoolTypedSubstateValue,
-};
-
-use radix_engine::types::*;
-
-use radix_engine_queries::typed_substate_layout::*;
-
-use super::super::MappingError;
 use super::*;
+use crate::core_api::models;
+
+use crate::scrypto_prelude::*;
 
 pub fn to_api_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/transaction_tracker.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/transaction_tracker.rs
@@ -1,10 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use radix_engine::system::system_substates::{FieldSubstate, KeyValueEntrySubstate};
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_transaction_tracker_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/transaction_tracker.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/transaction_tracker.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use super::*;
 use crate::core_api::models;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_transaction_tracker_substate(
     context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/type_info_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/type_info_module.rs
@@ -2,7 +2,7 @@ use super::super::*;
 use super::*;
 use crate::core_api::models;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub fn to_api_vm_boot_substate(
     _context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/type_info_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/type_info_module.rs
@@ -2,9 +2,7 @@ use super::super::*;
 use super::*;
 use crate::core_api::models;
 
-use radix_engine::types::*;
-use radix_engine::vm::VmBoot;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 pub fn to_api_vm_boot_substate(
     _context: &MappingContext,

--- a/core-rust/core-api-server/src/core_api/errors.rs
+++ b/core-rust/core-api-server/src/core_api/errors.rs
@@ -6,8 +6,8 @@ use axum::{
 use models::stream_proofs_error_details::StreamProofsErrorDetails;
 use std::any::Any;
 
+use crate::scrypto_prelude::*;
 use hyper::StatusCode;
-use radix_engine_interface::network::NetworkDefinition;
 use tower_http::catch_panic::ResponseForPanic;
 
 use super::{models, CoreApiState};

--- a/core-rust/core-api-server/src/core_api/errors.rs
+++ b/core-rust/core-api-server/src/core_api/errors.rs
@@ -6,7 +6,7 @@ use axum::{
 use models::stream_proofs_error_details::StreamProofsErrorDetails;
 use std::any::Any;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use hyper::StatusCode;
 use tower_http::catch_panic::ResponseForPanic;
 

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
@@ -1,6 +1,6 @@
 use crate::core_api::*;
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
+
 use state_manager::query::{dump_component_state, VaultData};
 
 use std::ops::Deref;

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_all_fungible_resource_balances.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::query::{dump_component_state, VaultData};
 

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_deposit_behaviour.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_deposit_behaviour.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::LedgerHeader;
 use std::ops::Deref;

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_deposit_behaviour.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_deposit_behaviour.rs
@@ -1,16 +1,10 @@
 use crate::core_api::*;
-use radix_engine::blueprints::account::{
-    AccountAuthorizedDepositorEntryPayload, AccountCollection, AccountDepositRuleFieldSubstate,
-    AccountField, AccountResourcePreference, AccountResourcePreferenceEntryPayload,
-    AccountResourcePreferenceV1, AccountResourceVaultEntryPayload,
-};
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
 
 use state_manager::LedgerHeader;
 use std::ops::Deref;
 
 use node_common::utils::IsAccountExt;
-use radix_engine_interface::blueprints::account::{DefaultDepositRule, ResourcePreference};
 
 /// Maximum number of resource addresses allowed in the request.
 /// Must be aligned with the `maxItems` in the API documentation.

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
@@ -1,7 +1,5 @@
 use crate::core_api::*;
-use radix_engine::blueprints::account::{AccountCollection, AccountResourceVaultEntryPayload};
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 use state_manager::LedgerHeader;
 use std::ops::Deref;

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::LedgerHeader;
 use std::ops::Deref;

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use std::ops::Deref;
 

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
@@ -1,6 +1,6 @@
 use crate::core_api::*;
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
+
 use std::ops::Deref;
 
 #[tracing::instrument(skip(state))]

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
@@ -1,15 +1,15 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core_api::*;
+use crate::scrypto_prelude::*;
 
 use state_manager::{
-    AlreadyCommittedError, DetailedTransactionOutcome, RejectionReason, StateVersion,
+    AlreadyCommittedError, DetailedTransactionOutcome, MempoolRejectionReason, StateVersion,
 };
 
 use state_manager::mempool::pending_transaction_result_cache::PendingTransactionRecord;
 use state_manager::query::StateManagerSubstateQueries;
 use state_manager::store::traits::*;
-use transaction::prelude::*;
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_lts_transaction_status(
@@ -223,7 +223,7 @@ fn map_rejected_payloads_due_to_known_commit(
                 // commit, and we may see a "not-yet-updated" entry - luckily, in such case, we can
                 // precisely tell the transaction's status ourselves:
                 .unwrap_or_else(|| {
-                    RejectionReason::AlreadyCommitted(AlreadyCommittedError {
+                    MempoolRejectionReason::AlreadyCommitted(AlreadyCommittedError {
                         notarized_transaction_hash,
                         committed_state_version,
                         committed_notarized_transaction_hash: *committed_notarized_transaction_hash,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::{
     AlreadyCommittedError, DetailedTransactionOutcome, MempoolRejectionReason, StateVersion,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
@@ -1,10 +1,10 @@
 use crate::core_api::*;
+use crate::scrypto_prelude::*;
 
 use crate::core_api::handlers::to_api_committed_intent_metadata;
 use hyper::StatusCode;
 use models::lts_transaction_submit_error_details::LtsTransactionSubmitErrorDetails;
 use state_manager::{MempoolAddError, MempoolAddSource};
-use transaction::prelude::RawNotarizedTransaction;
 
 #[tracing::instrument(level = "debug", skip(state))]
 pub(crate) async fn handle_lts_transaction_submit(

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_submit.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::core_api::handlers::to_api_committed_intent_metadata;
 use hyper::StatusCode;

--- a/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
@@ -1,8 +1,7 @@
 use crate::core_api::*;
 
-use radix_engine::blueprints::access_controller::AccessControllerField;
-use radix_engine::system::attached_modules::role_assignment::RoleAssignmentField;
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
+
 use state_manager::query::dump_component_state;
 
 use std::ops::Deref;

--- a/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_access_controller.rs
@@ -1,6 +1,6 @@
 use crate::core_api::*;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::query::dump_component_state;
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_account.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_account.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::query::{dump_component_state, VaultData};
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_account.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_account.rs
@@ -1,7 +1,6 @@
 use crate::core_api::*;
-use radix_engine::blueprints::account::AccountField;
-use radix_engine::system::attached_modules::role_assignment::RoleAssignmentField;
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
+
 use state_manager::query::{dump_component_state, VaultData};
 
 use std::ops::Deref;

--- a/core-rust/core-api-server/src/core_api/handlers/state_component.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_component.rs
@@ -1,7 +1,6 @@
 use crate::core_api::*;
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
-use radix_engine_store_interface::db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper};
+use crate::scrypto_prelude::*;
+
 use state_manager::query::{dump_component_state, ComponentStateDump, DescendantParentOpt};
 
 use std::ops::Deref;

--- a/core-rust/core-api-server/src/core_api/handlers/state_component.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_component.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::query::{dump_component_state, ComponentStateDump, DescendantParentOpt};
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::protocol::ProtocolVersionName;
 use state_manager::StateManagerDatabase;

--- a/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
@@ -1,6 +1,5 @@
 use crate::core_api::*;
-use radix_engine::blueprints::consensus_manager::*;
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
 
 use state_manager::protocol::ProtocolVersionName;
 use state_manager::StateManagerDatabase;

--- a/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use std::ops::Deref;
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
@@ -1,11 +1,8 @@
-use radix_engine::blueprints::resource::*;
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::{TypedMainModuleSubstateKey, TypedSubstateKey};
+use crate::scrypto_prelude::*;
 
 use std::ops::Deref;
 
 use crate::core_api::*;
-use radix_engine_common::types::SubstateKey;
 
 use crate::core_api::models::StateNonFungibleResponse;
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_package.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_package.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use std::ops::Deref;
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_package.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_package.rs
@@ -1,7 +1,5 @@
 use crate::core_api::*;
-use radix_engine::blueprints::package::PackageField;
-use radix_engine::system::attached_modules::role_assignment::RoleAssignmentField;
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
 
 use std::ops::Deref;
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use std::ops::Deref;
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_resource.rs
@@ -1,11 +1,7 @@
 use crate::core_api::*;
-
-use radix_engine::types::*;
-use radix_engine_queries::typed_substate_layout::*;
+use crate::scrypto_prelude::*;
 
 use std::ops::Deref;
-
-use radix_engine_common::types::EntityType;
 
 enum ManagerByType {
     Fungible(

--- a/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::query::dump_component_state;
 

--- a/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_validator.rs
@@ -1,8 +1,6 @@
 use crate::core_api::*;
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
 
-use radix_engine::blueprints::consensus_manager::ValidatorField;
-use radix_engine::system::attached_modules::role_assignment::RoleAssignmentField;
 use state_manager::query::dump_component_state;
 
 use std::ops::Deref;

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
@@ -1,7 +1,5 @@
 use crate::core_api::*;
-use radix_engine::types::*;
-use radix_engine_common::types::EntityType;
-use radix_engine_interface::address::HrpSet;
+use crate::scrypto_prelude::*;
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_status_network_configuration(

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_status_network_configuration(

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -1,6 +1,6 @@
 use crate::core_api::*;
 
-use radix_engine_interface::prelude::*;
+use crate::scrypto_prelude::*;
 
 use state_manager::query::TransactionIdentifierLoader;
 use state_manager::store::traits::*;

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -1,6 +1,6 @@
 use crate::core_api::*;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::query::TransactionIdentifierLoader;
 use state_manager::store::traits::*;

--- a/core-rust/core-api-server/src/core_api/handlers/status_scenarios.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_scenarios.rs
@@ -1,6 +1,6 @@
 use crate::core_api::*;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::store::traits::scenario::{
     ExecutedGenesisScenario, ExecutedGenesisScenarioStore, ExecutedScenarioTransaction,

--- a/core-rust/core-api-server/src/core_api/handlers/status_scenarios.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_scenarios.rs
@@ -1,6 +1,6 @@
 use crate::core_api::*;
 
-use radix_engine_interface::prelude::*;
+use crate::scrypto_prelude::*;
 
 use state_manager::store::traits::scenario::{
     ExecutedGenesisScenario, ExecutedGenesisScenarioStore, ExecutedScenarioTransaction,

--- a/core-rust/core-api-server/src/core_api/handlers/stream_proofs.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_proofs.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use state_manager::store::{traits::*, StateManagerDatabase};
 use state_manager::{LedgerProof, LedgerProofOrigin, StateVersion};
 

--- a/core-rust/core-api-server/src/core_api/handlers/stream_proofs.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_proofs.rs
@@ -1,9 +1,7 @@
 use crate::core_api::*;
-
+use crate::scrypto_prelude::*;
 use state_manager::store::{traits::*, StateManagerDatabase};
 use state_manager::{LedgerProof, LedgerProofOrigin, StateVersion};
-
-use transaction::prelude::*;
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_stream_proofs(

--- a/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
@@ -1,12 +1,8 @@
-use radix_engine::track::{
-    BatchPartitionStateUpdate, NodeStateUpdates, PartitionStateUpdates, StateUpdates,
-};
+use crate::scrypto_prelude::*;
+
 use std::iter;
 
 use crate::core_api::*;
-
-use radix_engine::types::hash;
-use radix_engine_store_interface::interface::{DatabaseUpdate, DbSubstateValue};
 
 use state_manager::store::{traits::*, StateManagerDatabase};
 use state_manager::transaction::*;
@@ -14,9 +10,6 @@ use state_manager::{
     CommittedTransactionIdentifiers, LedgerHeader, LedgerProof, LedgerProofOrigin,
     LocalTransactionReceipt, StateVersion,
 };
-
-use transaction::manifest;
-use transaction::prelude::*;
 
 use super::to_api_committed_state_identifiers;
 

--- a/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/stream_transactions.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use std::iter;
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -1,29 +1,15 @@
 use crate::core_api::*;
-use models::{
-    target_identifier::TargetIdentifier,
-    transaction_call_preview_response::TransactionCallPreviewResponse,
-    transaction_status::TransactionStatus,
-};
-use radix_engine::{
-    transaction::{PreviewError, TransactionOutcome, TransactionResult},
-    types::Decimal,
-};
+use crate::scrypto_prelude::*;
 
-use radix_engine_interface::constants::FAUCET;
-use radix_engine_interface::manifest_args;
-use radix_engine_interface::{
-    blueprints::transaction_processor::InstructionOutput, data::scrypto::scrypto_encode,
-};
 use state_manager::PreviewRequest;
-use transaction::prelude::*;
 
 macro_rules! args_from_bytes_vec {
     ($args: expr) => {{
         let mut fields = Vec::new();
         for arg in $args {
-            fields.push(::radix_engine::types::manifest_decode(&arg).unwrap());
+            fields.push(crate::scrypto_prelude::manifest_decode(&arg).unwrap());
         }
-        ::radix_engine::types::ManifestValue::Tuple { fields }
+        crate::scrypto_prelude::ManifestValue::Tuple { fields }
     }};
 }
 
@@ -47,7 +33,7 @@ pub(crate) async fn handle_transaction_callpreview(
         .ok_or_else(|| client_error("Missing target from request".to_string()))?;
 
     let requested_call = match call_target {
-        TargetIdentifier::BlueprintFunctionTargetIdentifier {
+        models::TargetIdentifier::BlueprintFunctionTargetIdentifier {
             package_address,
             blueprint_name,
             function_name,
@@ -63,7 +49,7 @@ pub(crate) async fn handle_transaction_callpreview(
                 args: args_from_bytes_vec!(args),
             }
         }
-        TargetIdentifier::ComponentMethodTargetIdentifier {
+        models::TargetIdentifier::ComponentMethodTargetIdentifier {
             component_address,
             method_name,
         } => {
@@ -93,7 +79,7 @@ pub(crate) async fn handle_transaction_callpreview(
                     },
                     requested_call,
                 ],
-                blobs: btreemap!(),
+                blobs: index_map_new(),
             },
             explicit_epoch_range: None,
             notary_public_key: None,
@@ -136,15 +122,19 @@ pub(crate) async fn handle_transaction_callpreview(
                         Some(Err(err)) => Err(server_error(format!("{err:?}")))?,
                     };
 
-                    (TransactionStatus::Succeeded, output, None)
+                    (models::TransactionStatus::Succeeded, output, None)
                 }
-                TransactionOutcome::Failure(f) => {
-                    (TransactionStatus::Failed, None, Some(format!("{f:?}")))
-                }
+                TransactionOutcome::Failure(f) => (
+                    models::TransactionStatus::Failed,
+                    None,
+                    Some(format!("{f:?}")),
+                ),
             },
-            TransactionResult::Reject(r) => {
-                (TransactionStatus::Rejected, None, Some(format!("{r:?}")))
-            }
+            TransactionResult::Reject(r) => (
+                models::TransactionStatus::Rejected,
+                None,
+                Some(format!("{r:?}")),
+            ),
             TransactionResult::Abort(_) => {
                 // TODO: Should remove this
                 panic!("Should not be aborting");
@@ -152,7 +142,7 @@ pub(crate) async fn handle_transaction_callpreview(
         }
     };
 
-    Ok(Json(TransactionCallPreviewResponse {
+    Ok(Json(models::TransactionCallPreviewResponse {
         at_ledger_state: Box::new(to_api_ledger_state_summary(
             &mapping_context,
             &result.base_ledger_header,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::PreviewRequest;
 
@@ -7,9 +7,9 @@ macro_rules! args_from_bytes_vec {
     ($args: expr) => {{
         let mut fields = Vec::new();
         for arg in $args {
-            fields.push(crate::scrypto_prelude::manifest_decode(&arg).unwrap());
+            fields.push(crate::engine_prelude::manifest_decode(&arg).unwrap());
         }
-        crate::scrypto_prelude::ManifestValue::Tuple { fields }
+        crate::engine_prelude::ManifestValue::Tuple { fields }
     }};
 }
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_parse.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_parse.rs
@@ -8,7 +8,7 @@ use models::transaction_parse_response::TransactionParseResponse;
 use state_manager::mempool::pending_transaction_result_cache::MempoolRejectionReason;
 use state_manager::transaction::*;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use state_manager::store::StateManagerDatabase;
 
 use super::{

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_parse.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_parse.rs
@@ -1,18 +1,15 @@
 use crate::core_api::*;
 use std::ops::Deref;
 use std::time::SystemTime;
-use transaction::validation::{
-    NotarizedTransactionValidator, TransactionValidator, ValidationConfig,
-};
 
 use models::transaction_parse_request::{ParseMode, ResponseMode, ValidationMode};
 use models::transaction_parse_response::TransactionParseResponse;
 
-use state_manager::mempool::pending_transaction_result_cache::RejectionReason;
+use state_manager::mempool::pending_transaction_result_cache::MempoolRejectionReason;
 use state_manager::transaction::*;
 
+use crate::scrypto_prelude::*;
 use state_manager::store::StateManagerDatabase;
-use transaction::prelude::*;
 
 use super::{
     to_api_intent, to_api_ledger_transaction, to_api_notarized_transaction, to_api_signed_intent,
@@ -116,7 +113,7 @@ fn attempt_parsing_as_any_payload_type_and_map_for_api(
 struct ParsedNotarizedTransactionV1 {
     model: NotarizedTransactionV1,
     prepared: PreparedNotarizedTransactionV1,
-    validation: Option<Result<(), RejectionReason>>,
+    validation: Option<Result<(), MempoolRejectionReason>>,
 }
 
 fn attempt_parsing_as_notarized_transaction(
@@ -147,7 +144,7 @@ fn attempt_parsing_as_notarized_transaction(
                     .user_transaction_validator
                     .validate(prepared.clone())
                     .map(|_| ())
-                    .map_err(RejectionReason::ValidationError),
+                    .map_err(MempoolRejectionReason::ValidationError),
             );
             ParsedNotarizedTransactionV1 {
                 model,
@@ -160,7 +157,7 @@ fn attempt_parsing_as_notarized_transaction(
                 context
                     .user_transaction_validator
                     .validate(prepared.clone())
-                    .map_err(RejectionReason::ValidationError)
+                    .map_err(MempoolRejectionReason::ValidationError)
                     .and_then(|validated| {
                         let rejection = context
                             .committability_validator

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
@@ -1,18 +1,10 @@
 use crate::core_api::*;
-use radix_engine::prelude::*;
-use radix_engine::transaction::*;
+use crate::scrypto_prelude::*;
+
 use std::ops::Range;
 
 use state_manager::transaction::ProcessedPreviewResult;
 use state_manager::{ExecutionFeeData, LocalTransactionReceipt, PreviewRequest};
-use transaction::manifest;
-use transaction::manifest::BlobProvider;
-use transaction::model::{
-    AesGcmPayload, AesWrapped128BitKey, DecryptorsByCurve, EncryptedMessageV1, MessageV1,
-    PlaintextMessageV1, PreviewFlags, PublicKeyFingerprint,
-};
-use transaction::prelude::MessageContentsV1;
-use utils::copy_u8_array;
 
 pub(crate) async fn handle_transaction_preview(
     state: State<CoreApiState>,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_preview.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use std::ops::Range;
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -1,15 +1,15 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core_api::*;
+use crate::scrypto_prelude::*;
 
 use state_manager::{
-    AlreadyCommittedError, DetailedTransactionOutcome, RejectionReason, StateVersion,
+    AlreadyCommittedError, DetailedTransactionOutcome, MempoolRejectionReason, StateVersion,
 };
 
 use state_manager::mempool::pending_transaction_result_cache::PendingTransactionRecord;
 use state_manager::query::StateManagerSubstateQueries;
 use state_manager::store::traits::*;
-use transaction::prelude::*;
 
 #[tracing::instrument(skip(state))]
 pub(crate) async fn handle_transaction_status(
@@ -223,7 +223,7 @@ fn map_rejected_payloads_due_to_known_commit(
                 // commit, and we may see a "not-yet-updated" entry - luckily, in such case, we can
                 // precisely tell the transaction's status ourselves:
                 .unwrap_or_else(|| {
-                    RejectionReason::AlreadyCommitted(AlreadyCommittedError {
+                    MempoolRejectionReason::AlreadyCommitted(AlreadyCommittedError {
                         notarized_transaction_hash,
                         committed_state_version,
                         committed_notarized_transaction_hash: *committed_notarized_transaction_hash,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use state_manager::{
     AlreadyCommittedError, DetailedTransactionOutcome, MempoolRejectionReason, StateVersion,

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
@@ -1,5 +1,5 @@
 use crate::core_api::*;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use hyper::StatusCode;
 use models::transaction_submit_error_details::TransactionSubmitErrorDetails;

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_submit.rs
@@ -1,9 +1,9 @@
 use crate::core_api::*;
+use crate::scrypto_prelude::*;
 
 use hyper::StatusCode;
 use models::transaction_submit_error_details::TransactionSubmitErrorDetails;
 use state_manager::{AlreadyCommittedError, MempoolAddError, MempoolAddSource};
-use transaction::prelude::*;
 
 #[tracing::instrument(level = "debug", skip(state))]
 pub(crate) async fn handle_transaction_submit(

--- a/core-rust/core-api-server/src/core_api/helpers.rs
+++ b/core-rust/core-api-server/src/core_api/helpers.rs
@@ -1,8 +1,4 @@
-use radix_engine::types::*;
-
-use radix_engine::system::system_substates::{FieldSubstate, KeyValueEntrySubstate};
-use radix_engine_interface::api::CollectionIndex;
-use radix_engine_store_interface::{db_key_mapper::*, interface::SubstateDatabase};
+use crate::scrypto_prelude::*;
 use serde::Serialize;
 use state_manager::store::traits::*;
 use state_manager::store::StateManagerDatabase;

--- a/core-rust/core-api-server/src/core_api/helpers.rs
+++ b/core-rust/core-api-server/src/core_api/helpers.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use serde::Serialize;
 use state_manager::store::traits::*;
 use state_manager::store::StateManagerDatabase;

--- a/core-rust/core-api-server/src/core_api/server.rs
+++ b/core-rust/core-api-server/src/core_api/server.rs
@@ -77,9 +77,8 @@ use axum::{
     Router,
 };
 
+use crate::scrypto_prelude::*;
 use prometheus::Registry;
-use radix_engine_common::network::NetworkDefinition;
-use radix_engine_common::ScryptoSbor;
 use state_manager::StateManager;
 use tower_http::catch_panic::CatchPanicLayer;
 use tracing::{debug, error, info, trace, warn, Level};

--- a/core-rust/core-api-server/src/core_api/server.rs
+++ b/core-rust/core-api-server/src/core_api/server.rs
@@ -77,7 +77,7 @@ use axum::{
     Router,
 };
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use prometheus::Registry;
 use state_manager::StateManager;
 use tower_http::catch_panic::CatchPanicLayer;

--- a/core-rust/core-api-server/src/jni/mod.rs
+++ b/core-rust/core-api-server/src/jni/mod.rs
@@ -63,19 +63,19 @@
  */
 
 use crate::core_api::{create_server, CoreApiServerConfig, CoreApiState};
+use crate::scrypto_prelude::*;
 use futures::channel::oneshot;
 use futures::channel::oneshot::Sender;
 use futures::FutureExt;
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
+use node_common::java::*;
 use prometheus::*;
 use state_manager::jni::node_rust_environment::JNINodeRustEnvironment;
 use std::str;
 use std::sync::{Arc, MutexGuard};
 use tokio::runtime::Runtime;
-
-use node_common::java::*;
 
 const POINTER_JNI_FIELD_NAME: &str = "rustCoreApiServerPointer";
 

--- a/core-rust/core-api-server/src/jni/mod.rs
+++ b/core-rust/core-api-server/src/jni/mod.rs
@@ -63,7 +63,7 @@
  */
 
 use crate::core_api::{create_server, CoreApiServerConfig, CoreApiState};
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use futures::channel::oneshot;
 use futures::channel::oneshot::Sender;
 use futures::FutureExt;

--- a/core-rust/core-api-server/src/lib.rs
+++ b/core-rust/core-api-server/src/lib.rs
@@ -67,3 +67,38 @@ extern crate serde_json;
 
 mod core_api;
 pub mod jni;
+
+pub(crate) mod scrypto_prelude {
+    pub use blueprint_schema_init::*;
+    pub use radix_engine::blueprints::account::*;
+    pub use radix_engine::blueprints::models::*;
+    pub use radix_engine::blueprints::transaction_tracker::*;
+    pub use radix_engine::object_modules::metadata::*;
+    pub use radix_engine::system::system_modules::costing::*;
+    pub use radix_engine::system::system_substates::*;
+    pub use radix_engine::transaction::*;
+    pub use radix_engine::vm::*;
+    pub use radix_engine_common::prelude::*;
+    pub use radix_engine_interface::blueprints::access_controller::*;
+    pub use radix_engine_interface::blueprints::account::*;
+    pub use radix_engine_interface::blueprints::transaction_processor::*;
+    pub use radix_engine_interface::prelude::*;
+    pub use sbor::representations::*;
+    pub use substate_store_impls::hash_tree::tree_store::*;
+    pub use substate_store_interface::db_key_mapper::*;
+    pub use substate_store_interface::interface::*;
+    pub use substate_store_queries::typed_substate_layout::multi_resource_pool::*;
+    pub use substate_store_queries::typed_substate_layout::one_resource_pool::*;
+    pub use substate_store_queries::typed_substate_layout::two_resource_pool::*;
+    pub use substate_store_queries::typed_substate_layout::*;
+    pub use transaction::errors::*;
+    pub use transaction::manifest::*;
+    pub use transaction::model::*;
+    pub use transaction::validation::*;
+    pub use transaction::*;
+
+    // Note: plain `pub use radix_engine::track::*` would clash with the top-level `utils::prelude`
+    // (because it contains a private module of the same name)
+    pub use radix_engine::track::interface::*;
+    pub use radix_engine::track::state_updates::*;
+}

--- a/core-rust/core-api-server/src/lib.rs
+++ b/core-rust/core-api-server/src/lib.rs
@@ -68,7 +68,7 @@ extern crate serde_json;
 mod core_api;
 pub mod jni;
 
-pub(crate) mod scrypto_prelude {
+pub(crate) mod engine_prelude {
     pub use blueprint_schema_init::*;
     pub use radix_engine::blueprints::account::*;
     pub use radix_engine::blueprints::models::*;

--- a/core-rust/jni-export/Cargo.toml
+++ b/core-rust/jni-export/Cargo.toml
@@ -14,9 +14,9 @@ transaction-scenarios = { workspace = true }
 radix-engine-common = { workspace = true }
 radix-engine-interface = { workspace = true }
 radix-engine = { workspace = true }
-radix-engine-stores = { workspace = true }
-radix-engine-store-interface = { workspace = true }
-radix-engine-queries = { workspace = true }
+substate-store-impls = { workspace = true }
+substate-store-interface = { workspace = true }
+substate-store-queries = { workspace = true }
 utils = { workspace = true }
 
 # Non-Radix Engine Dependencies:

--- a/core-rust/node-common/Cargo.toml
+++ b/core-rust/node-common/Cargo.toml
@@ -9,9 +9,9 @@ transaction = { workspace = true }
 radix-engine-common = { workspace = true }
 radix-engine-interface = { workspace = true }
 radix-engine = { workspace = true }
-radix-engine-stores = { workspace = true }
-radix-engine-store-interface = { workspace = true }
-radix-engine-queries = { workspace = true }
+substate-store-impls = { workspace = true }
+substate-store-interface = { workspace = true }
+substate-store-queries = { workspace = true }
 utils = { workspace = true }
 
 # Non-Radix Engine Dependencies:

--- a/core-rust/node-common/src/config/limits.rs
+++ b/core-rust/node-common/src/config/limits.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine_common::prelude::*;
+use crate::scrypto_prelude::*;
 
 // TODO: revisit & tune before Babylon
 pub const DEFAULT_MAX_VERTEX_TRANSACTION_COUNT: u32 = 100;

--- a/core-rust/node-common/src/config/limits.rs
+++ b/core-rust/node-common/src/config/limits.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 // TODO: revisit & tune before Babylon
 pub const DEFAULT_MAX_VERTEX_TRANSACTION_COUNT: u32 = 100;

--- a/core-rust/node-common/src/config/mod.rs
+++ b/core-rust/node-common/src/config/mod.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub mod limits;
 

--- a/core-rust/node-common/src/config/mod.rs
+++ b/core-rust/node-common/src/config/mod.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use sbor::*;
+use crate::scrypto_prelude::*;
 
 pub mod limits;
 

--- a/core-rust/node-common/src/java/result.rs
+++ b/core-rust/node-common/src/java/result.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 #[derive(Debug, ScryptoSbor)]
 pub struct JavaError(pub String);

--- a/core-rust/node-common/src/java/result.rs
+++ b/core-rust/node-common/src/java/result.rs
@@ -62,8 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine_interface::*;
-use sbor::{DecodeError, EncodeError};
+use crate::scrypto_prelude::*;
 
 #[derive(Debug, ScryptoSbor)]
 pub struct JavaError(pub String);

--- a/core-rust/node-common/src/java/structure.rs
+++ b/core-rust/node-common/src/java/structure.rs
@@ -63,9 +63,7 @@
  */
 
 use crate::java::result::JavaResult;
-use radix_engine::types::{scrypto_decode, scrypto_encode, ScryptoDecode, ScryptoEncode};
-
-pub use sbor::{Decode, Encode};
+use crate::scrypto_prelude::*;
 
 pub trait StructFromJava {
     fn from_java(data: &[u8]) -> JavaResult<Self>

--- a/core-rust/node-common/src/java/structure.rs
+++ b/core-rust/node-common/src/java/structure.rs
@@ -62,8 +62,8 @@
  * permissions under this License.
  */
 
+use crate::engine_prelude::*;
 use crate::java::result::JavaResult;
-use crate::scrypto_prelude::*;
 
 pub trait StructFromJava {
     fn from_java(data: &[u8]) -> JavaResult<Self>

--- a/core-rust/node-common/src/java/types.rs
+++ b/core-rust/node-common/src/java/types.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use sbor::{Categorize, Decode, Encode};
+use crate::scrypto_prelude::*;
 
 #[derive(Debug, PartialEq, Eq, Categorize, Encode, Decode)]
 pub struct JavaHashCode(Vec<u8>);

--- a/core-rust/node-common/src/java/types.rs
+++ b/core-rust/node-common/src/java/types.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 #[derive(Debug, PartialEq, Eq, Categorize, Encode, Decode)]
 pub struct JavaHashCode(Vec<u8>);

--- a/core-rust/node-common/src/java/utils.rs
+++ b/core-rust/node-common/src/java/utils.rs
@@ -62,10 +62,9 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
-use radix_engine::types::{ScryptoDecode, ScryptoEncode};
-use sbor::Sbor;
 use std::panic;
 use std::panic::AssertUnwindSafe;
 

--- a/core-rust/node-common/src/java/utils.rs
+++ b/core-rust/node-common/src/java/utils.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
 use std::panic;

--- a/core-rust/node-common/src/jni/addressing.rs
+++ b/core-rust/node-common/src/jni/addressing.rs
@@ -62,8 +62,8 @@
  * permissions under this License.
  */
 
+use crate::engine_prelude::*;
 use crate::java::utils::jni_sbor_coded_call;
-use crate::scrypto_prelude::*;
 use bech32::{FromBase32, ToBase32, Variant};
 use jni::objects::JClass;
 use jni::sys::jbyteArray;

--- a/core-rust/node-common/src/jni/addressing.rs
+++ b/core-rust/node-common/src/jni/addressing.rs
@@ -63,14 +63,11 @@
  */
 
 use crate::java::utils::jni_sbor_coded_call;
+use crate::scrypto_prelude::*;
 use bech32::{FromBase32, ToBase32, Variant};
 use jni::objects::JClass;
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
-use radix_engine::types::ComponentAddress;
-use radix_engine_common::prelude::{AddressBech32Encoder, NetworkDefinition};
-use radix_engine_common::types::{EntityType, NodeId, ResourceAddress};
-use radix_engine_interface::crypto::Secp256k1PublicKey;
 
 #[no_mangle]
 extern "system" fn Java_com_radixdlt_identifiers_Bech32mCoder_encodeAddress(

--- a/core-rust/node-common/src/jni/scrypto_constants.rs
+++ b/core-rust/node-common/src/jni/scrypto_constants.rs
@@ -66,8 +66,8 @@ use jni::objects::JClass;
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
 
+use crate::engine_prelude::*;
 use crate::java::utils::jni_sbor_coded_call;
-use crate::scrypto_prelude::*;
 
 #[no_mangle]
 extern "system" fn Java_com_radixdlt_rev2_ScryptoConstants_getXrdResourceAddress(

--- a/core-rust/node-common/src/jni/scrypto_constants.rs
+++ b/core-rust/node-common/src/jni/scrypto_constants.rs
@@ -67,8 +67,7 @@ use jni::sys::jbyteArray;
 use jni::JNIEnv;
 
 use crate::java::utils::jni_sbor_coded_call;
-use radix_engine::types::{CONSENSUS_MANAGER, VALIDATOR_OWNER_BADGE, XRD};
-use radix_engine_interface::constants::FAUCET;
+use crate::scrypto_prelude::*;
 
 #[no_mangle]
 extern "system" fn Java_com_radixdlt_rev2_ScryptoConstants_getXrdResourceAddress(

--- a/core-rust/node-common/src/lib.rs
+++ b/core-rust/node-common/src/lib.rs
@@ -71,6 +71,6 @@ pub mod metrics;
 pub mod scheduler;
 pub mod utils;
 
-pub(crate) mod scrypto_prelude {
+pub(crate) mod engine_prelude {
     pub use radix_engine_common::prelude::*;
 }

--- a/core-rust/node-common/src/lib.rs
+++ b/core-rust/node-common/src/lib.rs
@@ -70,3 +70,7 @@ pub mod locks;
 pub mod metrics;
 pub mod scheduler;
 pub mod utils;
+
+pub(crate) mod scrypto_prelude {
+    pub use radix_engine_common::prelude::*;
+}

--- a/core-rust/node-common/src/utils.rs
+++ b/core-rust/node-common/src/utils.rs
@@ -62,8 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine::types::GlobalAddress;
-use radix_engine_common::types::EntityType;
+use crate::scrypto_prelude::*;
 
 pub trait IsAccountExt {
     fn is_account(&self) -> bool;

--- a/core-rust/node-common/src/utils.rs
+++ b/core-rust/node-common/src/utils.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub trait IsAccountExt {
     fn is_account(&self) -> bool;

--- a/core-rust/state-manager/Cargo.toml
+++ b/core-rust/state-manager/Cargo.toml
@@ -12,9 +12,9 @@ transaction-scenarios = { workspace = true }
 radix-engine-common = { workspace = true }
 radix-engine-interface = { workspace = true }
 radix-engine = { workspace = true }
-radix-engine-stores = { workspace = true }
-radix-engine-store-interface = { workspace = true }
-radix-engine-queries = { workspace = true }
+substate-store-impls = { workspace = true }
+substate-store-interface = { workspace = true }
+substate-store-queries = { workspace = true }
 utils = { workspace = true }
 
 # Non-Radix Engine Dependencies:

--- a/core-rust/state-manager/src/accumulator_tree/mod.rs
+++ b/core-rust/state-manager/src/accumulator_tree/mod.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use tree_builder::Merklizable;
 
 pub mod slice_merger;

--- a/core-rust/state-manager/src/accumulator_tree/mod.rs
+++ b/core-rust/state-manager/src/accumulator_tree/mod.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine_interface::prelude::*;
+use crate::scrypto_prelude::*;
 use tree_builder::Merklizable;
 
 pub mod slice_merger;

--- a/core-rust/state-manager/src/accumulator_tree/storage.rs
+++ b/core-rust/state-manager/src/accumulator_tree/storage.rs
@@ -62,8 +62,8 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use enum_dispatch::enum_dispatch;
-use radix_engine::types::{ScryptoCategorize, ScryptoDecode, ScryptoEncode};
 
 /// The "read" part of an accumulator tree storage SPI.
 /// Both the key type and node type are implementation-dependent.

--- a/core-rust/state-manager/src/accumulator_tree/storage.rs
+++ b/core-rust/state-manager/src/accumulator_tree/storage.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use enum_dispatch::enum_dispatch;
 
 /// The "read" part of an accumulator tree storage SPI.

--- a/core-rust/state-manager/src/accumulator_tree/test.rs
+++ b/core-rust/state-manager/src/accumulator_tree/test.rs
@@ -66,7 +66,7 @@ use super::slice_merger::AccuTreeSliceMerger;
 use super::storage::{ReadableAccuTreeStore, WriteableAccuTreeStore};
 use super::storage::{TreeSlice, TreeSliceLevel};
 use super::tree_builder::{AccuTree, Merklizable};
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use std::collections::HashMap;
 
 // Simple smoke tests using the actual hashing coming from our business use-cases:

--- a/core-rust/state-manager/src/accumulator_tree/test.rs
+++ b/core-rust/state-manager/src/accumulator_tree/test.rs
@@ -66,7 +66,7 @@ use super::slice_merger::AccuTreeSliceMerger;
 use super::storage::{ReadableAccuTreeStore, WriteableAccuTreeStore};
 use super::storage::{TreeSlice, TreeSliceLevel};
 use super::tree_builder::{AccuTree, Merklizable};
-use radix_engine_interface::crypto::{blake2b_256_hash, Hash};
+use crate::scrypto_prelude::*;
 use std::collections::HashMap;
 
 // Simple smoke tests using the actual hashing coming from our business use-cases:

--- a/core-rust/state-manager/src/jni/fatal_panic_handler.rs
+++ b/core-rust/state-manager/src/jni/fatal_panic_handler.rs
@@ -67,7 +67,6 @@ use jni::objects::{GlobalRef, JObject};
 use jni::{JNIEnv, JavaVM};
 use std::ops::Deref;
 use tracing::error;
-use transaction::prelude::*;
 
 /// An interface for notifying Java about a fatal panic.
 pub struct FatalPanicHandler {

--- a/core-rust/state-manager/src/jni/mempool.rs
+++ b/core-rust/state-manager/src/jni/mempool.rs
@@ -72,11 +72,9 @@ use jni::sys::jbyteArray;
 use jni::JNIEnv;
 
 use crate::mempool::*;
+use crate::scrypto_prelude::*;
 use crate::MempoolAddSource;
 use node_common::java::*;
-use sbor::{Categorize, Decode, Encode};
-use transaction::errors::TransactionValidationError;
-use transaction::model::*;
 
 use super::node_rust_environment::JNINodeRustEnvironment;
 use super::transaction_preparer::JavaPreparedNotarizedTransaction;

--- a/core-rust/state-manager/src/jni/mempool.rs
+++ b/core-rust/state-manager/src/jni/mempool.rs
@@ -71,8 +71,8 @@ use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
 
+use crate::engine_prelude::*;
 use crate::mempool::*;
-use crate::scrypto_prelude::*;
 use crate::MempoolAddSource;
 use node_common::java::*;
 

--- a/core-rust/state-manager/src/jni/mod.rs
+++ b/core-rust/state-manager/src/jni/mod.rs
@@ -74,7 +74,7 @@ pub mod transaction_preparer;
 pub mod transaction_store;
 pub mod vertex_store_recovery;
 
-use radix_engine::prelude::*;
+use crate::scrypto_prelude::*;
 
 /// Limits regarding the granularity of ledger sync (and thus of ledger proofs kept in storage).
 /// This struct is defined publicly here, since it is used by the transaction store and the ledger

--- a/core-rust/state-manager/src/jni/mod.rs
+++ b/core-rust/state-manager/src/jni/mod.rs
@@ -74,7 +74,7 @@ pub mod transaction_preparer;
 pub mod transaction_store;
 pub mod vertex_store_recovery;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 /// Limits regarding the granularity of ledger sync (and thus of ledger proofs kept in storage).
 /// This struct is defined publicly here, since it is used by the transaction store and the ledger

--- a/core-rust/state-manager/src/jni/node_rust_environment.rs
+++ b/core-rust/state-manager/src/jni/node_rust_environment.rs
@@ -66,6 +66,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::scrypto_prelude::*;
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
@@ -73,7 +74,6 @@ use node_common::environment::setup_tracing;
 use node_common::java::{jni_call, jni_jbytearray_to_vector, StructFromJava};
 use node_common::locks::*;
 use prometheus::Registry;
-use radix_engine_common::prelude::NetworkDefinition;
 
 use node_common::scheduler::{Scheduler, UntilDropTracker};
 use tokio::runtime::Runtime;

--- a/core-rust/state-manager/src/jni/node_rust_environment.rs
+++ b/core-rust/state-manager/src/jni/node_rust_environment.rs
@@ -66,7 +66,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;

--- a/core-rust/state-manager/src/jni/protocol_update.rs
+++ b/core-rust/state-manager/src/jni/protocol_update.rs
@@ -62,11 +62,11 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use crate::{protocol::*, ProtocolUpdateResult};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
-use radix_engine::types::*;
 
 use node_common::java::*;
 

--- a/core-rust/state-manager/src/jni/protocol_update.rs
+++ b/core-rust/state-manager/src/jni/protocol_update.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::{protocol::*, ProtocolUpdateResult};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -62,8 +62,8 @@
  * permissions under this License.
  */
 
+use crate::engine_prelude::*;
 use crate::protocol::ProtocolVersionName;
-use crate::scrypto_prelude::*;
 use crate::{protocol::ProtocolState, CommitSummary, LedgerProof};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -63,20 +63,15 @@
  */
 
 use crate::protocol::ProtocolVersionName;
+use crate::scrypto_prelude::*;
 use crate::{protocol::ProtocolState, CommitSummary, LedgerProof};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
-use radix_engine::types::*;
-use radix_engine_interface::blueprints::consensus_manager::{
-    ConsensusManagerConfig, EpochChangeCondition,
-};
 
 use node_common::java::*;
 
 use crate::types::{CommitRequest, InvalidCommitRequestError, PrepareRequest, PrepareResult};
-
-use radix_engine::system::bootstrap::GenesisDataChunk;
 
 use super::node_rust_environment::JNINodeRustEnvironment;
 

--- a/core-rust/state-manager/src/jni/state_reader.rs
+++ b/core-rust/state-manager/src/jni/state_reader.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;

--- a/core-rust/state-manager/src/jni/state_reader.rs
+++ b/core-rust/state-manager/src/jni/state_reader.rs
@@ -62,17 +62,10 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
-use radix_engine::system::system_substates::FieldSubstate;
-use radix_engine::types::*;
-
-use radix_engine_store_interface::db_key_mapper::*;
-
-use radix_engine::blueprints::consensus_manager::{
-    ValidatorField, ValidatorProtocolUpdateReadinessSignalFieldPayload,
-};
 
 use node_common::java::*;
 

--- a/core-rust/state-manager/src/jni/test_state_reader.rs
+++ b/core-rust/state-manager/src/jni/test_state_reader.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::{DetailedTransactionOutcome, LedgerTransactionOutcome, StateVersion};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;

--- a/core-rust/state-manager/src/jni/test_state_reader.rs
+++ b/core-rust/state-manager/src/jni/test_state_reader.rs
@@ -62,28 +62,22 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use crate::{DetailedTransactionOutcome, LedgerTransactionOutcome, StateVersion};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
-use radix_engine::types::*;
-
-use radix_engine_queries::query::ResourceAccounter;
 use std::ops::Deref;
 
 use crate::jni::node_rust_environment::JNINodeRustEnvironment;
 use crate::query::StateManagerSubstateQueries;
 use node_common::java::*;
 
-use radix_engine::blueprints::consensus_manager::{ValidatorField, ValidatorStateFieldSubstate};
-use radix_engine::system::type_info::TypeInfoSubstate;
-
 use crate::store::traits::{
     gc::StateHashTreeGcStore, IterableProofStore, QueryableProofStore, QueryableTransactionStore,
     SubstateNodeAncestryStore,
 };
 use crate::transaction::LedgerTransactionHash;
-use radix_engine_store_interface::db_key_mapper::{MappedSubstateDatabase, SpreadPrefixKeyMapper};
 
 //
 // JNI Interface (for test purposes only)

--- a/core-rust/state-manager/src/jni/transaction_preparer.rs
+++ b/core-rust/state-manager/src/jni/transaction_preparer.rs
@@ -62,17 +62,12 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use crate::transaction::*;
 use jni::objects::JClass;
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
 use node_common::java::*;
-use radix_engine::types::PublicKey;
-use radix_engine_common::types::Epoch;
-use radix_engine_interface::network::NetworkDefinition;
-use radix_engine_interface::*;
-use transaction::manifest::{compile, BlobProvider};
-use transaction::model::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 struct PrepareIntentRequest {

--- a/core-rust/state-manager/src/jni/transaction_preparer.rs
+++ b/core-rust/state-manager/src/jni/transaction_preparer.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::transaction::*;
 use jni::objects::JClass;
 use jni::sys::jbyteArray;

--- a/core-rust/state-manager/src/jni/transaction_store.rs
+++ b/core-rust/state-manager/src/jni/transaction_store.rs
@@ -62,10 +62,10 @@
  * permissions under this License.
  */
 
+use crate::engine_prelude::*;
 use crate::jni::node_rust_environment::JNINodeRustEnvironment;
 use crate::jni::LedgerSyncLimitsConfig;
 use crate::protocol::epoch_change_iter;
-use crate::scrypto_prelude::*;
 use crate::store::traits::*;
 use crate::{LedgerProof, StateVersion};
 use jni::objects::{JClass, JObject};

--- a/core-rust/state-manager/src/jni/transaction_store.rs
+++ b/core-rust/state-manager/src/jni/transaction_store.rs
@@ -65,13 +65,13 @@
 use crate::jni::node_rust_environment::JNINodeRustEnvironment;
 use crate::jni::LedgerSyncLimitsConfig;
 use crate::protocol::epoch_change_iter;
+use crate::scrypto_prelude::*;
 use crate::store::traits::*;
 use crate::{LedgerProof, StateVersion};
 use jni::objects::{JClass, JObject};
 use jni::sys::jbyteArray;
 use jni::JNIEnv;
 use node_common::java::*;
-use radix_engine::types::*;
 use std::ops::Deref;
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]

--- a/core-rust/state-manager/src/lib.rs
+++ b/core-rust/state-manager/src/lib.rs
@@ -91,3 +91,35 @@ pub use crate::state_computer::*;
 pub use crate::state_manager::*;
 pub use crate::store::*;
 pub use crate::types::*;
+
+pub(crate) mod scrypto_prelude {
+    pub use radix_engine::errors::*;
+    pub use radix_engine::system::bootstrap::*;
+    pub use radix_engine::system::system_db_reader::*;
+    pub use radix_engine::system::system_substates::*;
+    pub use radix_engine::transaction::*;
+    pub use radix_engine::utils::*;
+    pub use radix_engine::vm::wasm::*;
+    pub use radix_engine::vm::*;
+    pub use radix_engine_common::prelude::*;
+    pub use radix_engine_interface::blueprints::transaction_processor::*;
+    pub use radix_engine_interface::prelude::*;
+    pub use substate_store_impls::hash_tree::tree_store::*;
+    pub use substate_store_impls::hash_tree::*;
+    pub use substate_store_interface::db_key_mapper::*;
+    pub use substate_store_interface::interface::*;
+    pub use substate_store_queries::query::*;
+    pub use substate_store_queries::typed_substate_layout::*;
+    pub use transaction::builder::*;
+    pub use transaction::errors::*;
+    pub use transaction::manifest::*;
+    pub use transaction::model::*;
+    pub use transaction::prelude::*;
+    pub use transaction::validation::*;
+    pub use transaction::*;
+
+    // Note: plain `pub use radix_engine::track::*` would clash with the top-level `utils::prelude`
+    // (because it contains a private module of the same name)
+    pub use radix_engine::track::interface::*;
+    pub use radix_engine::track::state_updates::*;
+}

--- a/core-rust/state-manager/src/lib.rs
+++ b/core-rust/state-manager/src/lib.rs
@@ -92,7 +92,7 @@ pub use crate::state_manager::*;
 pub use crate::store::*;
 pub use crate::types::*;
 
-pub(crate) mod scrypto_prelude {
+pub(crate) mod engine_prelude {
     pub use radix_engine::errors::*;
     pub use radix_engine::system::bootstrap::*;
     pub use radix_engine::system::system_db_reader::*;

--- a/core-rust/state-manager/src/limits.rs
+++ b/core-rust/state-manager/src/limits.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use node_common::config::limits::VertexLimitsConfig;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/core-rust/state-manager/src/limits.rs
+++ b/core-rust/state-manager/src/limits.rs
@@ -62,9 +62,8 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use node_common::config::limits::VertexLimitsConfig;
-use radix_engine::transaction::TransactionFeeSummary;
-use radix_engine::types::*;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VertexLimitsExceeded {

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -68,7 +68,6 @@ use crate::mempool::*;
 use crate::MempoolAddSource;
 use node_common::metrics::TakesMetricLabels;
 use prometheus::Registry;
-use transaction::model::*;
 
 use std::cmp::max;
 use std::collections::HashSet;

--- a/core-rust/state-manager/src/mempool/mempool_relay_dispatcher.rs
+++ b/core-rust/state-manager/src/mempool/mempool_relay_dispatcher.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use jni::errors::Result;
 use jni::objects::{GlobalRef, JObject, JValue};
 use jni::{JNIEnv, JavaVM};

--- a/core-rust/state-manager/src/mempool/mempool_relay_dispatcher.rs
+++ b/core-rust/state-manager/src/mempool/mempool_relay_dispatcher.rs
@@ -62,11 +62,11 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use jni::errors::Result;
 use jni::objects::{GlobalRef, JObject, JValue};
 use jni::{JNIEnv, JavaVM};
 use std::ops::Deref;
-use transaction::prelude::*;
 
 use node_common::java::*;
 

--- a/core-rust/state-manager/src/mempool/metrics.rs
+++ b/core-rust/state-manager/src/mempool/metrics.rs
@@ -65,7 +65,7 @@
 use node_common::metrics::*;
 use prometheus::*;
 
-use crate::{MempoolAddError, MempoolAddSource, RejectionReason};
+use crate::{MempoolAddError, MempoolAddSource, MempoolRejectionReason};
 
 pub struct MempoolMetrics {
     pub current_transactions: IntGauge,
@@ -142,9 +142,9 @@ impl MetricLabel for MempoolAddError {
         match self {
             MempoolAddError::PriorityThresholdNotMet { .. } => "PriorityThresholdNotMet",
             MempoolAddError::Rejected(rejection) => match &rejection.reason {
-                RejectionReason::AlreadyCommitted(_) => "AlreadyCommitted",
-                RejectionReason::FromExecution(_) => "ExecutionError",
-                RejectionReason::ValidationError(_) => "ValidationError",
+                MempoolRejectionReason::AlreadyCommitted(_) => "AlreadyCommitted",
+                MempoolRejectionReason::FromExecution(_) => "ExecutionError",
+                MempoolRejectionReason::ValidationError(_) => "ValidationError",
             },
             MempoolAddError::Duplicate(_) => "Duplicate",
         }

--- a/core-rust/state-manager/src/mempool/mod.rs
+++ b/core-rust/state-manager/src/mempool/mod.rs
@@ -62,8 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine_common::types::Epoch;
-use transaction::{errors::TransactionValidationError, prelude::NotarizedTransactionHash};
+use crate::scrypto_prelude::*;
 
 use std::string::ToString;
 
@@ -87,7 +86,7 @@ pub enum MempoolAddError {
 
 #[derive(Debug)]
 pub struct MempoolAddRejection {
-    pub reason: RejectionReason,
+    pub reason: MempoolRejectionReason,
     pub against_state: AtState,
     pub retry_from: RetryFrom,
     pub was_cached: bool,
@@ -99,7 +98,7 @@ pub struct MempoolAddRejection {
 impl MempoolAddRejection {
     pub fn for_static_rejection(validation_error: TransactionValidationError) -> Self {
         Self {
-            reason: RejectionReason::ValidationError(validation_error),
+            reason: MempoolRejectionReason::ValidationError(validation_error),
             against_state: AtState::Static,
             retry_from: RetryFrom::Never,
             was_cached: false,

--- a/core-rust/state-manager/src/mempool/mod.rs
+++ b/core-rust/state-manager/src/mempool/mod.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use std::string::ToString;
 

--- a/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
+++ b/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
@@ -1,5 +1,4 @@
-use radix_engine_common::types::Epoch;
-use transaction::{errors::TransactionValidationError, model::*};
+use crate::scrypto_prelude::*;
 
 use crate::{
     transaction::{CheckMetadata, StaticValidation},
@@ -18,7 +17,7 @@ use std::{
 pub type ExecutionRejectionReason = radix_engine::errors::RejectionReason;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RejectionReason {
+pub enum MempoolRejectionReason {
     AlreadyCommitted(AlreadyCommittedError),
     FromExecution(Box<ExecutionRejectionReason>),
     ValidationError(TransactionValidationError),
@@ -31,13 +30,13 @@ pub struct AlreadyCommittedError {
     pub committed_notarized_transaction_hash: NotarizedTransactionHash,
 }
 
-impl From<TransactionValidationError> for RejectionReason {
+impl From<TransactionValidationError> for MempoolRejectionReason {
     fn from(value: TransactionValidationError) -> Self {
         Self::ValidationError(value)
     }
 }
 
-impl RejectionReason {
+impl MempoolRejectionReason {
     pub fn is_permanent_for_payload(&self) -> bool {
         self.permanence().is_permanent_for_payload()
     }
@@ -48,8 +47,8 @@ impl RejectionReason {
 
     pub fn is_rejected_because_intent_already_committed(&self) -> bool {
         match self {
-            RejectionReason::AlreadyCommitted(_) => true,
-            RejectionReason::FromExecution(rejection_reason) => match **rejection_reason {
+            MempoolRejectionReason::AlreadyCommitted(_) => true,
+            MempoolRejectionReason::FromExecution(rejection_reason) => match **rejection_reason {
                 ExecutionRejectionReason::SuccessButFeeLoanNotRepaid => false,
                 ExecutionRejectionReason::ErrorBeforeLoanAndDeferredCostsRepaid(_) => false,
                 ExecutionRejectionReason::TransactionEpochNotYetValid { .. } => false,
@@ -57,25 +56,25 @@ impl RejectionReason {
                 ExecutionRejectionReason::IntentHashPreviouslyCommitted => true,
                 ExecutionRejectionReason::IntentHashPreviouslyCancelled => true,
             },
-            RejectionReason::ValidationError(_) => false,
+            MempoolRejectionReason::ValidationError(_) => false,
         }
     }
 
     pub fn already_committed_error(&self) -> Option<&AlreadyCommittedError> {
         match self {
-            RejectionReason::AlreadyCommitted(error) => Some(error),
+            MempoolRejectionReason::AlreadyCommitted(error) => Some(error),
             _ => None,
         }
     }
 
     pub fn permanence(&self) -> RejectionPermanence {
         match self {
-            RejectionReason::AlreadyCommitted(_) => {
+            MempoolRejectionReason::AlreadyCommitted(_) => {
                 // This is permanent for the intent - because even other, non-committed transactions
                 // of the same intent will fail with `ExecutionRejectionReason::IntentHashPreviouslyCommitted`
                 RejectionPermanence::PermanentForAnyPayloadWithThisIntent
             }
-            RejectionReason::FromExecution(rejection_error) => match **rejection_error {
+            MempoolRejectionReason::FromExecution(rejection_error) => match **rejection_error {
                 ExecutionRejectionReason::SuccessButFeeLoanNotRepaid => {
                     RejectionPermanence::Temporary {
                         retry: RetrySettings::AfterDelay {
@@ -105,7 +104,7 @@ impl RejectionReason {
                     RejectionPermanence::PermanentForAnyPayloadWithThisIntent
                 }
             },
-            RejectionReason::ValidationError(validation_error) => match validation_error {
+            MempoolRejectionReason::ValidationError(validation_error) => match validation_error {
                 // The size is a property of the payload, not the intent
                 TransactionValidationError::TransactionTooLarge => {
                     RejectionPermanence::PermanentForPayload
@@ -174,12 +173,16 @@ pub enum RetrySettings {
     FromEpoch { epoch: Epoch },
 }
 
-impl fmt::Display for RejectionReason {
+impl fmt::Display for MempoolRejectionReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RejectionReason::AlreadyCommitted(error) => write!(f, "Already committed: {error:?}"),
-            RejectionReason::FromExecution(rejection_error) => write!(f, "{rejection_error}"),
-            RejectionReason::ValidationError(validation_error) => {
+            MempoolRejectionReason::AlreadyCommitted(error) => {
+                write!(f, "Already committed: {error:?}")
+            }
+            MempoolRejectionReason::FromExecution(rejection_error) => {
+                write!(f, "{rejection_error}")
+            }
+            MempoolRejectionReason::ValidationError(validation_error) => {
                 write!(f, "Validation Error: {validation_error:?}")
             }
         }
@@ -214,7 +217,7 @@ pub struct PendingTransactionRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionAttempt {
-    pub rejection: Option<RejectionReason>,
+    pub rejection: Option<MempoolRejectionReason>,
     pub against_state: AtState,
     pub timestamp: SystemTime,
 }
@@ -370,7 +373,7 @@ impl PendingTransactionRecord {
         }
     }
 
-    pub fn most_applicable_status(&self) -> Option<&RejectionReason> {
+    pub fn most_applicable_status(&self) -> Option<&MempoolRejectionReason> {
         self.earliest_permanent_rejection
             .as_ref()
             .and_then(|r| r.rejection.as_ref())
@@ -511,11 +514,13 @@ impl PendingTransactionResultCache {
                     // We even overwrite the record for transaction which got committed here
                     // because this is a cache for pending transactions, and it can't be re-committed
                     record.track_attempt(TransactionAttempt {
-                        rejection: Some(RejectionReason::AlreadyCommitted(AlreadyCommittedError {
-                            notarized_transaction_hash: *cached_payload_hash,
-                            committed_state_version: committed_transaction.state_version,
-                            committed_notarized_transaction_hash,
-                        })),
+                        rejection: Some(MempoolRejectionReason::AlreadyCommitted(
+                            AlreadyCommittedError {
+                                notarized_transaction_hash: *cached_payload_hash,
+                                committed_state_version: committed_transaction.state_version,
+                                committed_notarized_transaction_hash,
+                            },
+                        )),
                         against_state: AtState::Committed {
                             state_version: committed_transaction.state_version,
                         },
@@ -544,12 +549,14 @@ impl PendingTransactionResultCache {
                 *intent_hash,
                 None,
                 TransactionAttempt {
-                    rejection: Some(RejectionReason::AlreadyCommitted(AlreadyCommittedError {
-                        notarized_transaction_hash: *notarized_transaction_hash,
-                        committed_state_version: committed_intent_record.state_version,
-                        committed_notarized_transaction_hash: committed_intent_record
-                            .notarized_transaction_hash,
-                    })),
+                    rejection: Some(MempoolRejectionReason::AlreadyCommitted(
+                        AlreadyCommittedError {
+                            notarized_transaction_hash: *notarized_transaction_hash,
+                            committed_state_version: committed_intent_record.state_version,
+                            committed_notarized_transaction_hash: committed_intent_record
+                                .notarized_transaction_hash,
+                        },
+                    )),
                     against_state: AtState::Committed {
                         state_version: committed_intent_record.state_version,
                     },
@@ -629,7 +636,6 @@ struct CommittedIntentRecord {
 
 #[cfg(test)]
 mod tests {
-    use radix_engine_interface::crypto::blake2b_256_hash;
 
     use super::*;
 
@@ -661,7 +667,7 @@ mod tests {
         let intent_hash_3 = intent_hash(3);
 
         let example_attempt_1 = TransactionAttempt {
-            rejection: Some(RejectionReason::ValidationError(
+            rejection: Some(MempoolRejectionReason::ValidationError(
                 TransactionValidationError::TransactionTooLarge,
             )),
             against_state: AtState::Static,
@@ -669,7 +675,7 @@ mod tests {
         };
 
         let example_attempt_2 = TransactionAttempt {
-            rejection: Some(RejectionReason::FromExecution(Box::new(
+            rejection: Some(MempoolRejectionReason::FromExecution(Box::new(
                 ExecutionRejectionReason::SuccessButFeeLoanNotRepaid,
             ))),
             against_state: AtState::Committed {
@@ -837,7 +843,7 @@ mod tests {
         let intent_hash_2 = intent_hash(2);
 
         let attempt_with_temporary_rejection = TransactionAttempt {
-            rejection: Some(RejectionReason::FromExecution(Box::new(
+            rejection: Some(MempoolRejectionReason::FromExecution(Box::new(
                 ExecutionRejectionReason::SuccessButFeeLoanNotRepaid,
             ))),
             against_state: AtState::Committed {
@@ -846,7 +852,7 @@ mod tests {
             timestamp: start,
         };
         let attempt_with_rejection_until_epoch_10 = TransactionAttempt {
-            rejection: Some(RejectionReason::FromExecution(Box::new(
+            rejection: Some(MempoolRejectionReason::FromExecution(Box::new(
                 ExecutionRejectionReason::TransactionEpochNotYetValid {
                     valid_from: Epoch::of(10),
                     current_epoch: Epoch::of(9),
@@ -858,7 +864,7 @@ mod tests {
             timestamp: start,
         };
         let attempt_with_permanent_rejection = TransactionAttempt {
-            rejection: Some(RejectionReason::ValidationError(
+            rejection: Some(MempoolRejectionReason::ValidationError(
                 TransactionValidationError::TransactionTooLarge,
             )),
             against_state: AtState::Committed {

--- a/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
+++ b/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::{
     transaction::{CheckMetadata, StaticValidation},

--- a/core-rust/state-manager/src/mempool/priority_mempool.rs
+++ b/core-rust/state-manager/src/mempool/priority_mempool.rs
@@ -67,8 +67,6 @@ use node_common::metrics::TakesMetricLabels;
 use prometheus::Registry;
 use rand::seq::index::sample;
 use tracing::warn;
-use transaction::model::*;
-use utils::prelude::indexmap::IndexMap;
 
 use crate::mempool::*;
 use itertools::Itertools;
@@ -543,11 +541,6 @@ impl PriorityMempool {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
-
-    use radix_engine::types::PublicKey;
-    use radix_engine_common::crypto::{Secp256k1PublicKey, Secp256k1Signature};
-    use radix_engine_common::types::Epoch;
-    use transaction::model::*;
 
     use crate::mempool::priority_mempool::*;
 

--- a/core-rust/state-manager/src/metrics.rs
+++ b/core-rust/state-manager/src/metrics.rs
@@ -75,14 +75,12 @@ use node_common::metrics::*;
 use prometheus::{
     Gauge, GaugeVec, Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
 };
-use radix_engine::blueprints::consensus_manager::EpochChangeEvent;
 
 use crate::protocol::{
     PendingProtocolUpdateState, ProtocolState, ProtocolUpdateEnactmentCondition,
 };
+use crate::scrypto_prelude::*;
 use crate::store::traits::measurement::CategoryDbVolumeStatistic;
-use radix_engine::transaction::TransactionFeeSummary;
-use radix_engine_common::prelude::*;
 
 pub struct LedgerMetrics {
     address_encoder: AddressBech32Encoder, // for label rendering only

--- a/core-rust/state-manager/src/metrics.rs
+++ b/core-rust/state-manager/src/metrics.rs
@@ -76,10 +76,10 @@ use prometheus::{
     Gauge, GaugeVec, Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
 };
 
+use crate::engine_prelude::*;
 use crate::protocol::{
     PendingProtocolUpdateState, ProtocolState, ProtocolUpdateEnactmentCondition,
 };
-use crate::scrypto_prelude::*;
 use crate::store::traits::measurement::CategoryDbVolumeStatistic;
 
 pub struct LedgerMetrics {

--- a/core-rust/state-manager/src/protocol/protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_config.rs
@@ -1,13 +1,6 @@
-use radix_engine::prelude::ScryptoSbor;
-use radix_engine_common::math::Decimal;
-use radix_engine_common::network::NetworkDefinition;
-use radix_engine_common::prelude::{hash, scrypto_encode};
-
-use radix_engine_common::types::Epoch;
-use sbor::Sbor;
+use crate::scrypto_prelude::*;
 
 use crate::protocol::*;
-use utils::prelude::*;
 
 // This file contains types for node's local static protocol configuration
 

--- a/core-rust/state-manager/src/protocol/protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_config.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::protocol::*;
 

--- a/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
@@ -1,5 +1,4 @@
-use radix_engine::prelude::*;
-
+use crate::scrypto_prelude::*;
 use chrono::prelude::*;
 use chrono::Duration;
 

--- a/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use chrono::prelude::*;
 use chrono::Duration;
 

--- a/core-rust/state-manager/src/protocol/protocol_configs/dumunet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/dumunet_protocol_config.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;

--- a/core-rust/state-manager/src/protocol/protocol_configs/dumunet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/dumunet_protocol_config.rs
@@ -1,4 +1,4 @@
-use radix_engine::prelude::*;
+use crate::scrypto_prelude::*;
 
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;

--- a/core-rust/state-manager/src/protocol/protocol_configs/mainnet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/mainnet_protocol_config.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;

--- a/core-rust/state-manager/src/protocol/protocol_configs/mainnet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/mainnet_protocol_config.rs
@@ -1,4 +1,4 @@
-use radix_engine::prelude::*;
+use crate::scrypto_prelude::*;
 
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;

--- a/core-rust/state-manager/src/protocol/protocol_configs/mod.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/mod.rs
@@ -5,8 +5,8 @@ mod mainnet_protocol_config;
 mod stokenet_protocol_config;
 mod testnet_protocol_config;
 
+use crate::engine_prelude::*;
 use crate::protocol::*;
-use crate::scrypto_prelude::*;
 
 pub fn resolve_protocol_config(network: &NetworkDefinition) -> ProtocolConfig {
     match network.logical_name.as_str() {

--- a/core-rust/state-manager/src/protocol/protocol_configs/mod.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/mod.rs
@@ -6,7 +6,7 @@ mod stokenet_protocol_config;
 mod testnet_protocol_config;
 
 use crate::protocol::*;
-use radix_engine_common::network::NetworkDefinition;
+use crate::scrypto_prelude::*;
 
 pub fn resolve_protocol_config(network: &NetworkDefinition) -> ProtocolConfig {
     match network.logical_name.as_str() {

--- a/core-rust/state-manager/src/protocol/protocol_configs/stokenet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/stokenet_protocol_config.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;

--- a/core-rust/state-manager/src/protocol/protocol_configs/stokenet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/stokenet_protocol_config.rs
@@ -1,4 +1,4 @@
-use radix_engine::prelude::*;
+use crate::scrypto_prelude::*;
 
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;

--- a/core-rust/state-manager/src/protocol/protocol_configs/testnet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/testnet_protocol_config.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;

--- a/core-rust/state-manager/src/protocol/protocol_configs/testnet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/testnet_protocol_config.rs
@@ -1,4 +1,4 @@
-use radix_engine::prelude::*;
+use crate::scrypto_prelude::*;
 
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;

--- a/core-rust/state-manager/src/protocol/protocol_state.rs
+++ b/core-rust/state-manager/src/protocol/protocol_state.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 

--- a/core-rust/state-manager/src/protocol/protocol_state.rs
+++ b/core-rust/state-manager/src/protocol/protocol_state.rs
@@ -1,17 +1,7 @@
-use radix_engine::blueprints::consensus_manager::EpochChangeEvent;
-use radix_engine::prelude::{ScryptoCategorize, ScryptoDecode, ScryptoEncode};
+use crate::scrypto_prelude::*;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
-use radix_engine_common::constants::CONSENSUS_MANAGER;
-
-use radix_engine_common::math::Decimal;
-use radix_engine_common::prelude::scrypto_decode;
-
-use radix_engine_common::types::Epoch;
-use radix_engine_interface::api::ModuleId;
-use radix_engine_interface::prelude::CheckedMul;
-use radix_engine_interface::prelude::Emitter;
 use tracing::info;
 
 use crate::protocol::*;

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/anemone_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/anemone_definition.rs
@@ -1,11 +1,6 @@
 use crate::protocol::*;
+use crate::scrypto_prelude::*;
 use crate::transaction::FlashTransactionV1;
-use radix_engine::types::*;
-use radix_engine::utils::{
-    generate_pools_v1_1_state_updates, generate_seconds_precision_state_updates,
-    generate_validator_fee_fix_state_updates, generate_vm_boot_scrypto_minor_version_state_updates,
-};
-use radix_engine_store_interface::interface::SubstateDatabase;
 
 pub struct AnemoneProtocolUpdateDefinition;
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/anemone_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/anemone_definition.rs
@@ -1,5 +1,5 @@
+use crate::engine_prelude::*;
 use crate::protocol::*;
-use crate::scrypto_prelude::*;
 use crate::transaction::FlashTransactionV1;
 
 pub struct AnemoneProtocolUpdateDefinition;

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
@@ -1,5 +1,5 @@
+use crate::engine_prelude::*;
 use crate::protocol::*;
-use crate::scrypto_prelude::*;
 
 /// Any protocol update beginning `custom-` can have content injected via config.
 pub struct CustomProtocolUpdateDefinition;

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
@@ -1,6 +1,5 @@
 use crate::protocol::*;
-use radix_engine::types::*;
-use radix_engine_store_interface::interface::SubstateDatabase;
+use crate::scrypto_prelude::*;
 
 /// Any protocol update beginning `custom-` can have content injected via config.
 pub struct CustomProtocolUpdateDefinition;

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
@@ -1,5 +1,5 @@
+use crate::engine_prelude::*;
 use crate::protocol::*;
-use crate::scrypto_prelude::*;
 
 pub struct DefaultConfigOnlyProtocolDefinition;
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
@@ -1,5 +1,5 @@
 use crate::protocol::*;
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
 
 pub struct DefaultConfigOnlyProtocolDefinition;
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/test_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/test_definition.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::{protocol::*, transaction::FlashTransactionV1};
 
 /// Any protocol update beginning `test-` just injects a single transaction.

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/test_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/test_definition.rs
@@ -1,5 +1,5 @@
+use crate::scrypto_prelude::*;
 use crate::{protocol::*, transaction::FlashTransactionV1};
-use radix_engine::{track::StateUpdates, types::*};
 
 /// Any protocol update beginning `test-` just injects a single transaction.
 pub struct TestProtocolUpdateDefinition;

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_content_overrides.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_content_overrides.rs
@@ -1,6 +1,6 @@
 use super::definitions::*;
+use crate::engine_prelude::*;
 use crate::protocol::*;
-use crate::scrypto_prelude::*;
 
 type Overrides<X> = <X as ProtocolUpdateDefinition>::Overrides;
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_content_overrides.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_content_overrides.rs
@@ -1,10 +1,6 @@
 use super::definitions::*;
 use crate::protocol::*;
-use radix_engine::types::scrypto_encode;
-use sbor::Sbor;
-
-use radix_engine_common::ScryptoSbor;
-use utils::prelude::*;
+use crate::scrypto_prelude::*;
 
 type Overrides<X> = <X as ProtocolUpdateDefinition>::Overrides;
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_committer.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_committer.rs
@@ -3,7 +3,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use node_common::locks::{LockFactory, RwLock, StateLock};
 
 use crate::epoch_handling::EpochAwareAccuTreeFactory;

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_committer.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_committer.rs
@@ -3,10 +3,8 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use crate::scrypto_prelude::*;
 use node_common::locks::{LockFactory, RwLock, StateLock};
-use radix_engine::prelude::*;
-
-use transaction::prelude::*;
 
 use crate::epoch_handling::EpochAwareAccuTreeFactory;
 use crate::protocol::*;

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_definition.rs
@@ -1,7 +1,7 @@
 // This file contains the protocol update logic for specific protocol versions
 
+use crate::engine_prelude::*;
 use crate::protocol::*;
-use crate::scrypto_prelude::*;
 
 use crate::transaction::*;
 use crate::LoggingConfig;

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_definition.rs
@@ -1,12 +1,10 @@
 // This file contains the protocol update logic for specific protocol versions
 
 use crate::protocol::*;
-use radix_engine::transaction::CostingParameters;
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
 
 use crate::transaction::*;
 use crate::LoggingConfig;
-use transaction::validation::{NotarizedTransactionValidator, ValidationConfig};
 
 /// A protocol update definition consists of two parts:
 /// 1) Updating the current (state computer) configuration ("transaction processing rules").

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
@@ -2,8 +2,10 @@ use node_common::locks::StateLock;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use crate::scrypto_prelude::*;
+
 use crate::protocol::*;
-use crate::traits::*;
+
 use crate::StateManagerDatabase;
 
 pub trait ProtocolUpdater {

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
@@ -2,7 +2,7 @@ use node_common::locks::StateLock;
 use std::ops::Deref;
 use std::sync::Arc;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::protocol::*;
 

--- a/core-rust/state-manager/src/protocol/test.rs
+++ b/core-rust/state-manager/src/protocol/test.rs
@@ -64,7 +64,7 @@
 
 use prometheus::Registry;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::traits::QueryableProofStore;
 
 use node_common::locks::LockFactory;

--- a/core-rust/state-manager/src/protocol/test.rs
+++ b/core-rust/state-manager/src/protocol/test.rs
@@ -63,28 +63,15 @@
  */
 
 use prometheus::Registry;
-use utils::prelude::*;
 
+use crate::scrypto_prelude::*;
 use crate::traits::QueryableProofStore;
-use radix_engine::blueprints::consensus_manager::{
-    ConsensusManagerConfigurationFieldPayload, ConsensusManagerField,
-};
-use radix_engine::prelude::dec;
-use radix_engine::system::system_substates::FieldSubstate;
-use radix_engine::utils::generate_validator_fee_fix_state_updates;
-
-use radix_engine_common::prelude::{Epoch, CONSENSUS_MANAGER};
-use radix_engine_interface::prelude::MAIN_BASE_PARTITION;
-use radix_engine_store_interface::db_key_mapper::{MappedSubstateDatabase, SpreadPrefixKeyMapper};
-
-use sbor::HasLatestVersion;
 
 use node_common::locks::LockFactory;
 use node_common::scheduler::Scheduler;
 
 use crate::protocol::*;
 use crate::{LedgerProof, LedgerProofOrigin, StateManager, StateManagerConfig};
-use radix_engine_common::types::Round;
 use std::ops::Deref;
 
 use crate::test::prepare_and_commit_round_update;

--- a/core-rust/state-manager/src/query/component_dumper.rs
+++ b/core-rust/state-manager/src/query/component_dumper.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub enum VaultData {
     Fungible {

--- a/core-rust/state-manager/src/query/component_dumper.rs
+++ b/core-rust/state-manager/src/query/component_dumper.rs
@@ -62,12 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine::types::*;
-use radix_engine_interface::blueprints::resource::{
-    LiquidFungibleResource, LiquidNonFungibleVault,
-};
-use radix_engine_queries::query::{StateTreeTraverser, StateTreeVisitor};
-use radix_engine_store_interface::interface::SubstateDatabase;
+use crate::scrypto_prelude::*;
 
 pub enum VaultData {
     Fungible {

--- a/core-rust/state-manager/src/query/state_manager_substate_queries.rs
+++ b/core-rust/state-manager/src/query/state_manager_substate_queries.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 pub trait StateManagerSubstateQueries {
     fn get_epoch(&self) -> Epoch;

--- a/core-rust/state-manager/src/query/state_manager_substate_queries.rs
+++ b/core-rust/state-manager/src/query/state_manager_substate_queries.rs
@@ -1,10 +1,4 @@
-use radix_engine::blueprints::consensus_manager::{
-    ConsensusManagerField, ConsensusManagerStateFieldSubstate,
-};
-use radix_engine::types::*;
-
-use radix_engine_store_interface::db_key_mapper::{MappedSubstateDatabase, SpreadPrefixKeyMapper};
-use radix_engine_store_interface::interface::SubstateDatabase;
+use crate::scrypto_prelude::*;
 
 pub trait StateManagerSubstateQueries {
     fn get_epoch(&self) -> Epoch;

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, WriteableAccuTreeStore};
 use crate::accumulator_tree::tree_builder::{AccuTree, Merklizable};

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -1,18 +1,4 @@
-use radix_engine_interface::blueprints::transaction_processor::InstructionOutput;
-use radix_engine_queries::typed_substate_layout::EpochChangeEvent;
-
-use radix_engine::errors::RuntimeError;
-
-use radix_engine::transaction::{
-    CommitResult, CostingParameters, EventSystemStructure, FeeDestination, FeeSource,
-    StateUpdateSummary, SubstateSystemStructure, TransactionFeeSummary, TransactionOutcome,
-};
-use radix_engine::types::*;
-
-use radix_engine_interface::types::EventTypeIdentifier;
-use radix_engine_store_interface::interface::DbSubstateValue;
-use sbor::rust::collections::IndexMap;
-use transaction::prelude::TransactionCostingParameters;
+use crate::scrypto_prelude::*;
 
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, WriteableAccuTreeStore};
 use crate::accumulator_tree::tree_builder::{AccuTree, Merklizable};

--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -69,30 +69,20 @@ use super::ReadableStore;
 
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice};
 use crate::protocol::ProtocolState;
+use crate::scrypto_prelude::*;
+use crate::staging::overlays::{
+    MapSubstateNodeAncestryStore, StagedSubstateNodeAncestryStore, SubstateOverlayIterator,
+};
 use crate::staging::{
     AccuTreeDiff, HashStructuresDiff, HashUpdateContext, ProcessedTransactionReceipt,
     StateHashTreeDiff,
 };
+use crate::transaction::{LedgerTransactionHash, TransactionLogic};
 use crate::{EpochTransactionIdentifiers, ReceiptTreeHash, StateVersion, TransactionTreeHash};
 use im::hashmap::HashMap as ImmutableHashMap;
 use itertools::Itertools;
 
-use radix_engine_common::prelude::NodeId;
-
-use radix_engine_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
-
-use crate::staging::overlays::{
-    MapSubstateNodeAncestryStore, StagedSubstateNodeAncestryStore, SubstateOverlayIterator,
-};
-use crate::transaction::{LedgerTransactionHash, TransactionLogic};
-use radix_engine_store_interface::interface::{
-    DatabaseUpdate, DbPartitionKey, DbSortKey, DbSubstateValue, PartitionDatabaseUpdates,
-    PartitionEntry, SubstateDatabase,
-};
-use radix_engine_stores::hash_tree::tree_store::{NodeKey, ReadableTreeStore, TreeNode};
-
 use crate::store::traits::{SubstateNodeAncestryRecord, SubstateNodeAncestryStore};
-use sbor::rust::collections::HashMap;
 use slotmap::SecondaryMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd)]

--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -68,8 +68,8 @@ use super::stage_tree::{Accumulator, Delta, DerivedStageKey, StageKey, StageTree
 use super::ReadableStore;
 
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice};
+use crate::engine_prelude::*;
 use crate::protocol::ProtocolState;
-use crate::scrypto_prelude::*;
 use crate::staging::overlays::{
     MapSubstateNodeAncestryStore, StagedSubstateNodeAncestryStore, SubstateOverlayIterator,
 };

--- a/core-rust/state-manager/src/staging/mod.rs
+++ b/core-rust/state-manager/src/staging/mod.rs
@@ -70,9 +70,8 @@ mod result;
 mod stage_tree;
 
 use crate::accumulator_tree::storage::ReadableAccuTreeStore;
+use crate::scrypto_prelude::*;
 use crate::{ReceiptTreeHash, StateVersion, TransactionTreeHash};
-use radix_engine_store_interface::interface::SubstateDatabase;
-use radix_engine_stores::hash_tree::tree_store::ReadableTreeStore;
 
 use crate::store::traits::SubstateNodeAncestryStore;
 pub use cache::*;

--- a/core-rust/state-manager/src/staging/mod.rs
+++ b/core-rust/state-manager/src/staging/mod.rs
@@ -70,7 +70,7 @@ mod result;
 mod stage_tree;
 
 use crate::accumulator_tree::storage::ReadableAccuTreeStore;
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::{ReceiptTreeHash, StateVersion, TransactionTreeHash};
 
 use crate::store::traits::SubstateNodeAncestryStore;

--- a/core-rust/state-manager/src/staging/node_ancestry_resolver.rs
+++ b/core-rust/state-manager/src/staging/node_ancestry_resolver.rs
@@ -62,12 +62,11 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use crate::store::traits::*;
 use crate::{SubstateChangeAction, SubstateReference};
 use std::borrow::Borrow;
 use std::collections::hash_map::Entry;
-
-use radix_engine::types::*;
 
 /// A parent Substate and its owned Nodes.
 /// This structure may be used to represent only directly owned Nodes (i.e. all immediate children),
@@ -297,7 +296,6 @@ impl NodeAncestryResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sbor::Value;
 
     #[test]
     pub fn newly_created_child_nodes_are_recorded_under_their_existing_parents() {

--- a/core-rust/state-manager/src/staging/node_ancestry_resolver.rs
+++ b/core-rust/state-manager/src/staging/node_ancestry_resolver.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::store::traits::*;
 use crate::{SubstateChangeAction, SubstateReference};
 use std::borrow::Borrow;

--- a/core-rust/state-manager/src/staging/overlays.rs
+++ b/core-rust/state-manager/src/staging/overlays.rs
@@ -1,11 +1,9 @@
-use radix_engine_store_interface::interface::{DatabaseUpdate, DbSortKey, PartitionEntry};
+use crate::scrypto_prelude::*;
 use std::cmp::Ordering;
 use std::hash::Hash;
 use std::iter::Peekable;
 
 use crate::store::traits::{SubstateNodeAncestryRecord, SubstateNodeAncestryStore};
-use radix_engine_common::types::NodeId;
-use utils::prelude::NonIterMap;
 
 pub struct SubstateOverlayIterator<'a> {
     root_db: Peekable<Box<dyn Iterator<Item = PartitionEntry> + 'a>>,

--- a/core-rust/state-manager/src/staging/overlays.rs
+++ b/core-rust/state-manager/src/staging/overlays.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use std::cmp::Ordering;
 use std::hash::Hash;
 use std::iter::Peekable;

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -65,8 +65,8 @@
 use super::ReadableStateTreeStore;
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, WriteableAccuTreeStore};
 
+use crate::engine_prelude::*;
 use crate::protocol::{ProtocolState, ProtocolVersionName};
-use crate::scrypto_prelude::*;
 use crate::staging::epoch_handling::EpochAwareAccuTreeFactory;
 use crate::transaction::LedgerTransactionHash;
 use crate::{

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -66,6 +66,7 @@ use super::ReadableStateTreeStore;
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice, WriteableAccuTreeStore};
 
 use crate::protocol::{ProtocolState, ProtocolVersionName};
+use crate::scrypto_prelude::*;
 use crate::staging::epoch_handling::EpochAwareAccuTreeFactory;
 use crate::transaction::LedgerTransactionHash;
 use crate::{
@@ -74,29 +75,13 @@ use crate::{
     NextEpoch, PartitionChangeAction, ReceiptTreeHash, StateHash, StateVersion,
     SubstateChangeAction, SubstateReference, TransactionTreeHash,
 };
-use radix_engine::blueprints::consensus_manager::EpochChangeEvent;
-use radix_engine::blueprints::resource::{FungibleVaultBalanceFieldSubstate, FungibleVaultField};
-use radix_engine::transaction::{
-    AbortResult, BalanceChange, CommitResult, CostingParameters, RejectResult,
-    TransactionFeeSummary, TransactionReceipt, TransactionResult,
-};
-use radix_engine_interface::prelude::*;
 
 use crate::staging::ReadableStore;
-
-use radix_engine::track::{
-    BatchPartitionStateUpdate, NodeStateUpdates, PartitionStateUpdates, StateUpdates,
-};
 
 use crate::staging::node_ancestry_resolver::NodeAncestryResolver;
 use crate::staging::overlays::{MapSubstateNodeAncestryStore, StagedSubstateNodeAncestryStore};
 use crate::store::traits::{KeyedSubstateNodeAncestryRecord, SubstateNodeAncestryStore};
 use node_common::utils::IsAccountExt;
-use radix_engine_store_interface::db_key_mapper::*;
-use radix_engine_store_interface::interface::*;
-use radix_engine_stores::hash_tree::tree_store::*;
-use radix_engine_stores::hash_tree::*;
-use transaction::prelude::TransactionCostingParameters;
 
 pub enum ProcessedTransactionReceipt {
     Commit(ProcessedCommitResult),

--- a/core-rust/state-manager/src/staging/stage_tree.rs
+++ b/core-rust/state-manager/src/staging/stage_tree.rs
@@ -62,9 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine::types::*;
-
-use sbor::rust::vec::Vec;
+use crate::scrypto_prelude::*;
 use slotmap::{new_key_type, SlotMap};
 
 new_key_type! {
@@ -309,9 +307,8 @@ impl<D: Delta, A: Accumulator<D>> StageTree<D, A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use radix_engine::types::rust::iter::zip;
-    use sbor::rust::collections::HashMap;
-    use sbor::rust::vec::Vec;
+
+    use std::iter::zip;
 
     struct TestDelta(Vec<(u8, u32)>);
 

--- a/core-rust/state-manager/src/staging/stage_tree.rs
+++ b/core-rust/state-manager/src/staging/stage_tree.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use slotmap::{new_key_type, SlotMap};
 
 new_key_type! {

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -71,16 +71,11 @@ use crate::store::traits::*;
 use crate::transaction::*;
 use crate::types::{CommitRequest, PrepareRequest, PrepareResult};
 use crate::*;
-use ::transaction::errors::TransactionValidationError;
-use ::transaction::model::{IntentHash, NotarizedTransactionHash};
-use ::transaction::prelude::*;
 use node_common::config::limits::VertexLimitsConfig;
 
-use radix_engine::system::bootstrap::*;
-use radix_engine::transaction::TransactionReceipt;
-use radix_engine_interface::blueprints::consensus_manager::{
-    ConsensusManagerConfig, EpochChangeCondition,
-};
+use crate::scrypto_prelude::*;
+use ::transaction::model::PrepareError; // disambiguation needed because of a wide prelude
+
 use transaction_scenarios::scenario::DescribedAddress as ScenarioDescribedAddress;
 use transaction_scenarios::scenario::*;
 use transaction_scenarios::scenarios::*;
@@ -556,7 +551,7 @@ where
                         intent_hash,
                         notarized_transaction_hash,
                         invalid_at_epoch,
-                        rejection_reason: Some(RejectionReason::ValidationError(
+                        rejection_reason: Some(MempoolRejectionReason::ValidationError(
                             error.into_user_validation_error(),
                         )),
                     });
@@ -639,7 +634,7 @@ where
                         intent_hash,
                         notarized_transaction_hash,
                         invalid_at_epoch,
-                        rejection_reason: Some(RejectionReason::FromExecution(Box::new(
+                        rejection_reason: Some(MempoolRejectionReason::FromExecution(Box::new(
                             result.reason,
                         ))),
                     });
@@ -1459,13 +1454,14 @@ struct PendingTransactionResult {
     pub intent_hash: IntentHash,
     pub notarized_transaction_hash: NotarizedTransactionHash,
     pub invalid_at_epoch: Epoch,
-    pub rejection_reason: Option<RejectionReason>,
+    pub rejection_reason: Option<MempoolRejectionReason>,
 }
 
 #[cfg(test)]
 mod tests {
     use std::ops::Deref;
 
+    use crate::scrypto_prelude::*;
     use crate::transaction::{LedgerTransaction, RoundUpdateTransactionV1};
     use crate::{
         LedgerProof, PrepareRequest, PrepareResult, RoundHistory, StateManager, StateManagerConfig,
@@ -1474,11 +1470,7 @@ mod tests {
     use node_common::locks::LockFactory;
     use node_common::scheduler::Scheduler;
     use prometheus::Registry;
-    use radix_engine_common::prelude::NetworkDefinition;
-    use radix_engine_common::types::{Epoch, Round};
     use tempfile::TempDir;
-    use transaction::builder::ManifestBuilder;
-    use transaction::prelude::*;
 
     // TODO: maybe move/refactor testing infra as we add more Rust tests
     fn build_unit_test_round_history(proof: &LedgerProof) -> RoundHistory {

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -73,7 +73,7 @@ use crate::types::{CommitRequest, PrepareRequest, PrepareResult};
 use crate::*;
 use node_common::config::limits::VertexLimitsConfig;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use ::transaction::model::PrepareError; // disambiguation needed because of a wide prelude
 
 use transaction_scenarios::scenario::DescribedAddress as ScenarioDescribedAddress;
@@ -1461,7 +1461,7 @@ struct PendingTransactionResult {
 mod tests {
     use std::ops::Deref;
 
-    use crate::scrypto_prelude::*;
+    use crate::engine_prelude::*;
     use crate::transaction::{LedgerTransaction, RoundUpdateTransactionV1};
     use crate::{
         LedgerProof, PrepareRequest, PrepareResult, RoundHistory, StateManager, StateManagerConfig,

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -66,17 +66,9 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
-use node_common::scheduler::{Metrics, Scheduler, Spawner, Tracker};
-use node_common::{
-    config::{limits::VertexLimitsConfig, MempoolConfig},
-    locks::*,
-};
-use prometheus::Registry;
-
-use radix_engine_common::prelude::*;
-
 use crate::jni::LedgerSyncLimitsConfig;
 use crate::protocol::{ProtocolConfig, ProtocolState, ProtocolVersionName};
+use crate::scrypto_prelude::*;
 use crate::store::jmt_gc::StateHashTreeGcConfig;
 use crate::store::proofs_gc::{LedgerProofsGc, LedgerProofsGcConfig};
 use crate::store::traits::proofs::QueryableProofStore;
@@ -92,6 +84,12 @@ use crate::{
     transaction::{CachedCommittabilityValidator, CommittabilityValidator, TransactionPreviewer},
     PendingTransactionResultCache, ProtocolUpdateResult, StateComputer,
 };
+use node_common::scheduler::{Metrics, Scheduler, Spawner, Tracker};
+use node_common::{
+    config::{limits::VertexLimitsConfig, MempoolConfig},
+    locks::*,
+};
+use prometheus::Registry;
 
 /// An interval between time-intensive measurement of raw DB metrics.
 /// Some of our raw DB metrics take ~a few milliseconds to collect. We cannot afford the overhead of

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -66,9 +66,9 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::engine_prelude::*;
 use crate::jni::LedgerSyncLimitsConfig;
 use crate::protocol::{ProtocolConfig, ProtocolState, ProtocolVersionName};
-use crate::scrypto_prelude::*;
 use crate::store::jmt_gc::StateHashTreeGcConfig;
 use crate::store::proofs_gc::{LedgerProofsGc, LedgerProofsGcConfig};
 use crate::store::traits::proofs::QueryableProofStore;

--- a/core-rust/state-manager/src/store/codecs.rs
+++ b/core-rust/state-manager/src/store/codecs.rs
@@ -66,7 +66,7 @@ use std::ops::Range;
 
 use crate::StateVersion;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::store::traits::scenario::ScenarioSequenceNumber;
 use crate::store::typed_cf_api::*;
 use crate::transaction::RawLedgerTransaction;

--- a/core-rust/state-manager/src/store/codecs.rs
+++ b/core-rust/state-manager/src/store/codecs.rs
@@ -66,10 +66,7 @@ use std::ops::Range;
 
 use crate::StateVersion;
 
-use radix_engine::types::*;
-use radix_engine_store_interface::interface::*;
-use radix_engine_stores::hash_tree::tree_store::{encode_key, NodeKey};
-
+use crate::scrypto_prelude::*;
 use crate::store::traits::scenario::ScenarioSequenceNumber;
 use crate::store::typed_cf_api::*;
 use crate::transaction::RawLedgerTransaction;

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -69,19 +69,12 @@ use std::path::PathBuf;
 
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice};
 use crate::query::TransactionIdentifierLoader;
+use crate::scrypto_prelude::*;
 use crate::{
     CommittedTransactionIdentifiers, LedgerHashes, ReceiptTreeHash, StateVersion,
     TransactionTreeHash,
 };
 use enum_dispatch::enum_dispatch;
-use radix_engine_common::network::NetworkDefinition;
-use radix_engine_store_interface::interface::{
-    DbPartitionKey, DbSortKey, DbSubstateValue, PartitionEntry, SubstateDatabase,
-};
-use transaction::model::*;
-
-use radix_engine_stores::hash_tree::tree_store::{NodeKey, ReadableTreeStore, TreeNode};
-use sbor::{Categorize, Decode, Encode};
 
 #[derive(Debug, Categorize, Encode, Decode, Clone)]
 pub struct DatabaseBackendConfig {

--- a/core-rust/state-manager/src/store/db.rs
+++ b/core-rust/state-manager/src/store/db.rs
@@ -68,8 +68,8 @@ use crate::transaction::LedgerTransactionHash;
 use std::path::PathBuf;
 
 use crate::accumulator_tree::storage::{ReadableAccuTreeStore, TreeSlice};
+use crate::engine_prelude::*;
 use crate::query::TransactionIdentifierLoader;
-use crate::scrypto_prelude::*;
 use crate::{
     CommittedTransactionIdentifiers, LedgerHashes, ReceiptTreeHash, StateVersion,
     TransactionTreeHash,

--- a/core-rust/state-manager/src/store/jmt_gc.rs
+++ b/core-rust/state-manager/src/store/jmt_gc.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use std::iter;
 use std::ops::Deref;
 use std::sync::Arc;

--- a/core-rust/state-manager/src/store/jmt_gc.rs
+++ b/core-rust/state-manager/src/store/jmt_gc.rs
@@ -62,10 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine::types::{Categorize, Decode, Encode};
-use radix_engine_stores::hash_tree::tree_store::{
-    NodeKey, ReadableTreeStore, StaleTreePart, TreeChildEntry, TreeNode,
-};
+use crate::scrypto_prelude::*;
 use std::iter;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -260,13 +257,6 @@ fn recurse_children_and_append_parent<'s, S: ReadableTreeStore + 's>(
 mod tests {
 
     use super::*;
-    use radix_engine::types::indexmap::indexmap;
-    use radix_engine_store_interface::interface::{
-        DatabaseUpdate, DatabaseUpdates, DbSortKey, NodeDatabaseUpdates, PartitionDatabaseUpdates,
-    };
-    use radix_engine_stores::hash_tree::put_at_next_version;
-    use radix_engine_stores::hash_tree::tree_store::{NibblePath, TypedInMemoryTreeStore};
-    use utils::prelude::{index_set_new, IndexSet};
 
     #[test]
     fn iterates_substates_from_deleted_partition_in_dfs_order() {

--- a/core-rust/state-manager/src/store/proofs_gc.rs
+++ b/core-rust/state-manager/src/store/proofs_gc.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info};
@@ -310,10 +310,10 @@ impl ProofPruneRange {
 
 #[cfg(test)]
 mod tests {
+    use crate::engine_prelude::*;
     use crate::jni::LedgerSyncLimitsConfig;
     use crate::proofs_gc::{LedgerProofsGc, LedgerProofsGcConfig};
     use crate::protocol::*;
-    use crate::scrypto_prelude::*;
     use crate::store::traits::proofs::QueryableProofStore;
     use crate::test::commit_round_updates_until_epoch;
     use crate::traits::GetSyncableTxnsAndProofError;

--- a/core-rust/state-manager/src/store/proofs_gc.rs
+++ b/core-rust/state-manager/src/store/proofs_gc.rs
@@ -62,9 +62,7 @@
  * permissions under this License.
  */
 
-use radix_engine::types::{Categorize, Decode, Encode};
-
-use radix_engine_common::types::Epoch;
+use crate::scrypto_prelude::*;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info};
@@ -315,6 +313,7 @@ mod tests {
     use crate::jni::LedgerSyncLimitsConfig;
     use crate::proofs_gc::{LedgerProofsGc, LedgerProofsGcConfig};
     use crate::protocol::*;
+    use crate::scrypto_prelude::*;
     use crate::store::traits::proofs::QueryableProofStore;
     use crate::test::commit_round_updates_until_epoch;
     use crate::traits::GetSyncableTxnsAndProofError;
@@ -322,10 +321,6 @@ mod tests {
     use node_common::locks::LockFactory;
     use node_common::scheduler::Scheduler;
     use prometheus::Registry;
-    use radix_engine_common::prelude::*;
-    use radix_engine_interface::blueprints::consensus_manager::{
-        ConsensusManagerConfig, EpochChangeCondition,
-    };
     use std::time::Duration;
 
     #[test]

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -65,6 +65,7 @@
 use std::collections::HashSet;
 use std::fmt;
 
+use crate::scrypto_prelude::*;
 use crate::store::traits::*;
 use crate::{
     CommittedTransactionIdentifiers, LedgerProof, LedgerProofOrigin, LedgerTransactionReceipt,
@@ -73,16 +74,8 @@ use crate::{
     VersionedLedgerProof, VersionedLedgerTransactionReceipt, VersionedLocalTransactionExecution,
 };
 use node_common::utils::IsAccountExt;
-use radix_engine::types::*;
-use radix_engine_stores::hash_tree::tree_store::{
-    NodeKey, ReadableTreeStore, TreeNode, VersionedTreeNode,
-};
 use rocksdb::{ColumnFamilyDescriptor, Direction, Options, DB};
-use transaction::model::*;
 
-use radix_engine_store_interface::interface::*;
-
-use radix_engine_store_interface::db_key_mapper::{DatabaseKeyMapper, SpreadPrefixKeyMapper};
 use std::path::PathBuf;
 
 use tracing::{error, info, warn};

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -65,7 +65,7 @@
 use std::collections::HashSet;
 use std::fmt;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::store::traits::*;
 use crate::{
     CommittedTransactionIdentifiers, LedgerProof, LedgerProofOrigin, LedgerTransactionReceipt,

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -65,7 +65,7 @@
 use std::cmp::Ordering;
 use std::iter::Peekable;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use crate::staging::StateHashTreeDiff;
 use crate::store::StateManagerDatabase;
 use crate::transaction::*;

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -65,6 +65,7 @@
 use std::cmp::Ordering;
 use std::iter::Peekable;
 
+use crate::scrypto_prelude::*;
 use crate::staging::StateHashTreeDiff;
 use crate::store::StateManagerDatabase;
 use crate::transaction::*;
@@ -72,13 +73,9 @@ use crate::{CommittedTransactionIdentifiers, LedgerProof, LocalTransactionReceip
 pub use commit::*;
 use enum_dispatch::enum_dispatch;
 pub use proofs::*;
-use radix_engine_common::{Categorize, Decode, Encode};
 pub use substate::*;
 pub use transactions::*;
 pub use vertex::*;
-
-use radix_engine::types::{ScryptoCategorize, ScryptoDecode, ScryptoEncode};
-use sbor::define_single_versioned;
 
 #[derive(Debug, Clone)]
 pub enum DatabaseConfigValidationError {
@@ -177,13 +174,9 @@ pub mod vertex {
 
 pub mod substate {
     use super::*;
-    use radix_engine_common::types::NodeId;
     use std::slice;
 
     use crate::SubstateReference;
-    pub use radix_engine_store_interface::interface::{
-        CommittableSubstateDatabase, SubstateDatabase,
-    };
 
     /// A low-level storage of [`SubstateNodeAncestryRecord`].
     /// API note: this trait defines a simple "get by ID" method, and also a performance-driven
@@ -296,7 +289,6 @@ pub mod transactions {
 }
 
 pub mod proofs {
-    use radix_engine_common::types::Epoch;
 
     use super::*;
 
@@ -368,11 +360,6 @@ pub mod commit {
     use super::*;
     use crate::accumulator_tree::storage::TreeSlice;
     use crate::{ReceiptTreeHash, StateVersion, TransactionTreeHash};
-
-    use radix_engine_store_interface::interface::{
-        DatabaseUpdate, DatabaseUpdates, NodeDatabaseUpdates, PartitionDatabaseUpdates,
-    };
-    use radix_engine_stores::hash_tree::tree_store::{NodeKey, StaleTreePart, TreeNode};
 
     pub struct CommitBundle {
         pub transactions: Vec<CommittedTransactionBundle>,
@@ -537,8 +524,6 @@ pub mod commit {
 pub mod scenario {
     use super::*;
 
-    use transaction::model::IntentHash;
-
     pub type ScenarioSequenceNumber = u32;
 
     define_single_versioned! {
@@ -584,8 +569,6 @@ pub mod scenario {
 
 pub mod extensions {
     use super::*;
-    use radix_engine::types::GlobalAddress;
-    use radix_engine_common::network::NetworkDefinition;
 
     #[enum_dispatch]
     pub trait AccountChangeIndexExtension {
@@ -673,8 +656,6 @@ pub mod measurement {
 pub mod gc {
     use super::*;
     use crate::LedgerHeader;
-    use radix_engine_common::types::Epoch;
-    use radix_engine_stores::hash_tree::tree_store::NodeKey;
 
     /// A storage API tailored for the [`StateHashTreeGc`].
     #[enum_dispatch]

--- a/core-rust/state-manager/src/store/typed_cf_api.rs
+++ b/core-rust/state-manager/src/store/typed_cf_api.rs
@@ -62,8 +62,8 @@
  * permissions under this License.
  */
 
+use crate::scrypto_prelude::*;
 use itertools::Itertools;
-use radix_engine::types::*;
 use rocksdb::{ColumnFamily, Direction, IteratorMode, WriteBatch, DB};
 use std::ops::Range;
 

--- a/core-rust/state-manager/src/store/typed_cf_api.rs
+++ b/core-rust/state-manager/src/store/typed_cf_api.rs
@@ -62,7 +62,7 @@
  * permissions under this License.
  */
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use itertools::Itertools;
 use rocksdb::{ColumnFamily, Direction, IteratorMode, WriteBatch, DB};
 use std::ops::Range;

--- a/core-rust/state-manager/src/test/mod.rs
+++ b/core-rust/state-manager/src/test/mod.rs
@@ -1,11 +1,10 @@
 use crate::query::TransactionIdentifierLoader;
+use crate::scrypto_prelude::*;
 use crate::traits::QueryableProofStore;
 use crate::{
     CommitRequest, CommitSummary, LedgerHeader, LedgerProof, LedgerProofOrigin, PrepareRequest,
     PrepareResult, RoundHistory, StateManager,
 };
-use radix_engine_common::crypto::Hash;
-use radix_engine_common::prelude::{Epoch, Round};
 
 /// A bunch of test utils
 

--- a/core-rust/state-manager/src/test/mod.rs
+++ b/core-rust/state-manager/src/test/mod.rs
@@ -1,5 +1,5 @@
+use crate::engine_prelude::*;
 use crate::query::TransactionIdentifierLoader;
-use crate::scrypto_prelude::*;
 use crate::traits::QueryableProofStore;
 use crate::{
     CommitRequest, CommitSummary, LedgerHeader, LedgerProof, LedgerProofOrigin, PrepareRequest,

--- a/core-rust/state-manager/src/transaction/executable_logic.rs
+++ b/core-rust/state-manager/src/transaction/executable_logic.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 // disambiguation needed because of a wide prelude
 
 use crate::LoggingConfig;

--- a/core-rust/state-manager/src/transaction/executable_logic.rs
+++ b/core-rust/state-manager/src/transaction/executable_logic.rs
@@ -1,24 +1,12 @@
-use radix_engine::system::bootstrap::FlashReceipt;
-use radix_engine::system::system_db_reader::SystemDatabaseReader;
-use radix_engine::track::StateUpdates;
-use radix_engine::transaction::{
-    execute_transaction, CommitResult, CostingParameters, ExecutionConfig, SubstateSchemaMapper,
-    SystemStructure, TransactionOutcome, TransactionReceipt,
-};
-use radix_engine::vm::wasm::DefaultWasmEngine;
-use radix_engine::vm::{DefaultNativeVm, ScryptoVm, Vm};
-use radix_engine_common::network::NetworkDefinition;
-use std::collections::HashMap;
-use std::time::{Duration, Instant};
-
-use radix_engine_interface::*;
-use radix_engine_store_interface::interface::SubstateDatabase;
-
-use tracing::warn;
+use crate::scrypto_prelude::*;
+// disambiguation needed because of a wide prelude
 
 use crate::LoggingConfig;
-use transaction::model::*;
-use utils::prelude::index_map_new;
+use std::collections::HashMap;
+
+use std::time::{Duration, Instant};
+
+use tracing::warn;
 
 use super::ValidatedLedgerTransaction;
 

--- a/core-rust/state-manager/src/transaction/ledger_transaction.rs
+++ b/core-rust/state-manager/src/transaction/ledger_transaction.rs
@@ -1,13 +1,7 @@
-use radix_engine::system::bootstrap::create_substate_flash_for_genesis;
-
-use radix_engine::track::StateUpdates;
-
-use radix_engine_interface::api::node_modules::auth::AuthAddresses;
-use radix_engine_interface::prelude::*;
+use crate::scrypto_prelude::*;
+use ::transaction::model::PrepareError; // disambiguation needed because of a wide prelude
 
 use crate::transaction::{ConfigType, ConfiguredExecutable};
-use transaction::define_raw_transaction_payload;
-use transaction::prelude::*;
 
 use super::{
     HasRoundUpdateTransactionHash, PreparedRoundUpdateTransactionV1, RoundUpdateTransactionHash,

--- a/core-rust/state-manager/src/transaction/ledger_transaction.rs
+++ b/core-rust/state-manager/src/transaction/ledger_transaction.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use ::transaction::model::PrepareError; // disambiguation needed because of a wide prelude
 
 use crate::transaction::{ConfigType, ConfiguredExecutable};

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -1,6 +1,5 @@
+use crate::scrypto_prelude::*;
 use node_common::locks::{RwLock, StateLock};
-use radix_engine::transaction::{PreviewError, TransactionReceipt, TransactionResult};
-use radix_engine_store_interface::db_key_mapper::SpreadPrefixKeyMapper;
 use std::ops::{Deref, Range};
 use std::sync::Arc;
 
@@ -11,11 +10,6 @@ use crate::transaction::*;
 use crate::{
     GlobalBalanceSummary, LedgerHeader, LedgerStateChanges, PreviewRequest, ProcessedCommitResult,
 };
-use radix_engine_common::prelude::*;
-use transaction::model::*;
-use transaction::prelude::Secp256k1PrivateKey;
-use transaction::validation::NotarizedTransactionValidator;
-use transaction::validation::ValidationConfig;
 
 /// A transaction preview runner.
 pub struct TransactionPreviewer<S> {
@@ -132,12 +126,11 @@ impl<S: ReadableStore + QueryableProofStore + TransactionIdentifierLoader> Trans
 #[cfg(test)]
 mod tests {
 
+    use crate::scrypto_prelude::*;
     use crate::{PreviewRequest, StateManager, StateManagerConfig};
     use node_common::locks::LockFactory;
     use node_common::scheduler::Scheduler;
     use prometheus::Registry;
-    use transaction::builder::ManifestBuilder;
-    use transaction::model::{MessageV1, PreviewFlags};
 
     #[test]
     fn test_preview_processed_substate_changes() {

--- a/core-rust/state-manager/src/transaction/preview.rs
+++ b/core-rust/state-manager/src/transaction/preview.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use node_common::locks::{RwLock, StateLock};
 use std::ops::{Deref, Range};
 use std::sync::Arc;
@@ -126,7 +126,7 @@ impl<S: ReadableStore + QueryableProofStore + TransactionIdentifierLoader> Trans
 #[cfg(test)]
 mod tests {
 
-    use crate::scrypto_prelude::*;
+    use crate::engine_prelude::*;
     use crate::{PreviewRequest, StateManager, StateManagerConfig};
     use node_common::locks::LockFactory;
     use node_common::scheduler::Scheduler;

--- a/core-rust/state-manager/src/transaction/round_update_transaction.rs
+++ b/core-rust/state-manager/src/transaction/round_update_transaction.rs
@@ -1,10 +1,7 @@
-use radix_engine::types::*;
+use crate::scrypto_prelude::*;
+use ::transaction::model::PrepareError; // disambiguation needed because of a wide prelude
 
 use crate::{LedgerHeader, RoundHistory, ValidatorId};
-use radix_engine_interface::api::node_modules::auth::AuthAddresses;
-use radix_engine_interface::blueprints::consensus_manager::*;
-use sbor::FixedEnumVariant;
-use transaction::{define_raw_transaction_payload, model::*};
 
 #[derive(Debug, Clone, Categorize, Encode, Decode, PartialEq, Eq)]
 pub struct RoundUpdateTransactionV1 {

--- a/core-rust/state-manager/src/transaction/round_update_transaction.rs
+++ b/core-rust/state-manager/src/transaction/round_update_transaction.rs
@@ -1,4 +1,4 @@
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use ::transaction::model::PrepareError; // disambiguation needed because of a wide prelude
 
 use crate::{LedgerHeader, RoundHistory, ValidatorId};

--- a/core-rust/state-manager/src/transaction/series_execution.rs
+++ b/core-rust/state-manager/src/transaction/series_execution.rs
@@ -71,7 +71,7 @@ use crate::store::traits::*;
 use crate::transaction::*;
 use crate::*;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use node_common::locks::{Mutex, RwLock};
 
 /// An internal delegate for executing a series of consecutive transactions while tracking their

--- a/core-rust/state-manager/src/transaction/series_execution.rs
+++ b/core-rust/state-manager/src/transaction/series_execution.rs
@@ -71,9 +71,8 @@ use crate::store::traits::*;
 use crate::transaction::*;
 use crate::*;
 
-use ::transaction::prelude::*;
+use crate::scrypto_prelude::*;
 use node_common::locks::{Mutex, RwLock};
-use radix_engine::blueprints::consensus_manager::EpochChangeEvent;
 
 /// An internal delegate for executing a series of consecutive transactions while tracking their
 /// progress.

--- a/core-rust/state-manager/src/transaction/validation.rs
+++ b/core-rust/state-manager/src/transaction/validation.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use crate::scrypto_prelude::*;
+use crate::engine_prelude::*;
 use ::transaction::model::PrepareError; // disambiguation needed because of a wide prelude
 
 use crate::query::StateManagerSubstateQueries;

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -64,16 +64,14 @@
 
 use crate::accumulator_tree::IsMerklizableHash;
 use crate::protocol::ProtocolVersionName;
+use crate::scrypto_prelude::*;
 use crate::transaction::*;
 use crate::{LedgerTransactionOutcome, PartitionChange, SubstateChange};
-use radix_engine::types::*;
-use radix_engine_common::prelude::IsHash;
 use std::fmt;
 use std::fmt::Formatter;
 use std::mem::size_of;
 use std::num::TryFromIntError;
 use std::ops::Range;
-use transaction::prelude::*;
 
 /// A complete ID of a Substate.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -63,8 +63,8 @@
  */
 
 use crate::accumulator_tree::IsMerklizableHash;
+use crate::engine_prelude::*;
 use crate::protocol::ProtocolVersionName;
-use crate::scrypto_prelude::*;
 use crate::transaction::*;
 use crate::{LedgerTransactionOutcome, PartitionChange, SubstateChange};
 use std::fmt;


### PR DESCRIPTION
## Summary

This addresses https://radixdlt.atlassian.net/browse/NODE-596.

## Details

Apart from pulling the newest scrypto dep, this PR contains a slight convenience-only refactor:

Each of our crates now contains a top-level `pub(crate) mod scrypto_prelude { <lots of engine imports relevant to that crate> }`.
From this point on, all other files in these crates are supposed to only import a single `use crate::scrypto_prelude::*;` (instead of many independent engine imports).

## Testing

No Node feature / behavior change here - existing tests are sufficient.