### PR TITLE
Bugfix: Capture JMT-associated substate values at the right database state version

### DIFF
--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -82,6 +82,7 @@ use im::hashmap::HashMap as ImmutableHashMap;
 use itertools::Itertools;
 
 use crate::store::traits::{SubstateNodeAncestryRecord, SubstateNodeAncestryStore};
+use crate::traits::ConfigurableDatabase;
 use slotmap::SecondaryMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd)]
@@ -398,6 +399,24 @@ impl<'s, S: SubstateNodeAncestryStore> SubstateNodeAncestryStore for StagedStore
     ) -> Vec<Option<SubstateNodeAncestryRecord>> {
         let overlay = MapSubstateNodeAncestryStore::wrap(&self.overlay.node_ancestry_records);
         StagedSubstateNodeAncestryStore::new(self.root, &overlay).batch_get_ancestry(node_ids)
+    }
+}
+
+impl<'s, S: ConfigurableDatabase> ConfigurableDatabase for StagedStore<'s, S> {
+    fn is_account_change_index_enabled(&self) -> bool {
+        self.root.is_account_change_index_enabled()
+    }
+
+    fn is_local_transaction_execution_index_enabled(&self) -> bool {
+        self.root.is_local_transaction_execution_index_enabled()
+    }
+
+    fn is_state_history_enabled(&self) -> bool {
+        self.root.is_state_history_enabled()
+    }
+
+    fn get_first_stored_historical_state_version(&self) -> StateVersion {
+        self.root.get_first_stored_historical_state_version()
     }
 }
 

--- a/core-rust/state-manager/src/staging/mod.rs
+++ b/core-rust/state-manager/src/staging/mod.rs
@@ -74,6 +74,7 @@ use crate::engine_prelude::*;
 use crate::{ReceiptTreeHash, StateVersion, TransactionTreeHash};
 
 use crate::store::traits::SubstateNodeAncestryStore;
+use crate::traits::ConfigurableDatabase;
 pub use cache::*;
 pub use result::*;
 
@@ -94,10 +95,13 @@ impl<T> ReadableHashStructuresStore for T where
 }
 
 pub trait ReadableStore:
-    SubstateDatabase + ReadableHashStructuresStore + SubstateNodeAncestryStore
+    SubstateDatabase + ReadableHashStructuresStore + SubstateNodeAncestryStore + ConfigurableDatabase
 {
 }
 impl<T> ReadableStore for T where
-    T: SubstateDatabase + ReadableHashStructuresStore + SubstateNodeAncestryStore
+    T: SubstateDatabase
+        + ReadableHashStructuresStore
+        + SubstateNodeAncestryStore
+        + ConfigurableDatabase
 {
 }

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -214,9 +214,7 @@ impl GenesisCommitRequestFactory {
         &mut self,
         result: ScenarioPrepareResult,
     ) -> Option<GenesisCommitRequest> {
-        let Some(ledger_hashes) = result.committable_ledger_hashes else {
-            return None;
-        };
+        let ledger_hashes = result.committable_ledger_hashes?;
         self.state_version = self
             .state_version
             .next()

--- a/core-rust/state-manager/src/store/historical_state.rs
+++ b/core-rust/state-manager/src/store/historical_state.rs
@@ -218,10 +218,10 @@ impl<'s, R: ReadableRocks> VersionScopedSubstateDatabase<'s, StateManagerDatabas
             return Ok(Self::current(database, current_version)); // explicit "use current version"
         }
 
