### PR TITLE
LZ-22: Store historical values on commit

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "blueprint-schema-init"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "bitflags 1.3.2",
  "radix-engine-common",
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "native-sdk"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "radix-engine-common",
  "radix-engine-interface",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "bitflags 1.3.2",
  "blueprint-schema-init",
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "bech32",
  "blake2",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "bitflags 1.3.2",
  "blueprint-schema-init",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-macros"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -1621,7 +1621,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "fixedstr",
 ]
@@ -1747,7 +1747,7 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 [[package]]
 name = "resources-tracker-macro"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "sbor"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "const-sha1",
  "hex",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "const-sha1",
  "itertools 0.10.5",
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "substate-store-impls"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "hex",
  "itertools 0.10.5",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "substate-store-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "hex",
  "itertools 0.10.5",
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "substate-store-queries"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "hex",
  "itertools 0.10.5",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "transaction"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "bech32",
  "hex",
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "transaction-scenarios"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "blueprint-schema-init",
  "hex",
@@ -2539,7 +2539,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "utils"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-1b29786b#1b29786b43189dec07d94e76fcf2450fbb811cce"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=develop-12fc70c3#12fc70c327db863d7b3ba12cfec8ad7ff0491036"
 dependencies = [
  "indexmap 2.0.0-pre",
  "serde",

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -22,17 +22,17 @@ resolver = "2"
 #   $ git push origin "release_name-BLAH"
 # * Then use tag="release_name-BLAH" in the below dependencies.
 # 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b", features = ["serde"] }
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b", features = ["serde"] }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b" }
-utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b", features = ["serde"] }
-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-1b29786b", features = ["serde"] }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3", features = ["serde"] }
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3" }
+transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3" }
+radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3", features = ["serde"] }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3" }
+substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3" }
+substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3" }
+substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3" }
+utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3", features = ["serde"] }
+blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-12fc70c3", features = ["serde"] }
 
 itertools = { version = "0.11.0" }
 jni = { version = "0.19.0" }

--- a/core-rust/state-manager/src/commit_bundle.rs
+++ b/core-rust/state-manager/src/commit_bundle.rs
@@ -73,12 +73,13 @@ use crate::engine_prelude::*;
 
 use crate::accumulator_tree::slice_merger::AccuTreeSliceMerger;
 
-/// A builder of a [`CommitBundle`] from individual transactions and their commit results
+/// A builder of a [`CommitBundle`] from individual transactions and their commit results.
 pub struct CommitBundleBuilder {
     committed_transaction_bundles: Vec<CommittedTransactionBundle>,
     substate_store_update: SubstateStoreUpdate,
     state_hash_tree_update: HashTreeUpdate,
     new_substate_node_ancestry_records: Vec<KeyedSubstateNodeAncestryRecord>,
+    new_leaf_substate_keys: Vec<LeafSubstateKeyAssociation>,
     transaction_tree_slice_merger: AccuTreeSliceMerger<TransactionTreeHash>,
     receipt_tree_slice_merger: AccuTreeSliceMerger<ReceiptTreeHash>,
 }
@@ -96,6 +97,7 @@ impl CommitBundleBuilder {
             substate_store_update: SubstateStoreUpdate::new(),
             state_hash_tree_update: HashTreeUpdate::new(),
             new_substate_node_ancestry_records: Vec::new(),
+            new_leaf_substate_keys: Vec::new(),
             transaction_tree_slice_merger: epoch_accu_trees.create_merger(),
             receipt_tree_slice_merger: epoch_accu_trees.create_merger(),
         }
@@ -116,6 +118,8 @@ impl CommitBundleBuilder {
             .add(state_version, hash_structures_diff.state_hash_tree_diff);
         self.new_substate_node_ancestry_records
             .extend(result.new_substate_node_ancestry_records);
+        self.new_leaf_substate_keys
+            .extend(result.new_leaf_substate_keys);
         self.transaction_tree_slice_merger
             .append(hash_structures_diff.transaction_tree_diff.slice);
         self.receipt_tree_slice_merger
@@ -147,6 +151,7 @@ impl CommitBundleBuilder {
             ),
             receipt_tree_slice: ReceiptAccuTreeSliceV1(self.receipt_tree_slice_merger.into_slice()),
             new_substate_node_ancestry_records: self.new_substate_node_ancestry_records,
+            new_leaf_substate_keys: self.new_leaf_substate_keys,
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses https://radixdlt.atlassian.net/browse/LZ-22.

## Details

The changes are easier than expected:
- The new substate JMT leaf keys are collected during execution (but associated to DB substate keys only, to save memory).
- The `JMT key -> Substate key` association is turned into `JMT key -> Substate value` (using `DatabaseUpdates`) during commit, and persisted to DB.

## Testing

Similar to https://github.com/radixdlt/babylon-node/pull/863: this is hard to test without any other piece of history-supported feature implemented. But another PR which does historical reads is coming soon, and it will perfectly test the entirety.

The feature is disabled by default Node flags.