### PR TITLE
Simplifying the `SubstateDatabase`-on-JMT impl after Engine's JMT facade refactor

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "blueprint-schema-init"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "bitflags 1.3.2",
  "radix-engine-common",
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "native-sdk"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "radix-engine-common",
  "radix-engine-interface",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "bitflags 1.3.2",
  "blueprint-schema-init",
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "bech32",
  "blake2",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "bitflags 1.3.2",
  "blueprint-schema-init",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-macros"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "fixedstr",
 ]
@@ -1747,7 +1747,7 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 [[package]]
 name = "resources-tracker-macro"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "sbor"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "const-sha1",
  "hex",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "const-sha1",
  "itertools 0.10.5",
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "substate-store-impls"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "hex",
  "itertools 0.10.5",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "substate-store-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "hex",
  "itertools 0.10.5",
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "substate-store-queries"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "hex",
  "itertools 0.10.5",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "transaction"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "bech32",
  "hex",
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "transaction-scenarios"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "blueprint-schema-init",
  "hex",
@@ -2539,7 +2539,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "utils"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-af7de944#af7de9441e07e9c283704a2dad74aeb81ffecaa6"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
 dependencies = [
  "indexmap 2.0.0-pre",
  "serde",

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -22,17 +22,17 @@ resolver = "2"
 #   $ git push origin "release_name-BLAH"
 # * Then use tag="release_name-BLAH" in the below dependencies.
 # 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944", features = ["serde"] }
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944" }
-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944" }
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944", features = ["serde"] }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944" }
-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944" }
-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944" }
-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944" }
-utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944", features = ["serde"] }
-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-af7de944", features = ["serde"] }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b", features = ["serde"] }
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
+transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
+radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b", features = ["serde"] }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
+substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
+substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
+substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
+utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b", features = ["serde"] }
+blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b", features = ["serde"] }
 
 itertools = { version = "0.11.0" }
 jni = { version = "0.19.0" }

