### PR TITLE
Add keygen startScripts dependency for distZip and distTar; update scripts path

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -379,8 +379,14 @@ task deb4docker(dependsOn: buildDeb) {
     }
 }
 
+// This adds the `startScripts` task artifacts from the keygen subproject (i.e. app
+// run scripts: `keygen` and `keygen.bat`) to the "bin" folder in core's distribution.
+// Note that we don't need to manually add keygen jars (to "libs") - this is taken care of
+// by regular dependency management.
 applicationDistribution.from(project(":keygen").getTasksByName("startScripts", false).outputs) {
     into "bin"
 }
 
+// This ensures that keygen scripts are built (and can be copied over to "bin", see above)
+// before we assemble core's packages.
 [distZip, distTar]*.mustRunAfter ":keygen:startScripts"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -383,4 +383,4 @@ applicationDistribution.from(project(":keygen").getTasksByName("startScripts", f
     into "bin"
 }
 
-[distZip, distTar]*.shouldRunAfter ":keygen:startScripts"
+[distZip, distTar]*.mustRunAfter ":keygen:startScripts"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -379,6 +379,8 @@ task deb4docker(dependsOn: buildDeb) {
     }
 }
 
-applicationDistribution.from(new File(project(':keygen').buildDir, "scripts")) {
+applicationDistribution.from(project(":keygen").getTasksByName("startScripts", false).outputs) {
     into "bin"
 }
+
+[distZip, distTar]*.shouldRunAfter ":keygen:startScripts"


### PR DESCRIPTION
Adds missing task dependency to make sure that keygen artifacts (of the `startScripts` task) are available when core zip is being built.

As a drive-by update the path to the artifacts to use the `outputs` property of a task, rather than hardcoded folder name.