### PR TITLE
Refactor: some cleanups after mempool reevalution tweaks

### DIFF
--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
@@ -123,7 +123,7 @@ pub(crate) async fn handle_lts_transaction_status(
     }
 
     let mempool = state.state_manager.mempool.read();
-    let mempool_payloads_hashes = mempool.get_payload_hashes_for_intent(&intent_hash);
+    let mempool_payloads_hashes = mempool.get_notarized_transaction_hashes_for_intent(&intent_hash);
     drop(mempool);
 
     if !mempool_payloads_hashes.is_empty() {

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -122,7 +122,7 @@ pub(crate) async fn handle_transaction_status(
     }
 
     let mempool = state.state_manager.mempool.read();
-    let mempool_payloads_hashes = mempool.get_payload_hashes_for_intent(&intent_hash);
+    let mempool_payloads_hashes = mempool.get_notarized_transaction_hashes_for_intent(&intent_hash);
     drop(mempool);
 
     if !mempool_payloads_hashes.is_empty() {

--- a/core-rust/node-common/src/indexing.rs
+++ b/core-rust/node-common/src/indexing.rs
@@ -92,7 +92,7 @@ impl<K: Ord, V: Ord> SecondaryIndex<K, V> {
     /// Inserts a new pair.
     ///
     /// *Panics* if such pair was already in the index.
-    pub fn insert(&mut self, key: K, value: V) {
+    pub fn insert_unique(&mut self, key: K, value: V) {
         if !self.sorted_set.insert((key, value)) {
             panic!("value already present in the index");
         }
@@ -101,7 +101,7 @@ impl<K: Ord, V: Ord> SecondaryIndex<K, V> {
     /// Removes the given pair.
     ///
     /// *Panics* if such pair was not in the index.
-    pub fn remove(&mut self, key: K, value: V) {
+    pub fn remove_existing(&mut self, key: K, value: V) {
         if !self.sorted_set.remove(&(key, value)) {
             panic!("value not present in the index");
         }

--- a/core-rust/state-manager/src/jni/mempool.rs
+++ b/core-rust/state-manager/src/jni/mempool.rs
@@ -173,8 +173,8 @@ extern "system" fn Java_com_radixdlt_mempool_RustMempool_reevaluateTransactionCo
     request_payload: jbyteArray,
 ) -> jbyteArray {
     jni_sbor_coded_call(&env, request_payload, |max_reevaluated_count: u32| {
-        let mempool_manager = JNINodeRustEnvironment::get_mempool_manager(&env, j_node_rust_env);
-        mempool_manager.reevaluate_transaction_committability(max_reevaluated_count);
+        JNINodeRustEnvironment::get_mempool_manager(&env, j_node_rust_env)
+            .reevaluate_transaction_committability(max_reevaluated_count);
     })
 }
 

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -310,28 +310,6 @@ impl MempoolManager {
             .for_each(|wait| self.metrics.from_local_api_to_commit_wait.observe(wait));
     }
 
-    /// Removes the transactions specified by the given user payload hashes (while checking
-    /// consistency of their intent hashes).
-    /// This method is meant to be called for transactions that were rejected - and
-    /// this assumption is important for metric correctness.
-    ///
-    /// Note:
-    /// Removing transactions rejected during prepare from the mempool is a bit of overkill:
-    /// just because transactions were rejected in this history doesn't mean this history will be
-    /// committed.
-    /// But it'll do for now as a defensive measure until we can have a more intelligent mempool.
-    pub fn remove_rejected(
-        &self,
-        rejected_transactions: &[(&IntentHash, &NotarizedTransactionHash)],
-    ) {
-        let mut write_mempool = self.mempool.write();
-        rejected_transactions
-            .iter()
-            .for_each(|(_intent_hash, user_payload_hash)| {
-                write_mempool.remove_by_payload_hash(user_payload_hash);
-            });
-    }
-
     /// Removes transactions no longer valid at or after the given epoch.
     pub fn remove_txns_where_end_epoch_expired(&self, epoch: Epoch) -> Vec<MempoolData> {
         self.mempool

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -273,7 +273,7 @@ impl MempoolManager {
         // STEP 4 - We check if the result should mean we add the transaction to our mempool
         let PendingExecutedTransaction {
             transaction,
-            latest_attempt_against_state_version,
+            latest_attempt_against_state,
         } = record
             .should_accept_into_mempool(check_result)
             .map_err(MempoolAddError::Rejected)?;
@@ -286,7 +286,7 @@ impl MempoolManager {
             mempool_transaction.clone(),
             source,
             Instant::now(),
-            latest_attempt_against_state_version,
+            latest_attempt_against_state.committed_version(),
         ) {
             Ok(_evicted) => Ok(mempool_transaction),
             Err(error) => Err(error),

--- a/core-rust/state-manager/src/mempool/mempool_manager.rs
+++ b/core-rust/state-manager/src/mempool/mempool_manager.rs
@@ -165,12 +165,12 @@ impl MempoolManager {
     /// Checks the committability of up to `max_reevaluated_count` of transactions executed against
     /// earliest state versions and removes the newly rejected ones from the mempool.
     pub fn reevaluate_transaction_committability(&self, max_reevaluated_count: u32) {
-        let candidate_transactions: Vec<Arc<MempoolData>> = self
+        let candidate_transactions = self
             .mempool
             .read()
             .iter_by_state_version()
             .take(max_reevaluated_count as usize)
-            .collect(); // collect, just to release the mempool lock
+            .collect::<Vec<_>>(); // collect, just to release the mempool lock
 
         for candidate_transaction in candidate_transactions {
             // invoking the check automatically removes the transaction when rejected
@@ -333,7 +333,7 @@ impl MempoolManager {
     }
 
     /// Removes transactions no longer valid at or after the given epoch.
-    pub fn remove_txns_where_end_epoch_expired(&self, epoch: Epoch) -> Vec<Arc<MempoolData>> {
+    pub fn remove_txns_where_end_epoch_expired(&self, epoch: Epoch) -> Vec<MempoolData> {
         self.mempool
             .write()
             .remove_txns_where_end_epoch_expired(epoch)

--- a/core-rust/state-manager/src/mempool/mod.rs
+++ b/core-rust/state-manager/src/mempool/mod.rs
@@ -107,25 +107,33 @@ impl MempoolAddRejection {
     }
 
     pub fn is_permanent_for_payload(&self) -> bool {
-        match self.against_state {
-            AtState::Committed { .. } => self.reason.is_permanent_for_payload(),
-            AtState::PendingPreparingVertices { .. } => false,
+        match &self.against_state {
+            AtState::Specific(specific) => match specific {
+                AtSpecificState::Committed { .. } => self.reason.is_permanent_for_payload(),
+                AtSpecificState::PendingPreparingVertices { .. } => false,
+            },
             AtState::Static => self.reason.is_permanent_for_payload(),
         }
     }
 
     pub fn is_permanent_for_intent(&self) -> bool {
-        match self.against_state {
-            AtState::Committed { .. } => self.reason.is_permanent_for_intent(),
-            AtState::PendingPreparingVertices { .. } => false,
+        match &self.against_state {
+            AtState::Specific(specific) => match specific {
+                AtSpecificState::Committed { .. } => self.reason.is_permanent_for_intent(),
+                AtSpecificState::PendingPreparingVertices { .. } => false,
+            },
             AtState::Static => self.reason.is_permanent_for_payload(),
         }
     }
 
     pub fn is_rejected_because_intent_already_committed(&self) -> bool {
-        match self.against_state {
-            AtState::Committed { .. } => self.reason.is_rejected_because_intent_already_committed(),
-            AtState::PendingPreparingVertices { .. } => false,
+        match &self.against_state {
+            AtState::Specific(specific) => match specific {
+                AtSpecificState::Committed { .. } => {
+                    self.reason.is_rejected_because_intent_already_committed()
+                }
+                AtSpecificState::PendingPreparingVertices { .. } => false,
+            },
             AtState::Static => false,
         }
     }

--- a/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
+++ b/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
@@ -527,19 +527,19 @@ impl PendingTransactionResultCache {
             return record.clone();
         }
 
-        let new = PendingTransactionRecord::new(intent_hash, invalid_from_epoch, attempt);
+        let new_record = PendingTransactionRecord::new(intent_hash, invalid_from_epoch, attempt);
 
         // NB - removed is the item kicked out of the LRU cache if it's at capacity
         let removed = self
             .pending_transaction_records
-            .push(notarized_transaction_hash, new.clone());
+            .push(notarized_transaction_hash, new_record.clone());
 
         self.handled_added(intent_hash, notarized_transaction_hash);
-        if let Some((p, r)) = removed {
-            self.handled_removed(p, r);
+        if let Some((removed_notarized_transaction_hash, removed_record)) = removed {
+            self.handled_removed(removed_notarized_transaction_hash, removed_record);
         }
 
-        new
+        new_record
     }
 
     pub fn track_committed_transactions(

--- a/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
+++ b/core-rust/state-manager/src/mempool/pending_transaction_result_cache.rs
@@ -509,16 +509,9 @@ impl PendingTransactionResultCache {
         invalid_from_epoch: Option<Epoch>,
         attempt: TransactionAttempt,
     ) -> PendingTransactionRecord {
-        let mut write_mempool = self.mempool.write();
-        if attempt.rejection.is_some() {
-            write_mempool.remove_by_payload_hash(&notarized_transaction_hash);
-        } else if let AtState::Specific(specific_state) = &attempt.against_state {
-            write_mempool.update_transaction_executed_state_version(
-                &notarized_transaction_hash,
-                specific_state.committed_version(),
-            );
-        }
-        drop(write_mempool);
+        self.mempool
+            .write()
+            .observe_pending_execution_result(&notarized_transaction_hash, &attempt);
 
         let existing_record = self
             .pending_transaction_records

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -646,19 +646,6 @@ impl StateComputer {
             debug!("TXN INVALID: {}", &rejection.error);
         }
 
-        let pending_rejected_transactions = pending_transaction_results
-            .iter()
-            .filter(|pending_result| pending_result.rejection_reason.is_some())
-            .map(|pending_result| {
-                (
-                    &pending_result.intent_hash,
-                    &pending_result.notarized_transaction_hash,
-                )
-            })
-            .collect::<Vec<_>>();
-        self.mempool_manager
-            .remove_rejected(&pending_rejected_transactions);
-
         let mut write_pending_transaction_result_cache =
             self.pending_transaction_result_cache.write();
         for pending_transaction_result in pending_transaction_results {

--- a/core-rust/state-manager/src/state_computer.rs
+++ b/core-rust/state-manager/src/state_computer.rs
@@ -362,9 +362,11 @@ impl StateComputer {
         // our execution cache),
         //========================================================================================
 
-        let pending_transaction_base_state = AtState::PendingPreparingVertices {
-            base_committed_state_version: series_executor.latest_state_version(),
-        };
+        let pending_transaction_base_state =
+            AtState::Specific(AtSpecificState::PendingPreparingVertices {
+                base_committed_state_version: series_executor.latest_state_version(),
+                pending_transactions_root: prepare_request.ancestor_ledger_hashes.transaction_root,
+            });
 
         for raw_ancestor in prepare_request.ancestor_transactions {
             // TODO(optimization-only): We could avoid the hashing, decoding, signature verification

--- a/core-rust/state-manager/src/transaction/validation.rs
+++ b/core-rust/state-manager/src/transaction/validation.rs
@@ -12,9 +12,9 @@ use crate::store::traits::transactions::QueryableTransactionStore;
 use crate::store::traits::{QueryableProofStore, TransactionIndex};
 use crate::transaction::{ExecutionConfigurator, TransactionLogic};
 use crate::{
-    ActualStateManagerDatabase, AlreadyCommittedError, AtState, ExecutionRejectionReason,
-    MempoolRejectionReason, PendingTransactionRecord, PendingTransactionResultCache,
-    TransactionAttempt,
+    ActualStateManagerDatabase, AlreadyCommittedError, AtSpecificState, AtState,
+    ExecutionRejectionReason, MempoolRejectionReason, PendingTransactionRecord,
+    PendingTransactionResultCache, TransactionAttempt,
 };
 
 use super::{
@@ -243,9 +243,9 @@ impl CommittabilityValidator {
                             .notarized_transaction_hash,
                     },
                 )),
-                against_state: AtState::Committed {
+                against_state: AtState::Specific(AtSpecificState::Committed {
                     state_version: executed_at_state_version,
-                },
+                }),
                 timestamp,
             };
         }
@@ -280,9 +280,9 @@ impl CommittabilityValidator {
 
         TransactionAttempt {
             rejection: result.err(),
-            against_state: AtState::Committed {
+            against_state: AtState::Specific(AtSpecificState::Committed {
                 state_version: executed_at_state_version,
-            },
+            }),
             timestamp,
         }
     }


### PR DESCRIPTION
## Summary

This PR addresses some postponed pure-refactor comments from https://github.com/radixdlt/babylon-node/pull/681.
It is supposed to conclude https://radixdlt.atlassian.net/browse/NODE-617 for now.

## Details

- Removed some now-noop delete calls.
- Removed `Arc<>`s around `MempoolData`.
- Extracted some boilerplate into `indexing.rs`.
- Made `AtSpecificState` more... specific.

## Testing

Just the regression tests need to pass.