--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -359,7 +359,7 @@ impl<'s, S: SubstateDatabase> SubstateDatabase for StagedStore<'s, S> {
 }
 
 impl<'s, S: ReadableTreeStore> ReadableTreeStore for StagedStore<'s, S> {
-    fn get_node(&self, key: &NodeKey) -> Option<TreeNode> {
+    fn get_node(&self, key: &StoredTreeNodeKey) -> Option<TreeNode> {
         self.overlay
             .state_tree_nodes
             .get(key)
@@ -445,7 +445,7 @@ impl<K, N> AccuTreeDiff<K, N> {
 #[derive(Clone)]
 pub struct ImmutableStore {
     partition_updates: ImmutableHashMap<DbPartitionKey, ImmutablePartitionUpdates>,
-    state_tree_nodes: ImmutableHashMap<NodeKey, TreeNode>,
+    state_tree_nodes: ImmutableHashMap<StoredTreeNodeKey, TreeNode>,
     transaction_tree_slices: ImmutableHashMap<StateVersion, TreeSlice<TransactionTreeHash>>,
     receipt_tree_slices: ImmutableHashMap<StateVersion, TreeSlice<ReceiptTreeHash>>,
     node_ancestry_records: ImmutableHashMap<NodeId, SubstateNodeAncestryRecord>,

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -531,7 +531,7 @@ pub struct HashStructuresDiff {
 #[derive(Clone, Debug)]
 pub struct StateHashTreeDiff {
     pub new_root: StateHash,
-    pub new_nodes: Vec<(NodeKey, TreeNode)>,
+    pub new_nodes: Vec<(StoredTreeNodeKey, TreeNode)>,
     pub stale_tree_parts: Vec<StaleTreePart>,
 }
 
@@ -619,14 +619,22 @@ impl<'s, S: ReadableStateTreeStore> CollectingTreeStore<'s, S> {
 }
 
 impl<'s, S: ReadableTreeStore> ReadableTreeStore for CollectingTreeStore<'s, S> {
-    fn get_node(&self, key: &NodeKey) -> Option<TreeNode> {
+    fn get_node(&self, key: &StoredTreeNodeKey) -> Option<TreeNode> {
         self.readable_delegate.get_node(key)
     }
 }
 
 impl<'s, S> WriteableTreeStore for CollectingTreeStore<'s, S> {
-    fn insert_node(&self, key: NodeKey, node: TreeNode) {
+    fn insert_node(&self, key: StoredTreeNodeKey, node: TreeNode) {
         self.diff.borrow_mut().new_nodes.push((key, node));
+    }
+
+    fn associate_substate_value(
+        &self,
+        _global_key: &StoredTreeNodeKey,
+        _substate_value: &DbSubstateValue,
+    ) {
+        // TODO(historical-state): Collect these if the feature is enabled
     }
 
     fn record_stale_tree_part(&self, part: StaleTreePart) {

--- a/core-rust/state-manager/src/store/codecs.rs
+++ b/core-rust/state-manager/src/store/codecs.rs
@@ -168,7 +168,7 @@ impl<T: IsHash> DbCodec<T> for HashDbCodec<T> {
 ///
 /// An example:
 ///
-/// `(NodeKey[1, 3, 3, 7], PartitionNum(88), SortKey(200, 100, 150))`
+/// `(StoredTreeNodeKey[1, 3, 3, 7], PartitionNum(88), SortKey(200, 100, 150))`
 /// is encoded into:
 /// `[4, 1, 3, 3, 7, 88, 200, 100, 150]`
 #[derive(Default)]
@@ -243,15 +243,15 @@ impl SubstateKeyDbCodec {
 }
 
 #[derive(Default)]
-pub struct NodeKeyDbCodec {}
+pub struct StoredTreeNodeKeyDbCodec {}
 
-impl DbCodec<NodeKey> for NodeKeyDbCodec {
-    fn encode(&self, value: &NodeKey) -> Vec<u8> {
+impl DbCodec<StoredTreeNodeKey> for StoredTreeNodeKeyDbCodec {
+    fn encode(&self, value: &StoredTreeNodeKey) -> Vec<u8> {
         encode_key(value)
     }
 
-    fn decode(&self, _bytes: &[u8]) -> NodeKey {
-        unimplemented!("no use-case for decoding hash tree's `NodeKey`s exists yet")
+    fn decode(&self, _bytes: &[u8]) -> StoredTreeNodeKey {
+        unimplemented!("no use-case for decoding hash tree's `StoredTreeNodeKey`s exists yet")
     }
 }
 

--- a/core-rust/state-manager/src/store/historical_state.rs
+++ b/core-rust/state-manager/src/store/historical_state.rs
@@ -64,8 +64,7 @@
 #![allow(dead_code)]
 // TODO(historical-state): Remove the allow above once the impl here is used
 
-use std::ops::Deref;
-use std::{iter, mem};
+use substate_store_impls::hash_tree::entity_tier::EntityTier;
 
 use crate::engine_prelude::*;
 use crate::store::traits::*;
@@ -75,32 +74,24 @@ use crate::StateVersion;
 ///
 /// This database is backed by:
 /// - a [`ReadableTreeStore`] - a versioned source of ReNodes / Partitions / Substates metadata,
-/// - and a [`SubstateUpsertValueStore`] - a raw history of Substate values' upserts.
-pub struct StateHashTreeBasedSubstateDatabase<'t, 'v, T, V> {
+/// - and a [`LeafSubstateValueStore`] - a store of Substate values' associated with their leafs.
+pub struct StateHashTreeBasedSubstateDatabase<'t, T> {
     tree_store: &'t T,
-    upsert_value_store: &'v V,
     at_state_version: StateVersion,
 }
 
-impl<'t, 'v, T: ReadableTreeStore, V: SubstateUpsertValueStore>
-    StateHashTreeBasedSubstateDatabase<'t, 'v, T, V>
-{
+impl<'t, T: ReadableTreeStore + LeafSubstateValueStore> StateHashTreeBasedSubstateDatabase<'t, T> {
     /// Creates an instance backed by the given lower-level stores and scoped at the given version.
-    pub fn new(
-        tree_store: &'t T,
-        upsert_value_store: &'v V,
-        at_state_version: StateVersion,
-    ) -> Self {
+    pub fn new(tree_store: &'t T, at_state_version: StateVersion) -> Self {
         Self {
             tree_store,
-            upsert_value_store,
             at_state_version,
         }
     }
 }
 
-impl<'t, 'v, T: ReadableTreeStore, V: SubstateUpsertValueStore> SubstateDatabase
-    for StateHashTreeBasedSubstateDatabase<'t, 'v, T, V>
+impl<'t, T: ReadableTreeStore + LeafSubstateValueStore> SubstateDatabase
+    for StateHashTreeBasedSubstateDatabase<'t, T>
 {
     fn get_substate(
         &self,
@@ -127,153 +118,28 @@ impl<'t, 'v, T: ReadableTreeStore, V: SubstateUpsertValueStore> SubstateDatabase
             node_key,
             partition_num,
         } = partition_key.clone();
-
-        let node_tier_tree_browser =
-            TreeStoreBrowser::new(self.tree_store, self.at_state_version.number());
-        let node_leaf = node_tier_tree_browser.get_leaf(&NibblePath::new_even(node_key));
-        let Some(node_leaf) = node_leaf else {
-            return Box::new(iter::empty()); // The requested ReNode does not exist - treat as empty
-        };
-
-        let partition_tier_tree_browser = node_tier_tree_browser.nested(&node_leaf);
-        let partition_leaf =
-            partition_tier_tree_browser.get_leaf(&NibblePath::new_even(vec![partition_num]));
-        let Some(partition_leaf) = partition_leaf else {
-            return Box::new(iter::empty()); // The requested Partition does not exist - it is empty
-        };
-
-        let substate_tier_tree_browser = partition_tier_tree_browser.nested(&partition_leaf);
-        let sort_key_bytes = from_sort_key
-            .map(|sort_key| sort_key.0.clone())
-            .unwrap_or_default();
-
-        let partition_key = partition_key.clone(); // avoid lifetime dependency within iterator
-        Box::new(substate_tier_tree_browser
-            .iter_leaves_from(&NibblePath::new_even(sort_key_bytes))
-            .map(move |ResolvedLeaf { nibble_path, last_hash_change_version }| {
-                let sort_key = DbSortKey(nibble_path.bytes().to_vec());
-                let value = self.upsert_value_store
-                    .get_value(&partition_key, &sort_key, StateVersion::of(last_hash_change_version))
-                    .expect("DB inconsistency: value not found for substate upsert found in tree");
-                (sort_key, value)
-            }))
-    }
-}
-
-/// An implementation delegate allowing to browse a [`ReadableTreeStore`] at a specific version.
-struct TreeStoreBrowser<T> {
-    tree_store: T,
-    version: Version,
-}
-
-impl<'t, T: Deref<Target = impl ReadableTreeStore> + Clone + 't> TreeStoreBrowser<T> {
-    /// Creates an instance directly.
-    pub fn new(tree_store: T, version: Version) -> Self {
-        Self {
-            tree_store,
-            version,
-        }
-    }
-
-    /// Creates an instance for browsing a [`NestedTreeStore`] nested at the given leaf.
-    /// This effectively allows to access a lower Tier tree (of a Radix-specific 3-Tier JMT).
-    pub fn nested(&self, leaf: &ResolvedLeaf) -> TreeStoreBrowser<Rc<NestedTreeStore<T>>> {
-        let nested_tree_store =
-            NestedTreeStore::new(self.tree_store.clone(), leaf.nibble_path.bytes().to_vec());
-        TreeStoreBrowser::new(Rc::new(nested_tree_store), leaf.last_hash_change_version)
-    }
-
-    /// Returns a specific leaf, if found by starting at the scoped version's root and following the
-    /// given [`NibblePath`].
-    pub fn get_leaf(&self, nibble_path: &NibblePath) -> Option<ResolvedLeaf> {
-        self.iter_leaves_from(nibble_path)
-            .next()
-            .filter(|leaf| &leaf.nibble_path == nibble_path)
-    }
-
-    /// Returns an iterator of all leaves reachable from the scoped version's root, in
-    /// lexicographical order, starting from the given one.
-    pub fn iter_leaves_from(
-        &self,
-        nibble_path: &NibblePath,
-    ) -> Box<dyn Iterator<Item = ResolvedLeaf> + 't> {
-        recurse_until_leaves(
-            self.tree_store.clone(),
-            NodeKey::new_empty_path(self.version),
-            nibble_path.nibbles().collect(),
+        let entity_tier = EntityTier::new(self.tree_store, self.at_state_version.into());
+        let partition_tier = entity_tier.get_entity_partition_tier(node_key);
+        let substate_tier = partition_tier.get_partition_substate_tier(partition_num);
+        Box::new(
+            substate_tier
+                .into_iter_substate_summaries_from(from_sort_key)
+                .map(|substate| {
+                    let value = self
+                        .tree_store
+                        .get_associated_value(&substate.state_tree_leaf_key)
+                        .expect("DB inconsistency: associated value not found for leaf key");
+                    (substate.sort_key, value)
+                }),
         )
     }
 }
 
-/// Returns a lexicographically-sorted iterator of all the `tree_store`'s [`ResolvedLeaf`]s having
-/// [`NibblePath`]s greater or equal to the given `from_nibbles`.
-///
-/// The algorithm:
-/// - starts at the given `at_key`,
-/// - then goes down the tree, guided by the given `from_nibbles` chain, for as long as it is
-///   possible,
-///   - Note: this means it will either locate exactly this nibble path, or - if it does not
-///     exist - settle at its direct successor.
-/// - and then continues as if it was a classic DFS all the way,
-/// - but only leaf nodes are returned.
-///
-/// The implementation is a lazy recursive composite of child iterators.
-fn recurse_until_leaves<'t, T: Deref<Target = impl ReadableTreeStore> + Clone + 't>(
-    tree_store: T,
-    at_key: NodeKey,
-    from_nibbles: VecDeque<Nibble>,
-) -> Box<dyn Iterator<Item = ResolvedLeaf> + 't> {
-    let Some(node) = tree_store.get_node(&at_key) else {
-        panic!("{:?} referenced but not found in the storage", at_key);
-    };
-    match node {
-        TreeNode::Internal(internal) => {
-            let mut child_from_nibbles = from_nibbles;
-            let from_nibble = child_from_nibbles.pop_front();
-            Box::new(
-                internal
-                    .children
-                    .into_iter()
-                    .filter(move |child| Some(child.nibble) >= from_nibble)
-                    .flat_map(move |child| {
-                        let child_key = at_key.gen_child_node_key(child.version, child.nibble);
-                        let child_from_nibbles = if Some(child.nibble) == from_nibble {
-                            mem::take(&mut child_from_nibbles)
-                        } else {
-                            VecDeque::new()
-                        };
-                        recurse_until_leaves(tree_store.clone(), child_key, child_from_nibbles)
-                    }),
-            )
-        }
-        TreeNode::Leaf(leaf) => Box::new(
-            Some(leaf)
-                .filter(move |leaf| leaf.key_suffix.nibbles().ge(from_nibbles))
-                .map(|leaf| ResolvedLeaf::new(at_key.nibble_path(), leaf))
-                .into_iter(),
-        ),
-        TreeNode::Null => Box::new(iter::empty()),
-    }
-}
-
-/// A relevant information from a [`TreeLeafNode`] (specifically, with a resolved [`NibblePath`]).
-#[derive(Clone, Hash, Debug, Eq, PartialEq, Ord, PartialOrd)]
-struct ResolvedLeaf {
-    nibble_path: NibblePath,
-    last_hash_change_version: Version,
-}
-
-impl ResolvedLeaf {
-    /// Creates an instance by augmenting the given [`TreeLeafNode`] with its missing key prefix.
-    pub fn new(key_prefix: &NibblePath, leaf: TreeLeafNode) -> Self {
-        let TreeLeafNode {
-            key_suffix,
-            last_hash_change_version,
-            ..
-        } = leaf;
-        Self {
-            nibble_path: NibblePath::from_iter(key_prefix.nibbles().chain(key_suffix.nibbles())),
-            last_hash_change_version,
+impl From<StateVersion> for Option<Version> {
+    fn from(value: StateVersion) -> Self {
+        match value.number() {
+            0 => None,
+            positive => Some(positive),
         }
     }
 }
@@ -443,6 +309,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn lists_partition_substates_from_different_starting_keys() {
+        let mut test_stores = TestStores::new_empty();
+        let the_only_version = test_stores.put_substate_changes(vec![
+            change(8, 7, 1, Some(3)),
+            change(8, 7, 2, Some(5)),
+            change(8, 7, 4, Some(7)),
+            change(8, 7, 7, Some(9)),
+        ]);
+
+        let subject = test_stores.create_subject(the_only_version);
+        let all_substates = subject
+            .list_entries_from(&partition_key(8, 7), None)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            all_substates,
+            vec![
+                (sort_key(1), from_seed(3)),
+                (sort_key(2), from_seed(5)),
+                (sort_key(4), from_seed(7)),
+                (sort_key(7), from_seed(9)),
+            ]
+        );
+
+        let from_existent = subject
+            .list_entries_from(&partition_key(8, 7), Some(&sort_key(2)))
+            .collect::<Vec<_>>();
+        assert_eq!(from_existent, all_substates[1..]);
+
+        let from_non_existent = subject
+            .list_entries_from(&partition_key(8, 7), Some(&sort_key(3)))
+            .collect::<Vec<_>>();
+        assert_eq!(from_non_existent, all_substates[2..]);
+
+        let from_lt_min = subject
+            .list_entries_from(&partition_key(8, 7), Some(&sort_key(0)))
+            .collect::<Vec<_>>();
+        assert_eq!(from_lt_min, all_substates);
+
+        let from_gt_max = subject
+            .list_entries_from(&partition_key(8, 7), Some(&sort_key(9)))
+            .collect::<Vec<_>>();
+        assert_eq!(from_gt_max, vec![]);
+    }
+
     // Only test utils below:
 
     type SingleSubstateChange = (DbSubstateKey, DatabaseUpdate);
@@ -509,15 +420,13 @@ mod tests {
 
     struct TestStores {
         tree_store: TypedInMemoryTreeStore,
-        upsert_value_store: MemorySubstateUpsertValueStore,
         current_version: StateVersion,
     }
 
     impl TestStores {
         pub fn new_empty() -> Self {
             Self {
-                tree_store: TypedInMemoryTreeStore::new(),
-                upsert_value_store: MemorySubstateUpsertValueStore::default(),
+                tree_store: TypedInMemoryTreeStore::new().storing_substate_values(),
                 current_version: StateVersion::pre_genesis(),
             }
         }
@@ -556,15 +465,8 @@ mod tests {
         pub fn create_subject(
             &self,
             at_state_version: StateVersion,
-        ) -> StateHashTreeBasedSubstateDatabase<
-            TypedInMemoryTreeStore,
-            MemorySubstateUpsertValueStore,
-        > {
-            StateHashTreeBasedSubstateDatabase::new(
-                &self.tree_store,
-                &self.upsert_value_store,
-                at_state_version,
-            )
+        ) -> StateHashTreeBasedSubstateDatabase<TypedInMemoryTreeStore> {
+            StateHashTreeBasedSubstateDatabase::new(&self.tree_store, at_state_version)
         }
 
         fn apply_database_updates(&mut self, database_updates: &DatabaseUpdates) -> StateVersion {
@@ -575,8 +477,6 @@ mod tests {
                 database_updates,
             );
             let next_version = current_version.next().expect("too high version in a test");
-            self.upsert_value_store
-                .put_at_version(next_version, database_updates);
             self.current_version = next_version;
             self.current_version
         }
@@ -597,58 +497,14 @@ mod tests {
         }
     }
 
-    #[derive(Debug, PartialEq, Eq, Clone, Default)]
-    struct MemorySubstateUpsertValueStore {
-        memory: BTreeMap<(DbPartitionKey, DbSortKey, StateVersion), DbSubstateValue>,
-    }
-
-    impl MemorySubstateUpsertValueStore {
-        pub fn put_at_version(&mut self, version: StateVersion, updates: &DatabaseUpdates) {
-            for (node_key, node_updates) in &updates.node_updates {
-                for (partition_num, partition_updates) in &node_updates.partition_updates {
-                    let upserted_values = match partition_updates {
-                        PartitionDatabaseUpdates::Delta { substate_updates } => substate_updates
-                            .iter()
-                            .filter_map(|(sort_key, update)| match update {
-                                DatabaseUpdate::Set(value) => Some((sort_key, value)),
-                                DatabaseUpdate::Delete => None,
-                            })
-                            .collect::<Vec<_>>(),
-                        PartitionDatabaseUpdates::Reset {
-                            new_substate_values,
-                        } => new_substate_values.iter().collect::<Vec<_>>(),
-                    };
-                    for (sort_key, value) in upserted_values {
-                        self.memory.insert(
-                            (
-                                DbPartitionKey {
-                                    node_key: node_key.clone(),
-                                    partition_num: *partition_num,
-                                },
-                                sort_key.clone(),
-                                version,
-                            ),
-                            value.clone(),
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    impl SubstateUpsertValueStore for MemorySubstateUpsertValueStore {
-        fn get_value(
+    impl LeafSubstateValueStore for TypedInMemoryTreeStore {
+        fn get_associated_value(
             &self,
-            partition_key: &DbPartitionKey,
-            sort_key: &DbSortKey,
-            upserted_at_state_version: StateVersion,
+            state_tree_leaf_key: &StoredTreeNodeKey,
         ) -> Option<DbSubstateValue> {
-            self.memory
-                .get(&(
-                    partition_key.clone(),
-                    sort_key.clone(),
-                    upserted_at_state_version,
-                ))
+            self.associated_substate_values
+                .borrow()
+                .get(state_tree_leaf_key)
                 .cloned()
         }
     }

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -334,14 +334,14 @@ impl VersionedCf for VertexStoreCf {
 }
 
 /// Individual nodes of the Substate database's hash tree.
-/// Schema: `encode_key(NodeKey)` -> `scrypto_encode(VersionedTreeNode)`.
+/// Schema: `encode_key(StoredTreeNodeKey)` -> `scrypto_encode(VersionedTreeNode)`.
 struct StateHashTreeNodesCf;
 impl VersionedCf for StateHashTreeNodesCf {
-    type Key = NodeKey;
+    type Key = StoredTreeNodeKey;
     type Value = TreeNode;
 
     const VERSIONED_NAME: &'static str = "state_hash_tree_nodes";
-    type KeyCodec = NodeKeyDbCodec;
+    type KeyCodec = StoredTreeNodeKeyDbCodec;
     type VersionedValue = VersionedTreeNode;
 }
 
@@ -1608,7 +1608,7 @@ impl<R: ReadableRocks> SubstateNodeAncestryStore for StateManagerDatabase<R> {
 }
 
 impl<R: ReadableRocks> ReadableTreeStore for StateManagerDatabase<R> {
-    fn get_node(&self, key: &NodeKey) -> Option<TreeNode> {
+    fn get_node(&self, key: &StoredTreeNodeKey) -> Option<TreeNode> {
         self.open_read_context().cf(StateHashTreeNodesCf).get(key)
     }
 }
@@ -1622,7 +1622,7 @@ impl<R: WriteableRocks> StateHashTreeGcStore for StateManagerDatabase<R> {
             .iterate(Direction::Forward)
     }
 
-    fn batch_delete_node<'a>(&self, keys: impl IntoIterator<Item = &'a NodeKey>) {
+    fn batch_delete_node<'a>(&self, keys: impl IntoIterator<Item = &'a StoredTreeNodeKey>) {
         let db_context = self.open_rw_context();
         for key in keys {
             db_context.cf(StateHashTreeNodesCf).delete(key);


### PR DESCRIPTION
## Summary

This PR simplifies the feature introduced by https://github.com/radixdlt/babylon-node/pull/851, after Engine's JMT facade refactor that happened at https://github.com/radixdlt/radixdlt-scrypto/pull/1729.

Most notably, it integrates with the `WriteableTreeStore::associate_substate_value()` approach.

## Testing

The existing unit tests were adjusted.
Some missing ones (i.e. for "start iteration from key") were added.
The feature is not yet called from production code.