### PR TITLE
Refactoring: Rely only on version-scoped database in relevant endpoints

### DIFF
--- a/core-rust/node-http-apis/src/engine_state_api/helpers.rs
+++ b/core-rust/node-http-apis/src/engine_state_api/helpers.rs
@@ -1,6 +1,6 @@
 use state_manager::store::traits::*;
 use state_manager::store::StateManagerDatabase;
-use state_manager::{LedgerHeader, ReadableRocks, StateVersion};
+use state_manager::{LedgerHeader, ReadableRocks};
 
 #[tracing::instrument(skip_all)]
 pub(crate) fn read_current_ledger_header(
@@ -8,17 +8,6 @@ pub(crate) fn read_current_ledger_header(
 ) -> LedgerHeader {
     database
         .get_latest_proof()
-        .expect("proof for outputted state must exist")
-        .ledger_header
-}
-
-pub(crate) fn read_proving_ledger_header(
-    database: &StateManagerDatabase<impl ReadableRocks>,
-    proven_state_version: StateVersion,
-) -> LedgerHeader {
-    database
-        .get_proof_iter(proven_state_version)
-        .next()
         .expect("proof for outputted state must exist")
         .ledger_header
 }

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -1025,8 +1025,8 @@ impl<R: WriteableRocks> StateManagerDatabase<R> {
 
         let db_context = self.open_rw_context();
         let associated_values_cf = db_context.cf(AssociatedStateTreeValuesCf);
-        let substate_leaf_keys =
-            StateTreeBasedSubstateDatabase::new(self, current_version).iter_substate_leaf_keys();
+        let substate_database = StateTreeBasedSubstateDatabase::new(self, current_version);
+        let substate_leaf_keys = substate_database.iter_substate_leaf_keys();
         for (tree_node_key, (partition_key, sort_key)) in substate_leaf_keys {
             let value = self
                 .get_substate(&partition_key, &sort_key)


### PR DESCRIPTION
⚠️ This merges into https://github.com/radixdlt/babylon-node/pull/888

## Summary

After a couple of initial PRs in the "state history in Engine State API" epic (see https://radixdlt.atlassian.net/browse/NODE-614), Łukasz has suggested that it would be clearer and less error-prone to handle all database operations through a version-scoped wrapper.

## Details

This refactoring actually offered extra, unexpected simplifications, e.g. in the implementation of `/entity/iterator` (no need to manually implement the "version filter").

## Testing

This is a pure refactoring, the regression tests just need to pass.
