### PR TITLE
Support `at_ledger_state` in /kv-store/iterator endpoint

### DIFF
--- a/core-rust/node-http-apis/engine-state-api-schema.yaml
+++ b/core-rust/node-http-apis/engine-state-api-schema.yaml
@@ -2684,6 +2684,8 @@ components:
           $ref: "#/components/schemas/MaxPageSize"
         continuation_token:
           $ref: "#/components/schemas/ContinuationToken"
+        at_ledger_state:
+          $ref: "#/components/schemas/LedgerStateSelector"
     KeyValueStoreIteratorResponse:
       type: object
       required:

--- a/core-rust/node-http-apis/src/engine_state_api/generated/models/key_value_store_iterator_request.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/generated/models/key_value_store_iterator_request.rs
@@ -24,6 +24,8 @@ pub struct KeyValueStoreIteratorRequest {
     /// An opaque string conveying the information on where the next page of results starts. It is returned in every paged listing response (except for the last page), and it can be passed in every paged listing request (in order to begin listing from where the previous response ended). 
     #[serde(rename = "continuation_token", skip_serializing_if = "Option::is_none")]
     pub continuation_token: Option<String>,
+    #[serde(rename = "at_ledger_state", skip_serializing_if = "Option::is_none")]
+    pub at_ledger_state: Option<Box<crate::engine_state_api::generated::models::LedgerStateSelector>>,
 }
 
 impl KeyValueStoreIteratorRequest {
@@ -33,6 +35,7 @@ impl KeyValueStoreIteratorRequest {
             sbor_format_options: None,
             max_page_size: None,
             continuation_token: None,
+            at_ledger_state: None,
         }
     }
 }

--- a/core-rust/node-http-apis/src/engine_state_api/handlers/mod.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/handlers/mod.rs
@@ -45,7 +45,6 @@ pub struct HandlerPagingSupport {
 impl HandlerPagingSupport {
     /// A convenience [`Self::new_with_serialized_filter`] adapter for a filter directly coming from
     /// a `serde`-serialized request field.
-    #[allow(dead_code)] // TODO(state-history): it will be used by other listing endpoints soon
     pub fn new_with_serde_filter(
         max_page_size: Option<i32>,
         continuation_token: Option<String>,

--- a/core/src/test-core/java/com/radixdlt/api/engine_state/generated/models/KeyValueStoreIteratorRequest.java
+++ b/core/src/test-core/java/com/radixdlt/api/engine_state/generated/models/KeyValueStoreIteratorRequest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.radixdlt.api.engine_state.generated.models.LedgerStateSelector;
 import com.radixdlt.api.engine_state.generated.models.SborFormatOptions;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -35,7 +36,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   KeyValueStoreIteratorRequest.JSON_PROPERTY_ENTITY_ADDRESS,
   KeyValueStoreIteratorRequest.JSON_PROPERTY_SBOR_FORMAT_OPTIONS,
   KeyValueStoreIteratorRequest.JSON_PROPERTY_MAX_PAGE_SIZE,
-  KeyValueStoreIteratorRequest.JSON_PROPERTY_CONTINUATION_TOKEN
+  KeyValueStoreIteratorRequest.JSON_PROPERTY_CONTINUATION_TOKEN,
+  KeyValueStoreIteratorRequest.JSON_PROPERTY_AT_LEDGER_STATE
 })
 @javax.annotation.processing.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class KeyValueStoreIteratorRequest {
@@ -50,6 +52,9 @@ public class KeyValueStoreIteratorRequest {
 
   public static final String JSON_PROPERTY_CONTINUATION_TOKEN = "continuation_token";
   private String continuationToken;
+
+  public static final String JSON_PROPERTY_AT_LEDGER_STATE = "at_ledger_state";
+  private LedgerStateSelector atLedgerState;
 
   public KeyValueStoreIteratorRequest() { 
   }
@@ -160,6 +165,32 @@ public class KeyValueStoreIteratorRequest {
   }
 
 
+  public KeyValueStoreIteratorRequest atLedgerState(LedgerStateSelector atLedgerState) {
+    this.atLedgerState = atLedgerState;
+    return this;
+  }
+
+   /**
+   * Get atLedgerState
+   * @return atLedgerState
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_AT_LEDGER_STATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public LedgerStateSelector getAtLedgerState() {
+    return atLedgerState;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_AT_LEDGER_STATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setAtLedgerState(LedgerStateSelector atLedgerState) {
+    this.atLedgerState = atLedgerState;
+  }
+
+
   /**
    * Return true if this KeyValueStoreIteratorRequest object is equal to o.
    */
@@ -175,12 +206,13 @@ public class KeyValueStoreIteratorRequest {
     return Objects.equals(this.entityAddress, keyValueStoreIteratorRequest.entityAddress) &&
         Objects.equals(this.sborFormatOptions, keyValueStoreIteratorRequest.sborFormatOptions) &&
         Objects.equals(this.maxPageSize, keyValueStoreIteratorRequest.maxPageSize) &&
-        Objects.equals(this.continuationToken, keyValueStoreIteratorRequest.continuationToken);
+        Objects.equals(this.continuationToken, keyValueStoreIteratorRequest.continuationToken) &&
+        Objects.equals(this.atLedgerState, keyValueStoreIteratorRequest.atLedgerState);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entityAddress, sborFormatOptions, maxPageSize, continuationToken);
+    return Objects.hash(entityAddress, sborFormatOptions, maxPageSize, continuationToken, atLedgerState);
   }
 
   @Override
@@ -191,6 +223,7 @@ public class KeyValueStoreIteratorRequest {
     sb.append("    sborFormatOptions: ").append(toIndentedString(sborFormatOptions)).append("\n");
     sb.append("    maxPageSize: ").append(toIndentedString(maxPageSize)).append("\n");
     sb.append("    continuationToken: ").append(toIndentedString(continuationToken)).append("\n");
+    sb.append("    atLedgerState: ").append(toIndentedString(atLedgerState)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
⚠️ This merges to https://github.com/radixdlt/babylon-node/pull/885

## Summary

The next PR in the "state history support for Engine State API" epic (see https://radixdlt.atlassian.net/browse/NODE-614).
Many PRs for remaining endpoints will follow.

## Testing

A test case was added to the existing tests of this endpoint.
