### PR TITLE
LZ-21: Initialize the historical state table on boot-up when feature becomes enabled

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/environment/DatabaseConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/environment/DatabaseConfig.java
@@ -69,7 +69,9 @@ import com.radixdlt.sbor.codec.StructCodec;
 
 /** Database configuration options */
 public record DatabaseConfig(
-    boolean enableLocalTransactionExecutionIndex, boolean enableAccountChangeIndex) {
+    boolean enableLocalTransactionExecutionIndex,
+    boolean enableAccountChangeIndex,
+    boolean enableHistoricalSubstateValues) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         DatabaseConfig.class,

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -739,7 +739,7 @@ impl ActualStateManagerDatabase {
 
         state_manager_database.catchup_account_change_index();
         state_manager_database.restore_december_2023_lost_substates(network);
-        state_manager_database.ensure_historical_values();
+        state_manager_database.ensure_historical_substate_values();
 
         Ok(state_manager_database)
     }
@@ -882,7 +882,7 @@ impl<R: WriteableRocks> StateManagerDatabase<R> {
     /// [`Self::populate_hash_tree_associated_substate_values()`] initialization and records its
     /// success afterwards. With this approach, the lengthy backfill is tolerant to the Node's
     /// restarts (i.e. it will simply be re-run).
-    fn ensure_historical_values(&self) {
+    fn ensure_historical_substate_values(&self) {
         let db_context = self.open_rw_context();
         let extension_data_cf = db_context.cf(ExtensionsDataCf);
         let values_associated_since = extension_data_cf

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -87,6 +87,7 @@ pub enum DatabaseConfigValidationError {
 pub struct DatabaseConfig {
     pub enable_local_transaction_execution_index: bool,
     pub enable_account_change_index: bool,
+    pub enable_historical_substate_values: bool,
 }
 
 impl Default for DatabaseConfig {
@@ -94,6 +95,7 @@ impl Default for DatabaseConfig {
         DatabaseConfig {
             enable_local_transaction_execution_index: true,
             enable_account_change_index: true,
+            enable_historical_substate_values: false,
         }
     }
 }
@@ -133,6 +135,8 @@ pub trait ConfigurableDatabase {
     fn is_account_change_index_enabled(&self) -> bool;
 
     fn is_local_transaction_execution_index_enabled(&self) -> bool;
+
+    fn is_historical_substate_value_storage_enabled(&self) -> bool;
 }
 
 #[derive(Debug, Clone)]
@@ -222,7 +226,7 @@ pub mod substate {
     /// course share the same parent).
     pub type KeyedSubstateNodeAncestryRecord = (Vec<NodeId>, SubstateNodeAncestryRecord);
 
-    /// A store of historical substate values associated with state tree's leaves.
+    /// A store of historical substate values associated with state hash tree's leaves.
     /// See [`WriteableTreeStore::associate_substate_value()`].
     ///
     /// Note: this is *not* a "historical values" store, but only its lower-level source of values.

--- a/core-rust/state-manager/src/store/typed_cf_api.rs
+++ b/core-rust/state-manager/src/store/typed_cf_api.rs
@@ -111,6 +111,11 @@ impl<'r, R: WriteableRocks> BufferedWriteSupport<'r, R> {
             self.rocks.write(write_batch);
         }
     }
+
+    /// Returns the size of buffered data, in bytes.
+    fn buffered_data_size(&self) -> usize {
+        self.buffer.byte_size()
+    }
 }
 
 impl<'r, R: WriteableRocks> Drop for BufferedWriteSupport<'r, R> {
@@ -144,6 +149,11 @@ impl<'r, R: WriteableRocks> TypedDbContext<'r, R, BufferedWriteSupport<'r, R>> {
     /// subsequent reads).
     pub fn flush(&self) {
         self.write_support.flush();
+    }
+
+    /// Returns the size of buffered data, in bytes.
+    pub fn buffered_data_size(&self) -> usize {
+        self.write_support.buffered_data_size()
     }
 }
 
@@ -765,6 +775,10 @@ impl WriteBuffer {
 
     pub fn flip(&self) -> WriteBatch {
         self.write_batch.replace(WriteBatch::default())
+    }
+
+    pub fn byte_size(&self) -> usize {
+        self.write_batch.borrow().size_in_bytes()
     }
 }
 

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
@@ -220,7 +220,7 @@ public final class MultiNodeRebootTest {
                         GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
                                 this.roundsPerEpoch)
                             .totalEmissionXrdPerEpoch(Decimal.ofNonNegative(0))),
-                    new DatabaseConfig(true, false),
+                    new DatabaseConfig(true, false, false),
                     StateComputerConfig.REV2ProposerConfig.transactionGenerator(
                         new REV2TransactionGenerator(), 1),
                     false,

--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -274,11 +274,18 @@ public final class RadixNodeModule extends AbstractModule {
         NodeConstants.DEFAULT_MAX_TRANSACTION_SIZE);
     var mempoolConfig =
         new RustMempoolConfig(mempoolMaxTotalTransactionsSize, mempoolMaxTransactionCount);
+
     var enableLocalTransactionExecutionIndex =
         properties.get("db.local_transaction_execution_index.enable", true);
     var enableAccountChangeIndex = properties.get("db.account_change_index.enable", true);
+    // TODO(during review): should it be on by default?
+    var enableHistoricalSubstateValues =
+        properties.get("db.historical_substate_values.enable", false);
     var databaseConfig =
-        new DatabaseConfig(enableLocalTransactionExecutionIndex, enableAccountChangeIndex);
+        new DatabaseConfig(
+            enableLocalTransactionExecutionIndex,
+            enableAccountChangeIndex,
+            enableHistoricalSubstateValues);
 
     install(new REv2LedgerInitializerModule(genesisProvider));
 
@@ -450,7 +457,7 @@ public final class RadixNodeModule extends AbstractModule {
     // - a peak user transaction throughput is 100 TPS;
     // - we want to offer Merkle proofs verification up to 10 minutes after their generation.
     var stateVersionHistoryLength =
-        properties.get("state_hash_tree.state_version_history_length", 60000);
+        properties.get("state_hash_tree.state_version_history_length", 5000);
     Preconditions.checkArgument(
         stateVersionHistoryLength >= 0,
         "state version history length must not be negative: %s",

--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -278,7 +278,6 @@ public final class RadixNodeModule extends AbstractModule {
     var enableLocalTransactionExecutionIndex =
         properties.get("db.local_transaction_execution_index.enable", true);
     var enableAccountChangeIndex = properties.get("db.account_change_index.enable", true);
-    // TODO(during review): should it be on by default?
     var enableHistoricalSubstateValues =
         properties.get("db.historical_substate_values.enable", false);
     var databaseConfig =
@@ -457,7 +456,7 @@ public final class RadixNodeModule extends AbstractModule {
     // - a peak user transaction throughput is 100 TPS;
     // - we want to offer Merkle proofs verification up to 10 minutes after their generation.
     var stateVersionHistoryLength =
-        properties.get("state_hash_tree.state_version_history_length", 5000);
+        properties.get("state_hash_tree.state_version_history_length", 60000);
     Preconditions.checkArgument(
         stateVersionHistoryLength >= 0,
         "state version history length must not be negative: %s",

--- a/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
+++ b/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
@@ -191,7 +191,7 @@ public sealed interface StateComputerConfig {
     return new REv2StateComputerConfig(
         networkId,
         genesis,
-        new DatabaseConfig(true, false),
+        new DatabaseConfig(true, false, false),
         proposerConfig,
         false,
         StateHashTreeGcConfig.forTesting(),

--- a/core/src/test/java/com/radixdlt/api/DeterministicCoreApiTestBase.java
+++ b/core/src/test/java/com/radixdlt/api/DeterministicCoreApiTestBase.java
@@ -106,6 +106,8 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
 public abstract class DeterministicCoreApiTestBase {
+  private static final DatabaseConfig TEST_DATABASE_CONFIG = new DatabaseConfig(true, false, false);
+
   @Rule public TemporaryFolder folder = new TemporaryFolder();
   public static NetworkDefinition networkDefinition = NetworkDefinition.INT_TEST_NET;
   public static Addressing addressing = Addressing.ofNetwork(NetworkDefinition.INT_TEST_NET);
@@ -122,21 +124,18 @@ public abstract class DeterministicCoreApiTestBase {
 
   protected DeterministicTest buildRunningServerTest() {
     return buildRunningServerTest(
-        1000000,
-        new DatabaseConfig(true, false),
-        GenesisData.NO_SCENARIOS,
-        ProtocolConfig.testingDefault());
+        1000000, TEST_DATABASE_CONFIG, GenesisData.NO_SCENARIOS, ProtocolConfig.testingDefault());
   }
 
   protected DeterministicTest buildRunningServerTestWithProtocolConfig(
       int roundsPerEpoch, ProtocolConfig protocolConfig) {
     return buildRunningServerTest(
-        roundsPerEpoch, new DatabaseConfig(true, false), GenesisData.NO_SCENARIOS, protocolConfig);
+        roundsPerEpoch, TEST_DATABASE_CONFIG, GenesisData.NO_SCENARIOS, protocolConfig);
   }
 
   protected DeterministicTest buildRunningServerTestWithScenarios(ImmutableList<String> scenarios) {
     return buildRunningServerTest(
-        1000000, new DatabaseConfig(true, false), scenarios, ProtocolConfig.testingDefault());
+        1000000, TEST_DATABASE_CONFIG, scenarios, ProtocolConfig.testingDefault());
   }
 
   protected DeterministicTest buildRunningServerTest(DatabaseConfig databaseConfig) {
@@ -147,7 +146,7 @@ public abstract class DeterministicCoreApiTestBase {
   protected DeterministicTest buildRunningServerTest(int roundsPerEpoch) {
     return buildRunningServerTest(
         roundsPerEpoch,
-        new DatabaseConfig(true, false),
+        TEST_DATABASE_CONFIG,
         GenesisData.NO_SCENARIOS,
         ProtocolConfig.testingDefault());
   }

--- a/core/src/test/java/com/radixdlt/api/SystemApiTestBase.java
+++ b/core/src/test/java/com/radixdlt/api/SystemApiTestBase.java
@@ -136,7 +136,7 @@ public abstract class SystemApiTestBase {
                                 TEST_KEY.getPublicKey(),
                                 Decimal.ONE,
                                 GenesisConsensusManagerConfig.Builder.testDefaults()),
-                            new DatabaseConfig(false, false),
+                            new DatabaseConfig(false, false, false),
                             StateComputerConfig.REV2ProposerConfig.Mempool.defaults()),
                         new SyncRelayConfig(500, 10, 3000, 10, Long.MAX_VALUE)))),
             new TestP2PModule.Builder().build(),

--- a/core/src/test/java/com/radixdlt/api/core/LtsAccountDepositBehaviourTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/LtsAccountDepositBehaviourTest.java
@@ -83,7 +83,7 @@ public final class LtsAccountDepositBehaviourTest extends DeterministicCoreApiTe
 
   @Test
   public void account_with_default_config_allows_all_deposits() throws Exception {
-    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true))) {
+    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true, false))) {
       test.suppressUnusedWarning();
 
       // Arrange: pretty empty state
@@ -156,7 +156,7 @@ public final class LtsAccountDepositBehaviourTest extends DeterministicCoreApiTe
 
   @Test
   public void account_with_reject_default_rule_disallows_all_deposits() throws Exception {
-    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true))) {
+    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true, false))) {
       test.suppressUnusedWarning();
 
       // Arrange: create account and set its default deposit rule to `Reject`
@@ -210,7 +210,7 @@ public final class LtsAccountDepositBehaviourTest extends DeterministicCoreApiTe
 
   @Test
   public void configured_resource_preference_and_depositor_badge_is_returned() throws Exception {
-    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true))) {
+    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true, false))) {
       test.suppressUnusedWarning();
 
       // Arrange: create account with some resource preference and some authorized depositor badge

--- a/core/src/test/java/com/radixdlt/api/core/LtsAccountResourceBalanceTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/LtsAccountResourceBalanceTest.java
@@ -79,7 +79,7 @@ import org.junit.Test;
 public final class LtsAccountResourceBalanceTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_lts_account_xrd_balance() throws Exception {
-    try (var test = buildRunningServerTest(new DatabaseConfig(true, true))) {
+    try (var test = buildRunningServerTest(new DatabaseConfig(true, true, false))) {
       test.suppressUnusedWarning();
 
       var accountKeyPair = ECKeyPair.generateNew();

--- a/core/src/test/java/com/radixdlt/api/core/LtsTransactionOutcomesTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/LtsTransactionOutcomesTest.java
@@ -83,7 +83,7 @@ import org.junit.Test;
 public class LtsTransactionOutcomesTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_non_fungible_entity_changes() throws Exception {
-    try (var test = buildRunningServerTest(new DatabaseConfig(true, true))) {
+    try (var test = buildRunningServerTest(new DatabaseConfig(true, true, false))) {
       test.suppressUnusedWarning();
 
       var accountKeyPair = ECKeyPair.generateNew();
@@ -248,7 +248,7 @@ public class LtsTransactionOutcomesTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void test_multiple_transactions_have_correct_outcomes() throws Exception {
-    try (var test = buildRunningServerTest(new DatabaseConfig(true, true))) {
+    try (var test = buildRunningServerTest(new DatabaseConfig(true, true, false))) {
       test.suppressUnusedWarning();
 
       var faucetAddressStr = ScryptoConstants.FAUCET_ADDRESS.encode(networkDefinition);

--- a/core/src/test/java/com/radixdlt/rev2/LedgerProofsGcTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/LedgerProofsGcTest.java
@@ -138,7 +138,7 @@ public final class LedgerProofsGcTest {
                             Decimal.ONE,
                             GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
                                 roundsPerEpoch)),
-                        new DatabaseConfig(false, false),
+                        new DatabaseConfig(false, false, false),
                         REV2ProposerConfig.transactionGenerator(
                             new SizedTransactionGenerator(NetworkDefinition.INT_TEST_NET, txnSize),
                             1),

--- a/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
@@ -122,7 +122,7 @@ public class REv2StateComputerTest {
         new CryptoModule(),
         REv2StateManagerModule.createForTesting(
             ProposalLimitsConfig.testDefaults(),
-            new DatabaseConfig(false, false),
+            new DatabaseConfig(false, false, false),
             Option.none(),
             false,
             StateHashTreeGcConfig.forTesting(),

--- a/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
@@ -91,6 +91,9 @@ import org.junit.rules.TemporaryFolder;
 
 public final class RustMempoolTest {
 
+  private static final DatabaseConfig TEST_DATABASE_CONFIG =
+      new DatabaseConfig(false, false, false);
+
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   /** A no-op dispatcher of transactions to be relayed. */
@@ -128,7 +131,7 @@ public final class RustMempoolTest {
                 new RustMempoolConfig(mempoolMaxTotalTransactionsSize, mempoolMaxTransactionCount)),
             Option.none(),
             new DatabaseBackendConfig(folder.newFolder().getPath()),
-            new DatabaseConfig(false, false),
+            TEST_DATABASE_CONFIG,
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
             LedgerProofsGcConfig.forTesting(),
@@ -186,7 +189,7 @@ public final class RustMempoolTest {
                 new RustMempoolConfig(mempoolMaxTotalTransactionsSize, mempoolMaxTransactionCount)),
             Option.none(),
             new DatabaseBackendConfig(folder.newFolder().getPath()),
-            new DatabaseConfig(false, false),
+            TEST_DATABASE_CONFIG,
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
             LedgerProofsGcConfig.forTesting(),
@@ -327,7 +330,7 @@ public final class RustMempoolTest {
                 new RustMempoolConfig(mempoolMaxTotalTransactionsSize, mempoolMaxTransactionCount)),
             Option.none(),
             new DatabaseBackendConfig(folder.newFolder().getPath()),
-            new DatabaseConfig(false, false),
+            TEST_DATABASE_CONFIG,
             LoggingConfig.getDefault(),
             StateHashTreeGcConfig.forTesting(),
             LedgerProofsGcConfig.forTesting(),

--- a/core/src/test/java/com/radixdlt/rev2/StateHashTreeGcTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/StateHashTreeGcTest.java
@@ -118,7 +118,8 @@ public final class StateHashTreeGcTest {
                             1,
                             Decimal.ONE,
                             GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(100)),
-                        new DatabaseConfig(false, false),
+                        // TODO(historical-state): test that GC actually cleans the history table
+                        new DatabaseConfig(false, false, true),
                         REV2ProposerConfig.noUserTransactions(),
                         false,
                         new StateHashTreeGcConfig(

--- a/core/src/test/java/com/radixdlt/rev2/protocol/ProtocolUpdateWithEpochBoundsTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/protocol/ProtocolUpdateWithEpochBoundsTest.java
@@ -303,7 +303,7 @@ public final class ProtocolUpdateWithEpochBoundsTest {
                             STAKE_PER_VALIDATOR,
                             GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(30)
                                 .totalEmissionXrdPerEpoch(Decimal.ZERO)),
-                        new DatabaseConfig(true, false),
+                        new DatabaseConfig(true, false, false),
                         StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
                         false,
                         true,

--- a/docker/config/default.config.envsubst
+++ b/docker/config/default.config.envsubst
@@ -12,6 +12,7 @@ network.p2p.use_proxy_protocol=$RADIXDLT_NETWORK_USE_PROXY_PROTOCOL
 db.location=$RADIXDLT_DB_LOCATION
 db.local_transaction_execution_index.enable=$RADIXDLT_DB_LOCAL_TRANSACTION_EXECUTION_INDEX_ENABLE
 db.account_change_index.enable=$RADIXDLT_DB_ACCOUNT_CHANGE_INDEX_ENABLE
+db.historical_substate_values.enable=$RADIXDLT_DB_HISTORICAL_SUBSTATE_VALUES_ENABLE
 
 mempool.max_transaction_count=${RADIXDLT_MEMPOOL_MAX_TRANSACTION_COUNT}
 mempool.max_memory=${RADIXDLT_MEMPOOL_MAX_MEMORY}


### PR DESCRIPTION
## Summary

Addresses the first part of https://radixdlt.atlassian.net/browse/LZ-21 (i.e. only the backfill on boot-up; handling new commits is out of scope here).

## Details

The backfill associates the current version JMT leaves with current values from SubstateDatabase, and records at which state version it happened (this information will finally be used - among other numbers - when checking whether particular historical state version is available).

## Testing

Hard to test without any other piece of history-supported feature implemented.
I manually verified that a Node with non-zero version successfully boots up and reports the backfill progress.
The feature is disabled by default Node flags.