### PR TITLE
ci: fix snyk sbom [DO-2367]

### DIFF
--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Generate SBOM
         uses: RDXWorks-actions/snyk-actions/gradle-jdk17@master
         with:
-          args: --all-projects --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json --json-file-output sbom.json
+          args: --all-projects --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json > sbom.json
           command: sbom
       - name: Upload SBOM
         uses: RDXWorks-actions/action-gh-release@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Generate SBOM # check SBOM can be generated but nothing is done with it
         uses: RDXWorks-actions/snyk-actions/gradle-jdk17@master
         with:
-          args: --all-projects --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json --json-file-output sbom.json
+          args: --all-projects --org=${{ env.SNYK_NETWORK_ORG_ID }} --format=cyclonedx1.4+json > sbom.json
           command: sbom
   build:
     name: Unit tests and sonarqube


### PR DESCRIPTION
`--json-file-output parameter` stopped working properly but the same effect can be achieved with stdout redirect `>`