### PR TITLE
Add missed env vars for state tree GC's properties

### DIFF
--- a/docker/config/default.config.envsubst
+++ b/docker/config/default.config.envsubst
@@ -9,6 +9,9 @@ network.host_ip=$RADIXDLT_HOST_IP_ADDRESS
 network.p2p.seed_nodes=$RADIXDLT_NETWORK_SEEDS_REMOTE
 network.p2p.use_proxy_protocol=$RADIXDLT_NETWORK_USE_PROXY_PROTOCOL
 
+state_hash_tree.gc.interval_sec=$RADIXDLT_STATE_TREE_GC_INTERVAL_SEC
+state_hash_tree.state_version_history_length=$RADIXDLT_STATE_TREE_STATE_VERSION_HISTORY_LENGTH
+
 db.location=$RADIXDLT_DB_LOCATION
 db.local_transaction_execution_index.enable=$RADIXDLT_DB_LOCAL_TRANSACTION_EXECUTION_INDEX_ENABLE
 db.account_change_index.enable=$RADIXDLT_DB_ACCOUNT_CHANGE_INDEX_ENABLE


### PR DESCRIPTION
## Summary

The entire scope is in the PR title.
This was simply missed earlier, while apparently useful for ephemeral networks' configuration (as reported by @les-sheppard).