### PR TITLE
Test for appropriate ledger state summary in historical Engine State API responses

### DIFF
--- a/core/src/test/java/com/radixdlt/api/CoreApiHelper.java
+++ b/core/src/test/java/com/radixdlt/api/CoreApiHelper.java
@@ -99,6 +99,10 @@ public class CoreApiHelper {
     return new StatusApi(apiClient).statusNetworkConfigurationPost().getWellKnownAddresses();
   }
 
+  public StreamApi streamApi() {
+    return new StreamApi(apiClient);
+  }
+
   public enum TransactionOutcome {
     CommittedSuccess,
     CommittedFailure,


### PR DESCRIPTION
## Summary

This concludes https://radixdlt.atlassian.net/browse/NODE-626.
The infra from https://github.com/radixdlt/babylon-node/pull/903 was integrated into Engine State API during update of `feature/browse_api` from `develop` (when I had to make it compile). So the only remaining bit was to add the tests.

## Testing

This PR is all about one thorough test.