### PR TITLE
fix: declare `exports` with `types` path inside `package.json`

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -10,8 +10,14 @@
   "module": "./dist/babylon-core-api-sdk.mjs",
   "exports": {
     ".": {
-      "import": "./dist/babylon-core-api-sdk.mjs",
-      "require": "./dist/babylon-core-api-sdk.umd.js"
+      "import": {
+        "types": "./dist/lib/index.d.ts",
+        "default": "./dist/babylon-core-api-sdk.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/index.d.ts",
+        "default": "./dist/babylon-core-api-sdk.umd.js"
+      }
     }
   },
   "description": "A client for the RadixDLT Babylon Core API",


### PR DESCRIPTION
## Summary

When importing from `@radixdlt/babylon-core-api-sdk` people get `TS7016`. Example:
```
import type {AuthConfig} from "@radixdlt/babylon-core-api-sdk";
// TS7016: Could not find a declaration file for module @radixdlt/babylon-core-api-sdk.
```
This change aligns `package.json` to what we have inside `@radixdlt/babylon-gateway-api-sdk`

## Testing

Tested manually by changing `exports` inside `node_modules/@radixdlt/babylon-core-api-sdk/package.json`. It helps Typescript understand types existing in `dist/lib`