-        let first_available_version = database.get_first_stored_historical_state_version();
-        let Some(first_available_version) = first_available_version else {
+        if !database.is_state_history_enabled() {
             return Err(StateHistoryError::StateHistoryDisabled);
         };
+        let first_available_version = database.get_first_stored_historical_state_version();
         if requested_version < first_available_version {
             return Err(StateHistoryError::StateVersionInTooDistantPast {
                 first_available_version,

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -1195,25 +1195,8 @@ impl<R: WriteableRocks> CommitStore for StateManagerDatabase<R> {
 
         if self.config.enable_historical_substate_values {
             let associated_values_cf = db_context.cf(AssociatedStateTreeValuesCf);
-            for new_leaf_substate_key in commit_bundle.new_leaf_substate_keys {
-                let LeafSubstateKeyAssociation {
-                    tree_node_key,
-                    substate_key,
-                    cause,
-                } = new_leaf_substate_key;
-                let substate_value = match cause {
-                    AssociationCause::SubstateUpsert => commit_bundle
-                        .substate_store_update
-                        .get_upserted_value(&substate_key)
-                        .map(Cow::Borrowed)
-                        .expect("upserted value not found in database updates"),
-                    AssociationCause::TreeRestructuring => db_context
-                        .cf(SubstatesCf)
-                        .get(&substate_key)
-                        .map(Cow::Owned)
-                        .expect("unchanged value not found in substate database"),
-                };
-                associated_values_cf.put(&tree_node_key, substate_value.as_ref());
+            for association in commit_bundle.new_leaf_substate_keys {
+                associated_values_cf.put(&association.tree_node_key, &association.substate_value);
             }
         }
 

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -1357,9 +1357,7 @@ impl<'r> Iterator for RocksDBCommittedTransactionBundleIterator<'r> {
     type Item = CommittedTransactionBundle;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let Some((txn_version, txn)) = self.txns_iter.next() else {
-            return None;
-        };
+        let (txn_version, txn) = self.txns_iter.next()?;
 
         let (ledger_receipt_version, ledger_receipt) = self
             .ledger_receipts_iter

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -136,12 +136,19 @@ pub trait ConfigurableDatabase {
 
     fn is_local_transaction_execution_index_enabled(&self) -> bool;
 
+    /// Returns [`true`] if the Node should be storing historical Substate values (and if it can
+    /// handle historical state requests).
+    ///
+    /// The exact [`StateVersion`] from which the history is available can be obtained from
+    /// [`Self::get_first_stored_historical_state_version()`].
+    fn is_state_history_enabled(&self) -> bool;
+
     /// Returns the first [`StateVersion`]s for which *historical* Substate values are currently
     /// available in the database.
     ///
-    /// Returns [`None`] if the state history feature is disabled, or if the history length
-    /// configuration is 0.
-    fn get_first_stored_historical_state_version(&self) -> Option<StateVersion>;
+    /// This method assumes that [`Self::is_state_history_enabled()`] returned [`true`] and *panics*
+    /// otherwise.
+    fn get_first_stored_historical_state_version(&self) -> StateVersion;
 }
 
 #[derive(Debug, Clone)]

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -155,33 +155,7 @@ pub struct CommittedTransactionBundle {
 #[derive(Debug, Clone)]
 pub struct LeafSubstateKeyAssociation {
     pub tree_node_key: StoredTreeNodeKey,
-    pub substate_key: DbSubstateKey,
-    pub cause: AssociationCause,
-}
-
-/// The reason of a particular [`LeafSubstateKeyAssociation`].
-#[derive(Debug, Clone)]
-pub enum AssociationCause {
-    /// A dominant, simple case: a Substate was created or updated. This naturally leads its leaf
-    /// node to be created within the state tree.
-    ///
-    /// The Substate's new value can be found in the [`DatabaseUpdates`].
-    SubstateUpsert,
-    /// The JMT-specific case: a leaf node had to be re-created at different key, because its nibble
-    /// path length has changed, because some other related tree nodes (on this path) were created
-    /// or deleted - see [`AssociatedSubstateValue`]'s docs for more details.
-    ///
-    /// The Substate's value was not changed and can be found in the [`SubstateDatabase`].
-    TreeRestructuring,
-}
-
-impl From<AssociatedSubstateValue<'_>> for AssociationCause {
-    fn from(value: AssociatedSubstateValue) -> Self {
-        match value {
-            AssociatedSubstateValue::Upserted(_) => AssociationCause::SubstateUpsert,
-            AssociatedSubstateValue::Unchanged => AssociationCause::TreeRestructuring,
-        }
-    }
+    pub substate_value: Vec<u8>,
 }
 
 pub mod vertex {

--- a/core/src/test/java/com/radixdlt/api/core/regression/StateHistoryTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/regression/StateHistoryTest.java
@@ -1,0 +1,133 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+package com.radixdlt.api.core.regression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.radixdlt.api.DeterministicCoreApiTestBase;
+import com.radixdlt.api.core.generated.models.*;
+import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.environment.DatabaseConfig;
+import com.radixdlt.environment.StateTreeGcConfig;
+import com.radixdlt.harness.deterministic.DeterministicTest;
+import com.radixdlt.identifiers.Address;
+import com.radixdlt.rev2.Manifest;
+import com.radixdlt.rev2.TransactionBuilder;
+import com.radixdlt.utils.UInt32;
+import com.radixdlt.utils.UInt64;
+import java.util.List;
+import org.junit.Test;
+
+public class StateHistoryTest extends DeterministicCoreApiTestBase {
+
+  @Test
+  public void state_history_supports_substate_deletes() throws Exception {
+    try (var test = buildTest(true, 20L)) {
+      test.suppressUnusedWarning();
+
+      // Arrange: we will use "burn NFT" for our "delete" operation:
+      final var resourceAddress = createFreeMintBurnNonFungibleResource(test);
+
+      final var accountKeyPair = ECKeyPair.generateNew();
+      final var accountAddress = Address.virtualAccountAddress(accountKeyPair.getPublicKey());
+      final var transactionMetadata =
+          getLtsApi()
+              .ltsTransactionConstructionPost(
+                  new LtsTransactionConstructionRequest().network(networkLogicalName));
+
+      final var mintManifest =
+          Manifest.mintNonFungiblesThenWithdrawAndBurnSome(
+              resourceAddress, accountAddress, List.of(1), List.of());
+      final var burnManifest =
+          Manifest.mintNonFungiblesThenWithdrawAndBurnSome(
+              resourceAddress, accountAddress, List.of(2), List.of(1, 2));
+
+      // Act: Queue up a minting transaction...
+      getLtsApi()
+          .ltsTransactionSubmitPost(
+              new LtsTransactionSubmitRequest()
+                  .network(networkLogicalName)
+                  .notarizedTransactionHex(
+                      TransactionBuilder.forNetwork(networkDefinition)
+                          .manifest(mintManifest)
+                          .fromEpoch(transactionMetadata.getCurrentEpoch())
+                          .signatories(List.of(accountKeyPair))
+                          .prepare()
+                          .hexPayloadBytes()));
+      // ... and then a burning transaction, so that they end up in one low-level "commit batch":
+      final var result = submitAndWaitForSuccess(test, burnManifest, List.of(accountKeyPair));
+
+      // Assert: we only need this to succeed (the original bug caused panics)
+      assertThat(result.errorMessage()).isNull();
+    }
+  }
+
+  private DeterministicTest buildTest(boolean stateHistoryEnabled, long historyLength) {
+    return buildRunningServerTest(
+        new DatabaseConfig(true, false, stateHistoryEnabled),
+        new StateTreeGcConfig(
+            UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(historyLength)));
+  }
+}

--- a/core/src/test/java/com/radixdlt/api/core/regression/StateHistoryTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/regression/StateHistoryTest.java
@@ -120,7 +120,7 @@ public class StateHistoryTest extends DeterministicCoreApiTestBase {
       final var result = submitAndWaitForSuccess(test, burnManifest, List.of(accountKeyPair));
 
       // Assert: we only need this to succeed (the original bug caused panics)
-      assertThat(result.errorMessage()).isNull();
+      assertThat(result.errorMessage()).isEmpty();
     }
   }
 


### PR DESCRIPTION
## Summary

This fixes https://radixdlt.atlassian.net/browse/NODE-620.

## Details

The problem is described at https://radixdlt.atlassian.net/browse/NODE-620?focusedCommentId=19841.
The solution is to capture the values right after each transaction's execution.

## Testing

The first commit adds a failing reproducing test, and the second one makes it pass.