### PR TITLE
Quickfix: Disable ReNode listing indices by default + Drive it by ENVs

### DIFF
--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -283,7 +283,7 @@ public final class RadixNodeModule extends AbstractModule {
     var enableAccountChangeIndex = properties.get("db.account_change_index.enable", true);
     var enableHistoricalSubstateValues =
         properties.get("db.historical_substate_values.enable", false);
-    var enableReNodeListingIndices = properties.get("db.re_node_listing_indices.enable", true);
+    var enableReNodeListingIndices = properties.get("db.re_node_listing_indices.enable", false);
     var databaseConfig =
         new DatabaseConfig(
             enableLocalTransactionExecutionIndex,

--- a/docker/config/default.config.envsubst
+++ b/docker/config/default.config.envsubst
@@ -15,6 +15,7 @@ state_hash_tree.state_version_history_length=$RADIXDLT_STATE_HASH_TREE_STATE_VER
 db.location=$RADIXDLT_DB_LOCATION
 db.local_transaction_execution_index.enable=$RADIXDLT_DB_LOCAL_TRANSACTION_EXECUTION_INDEX_ENABLE
 db.account_change_index.enable=$RADIXDLT_DB_ACCOUNT_CHANGE_INDEX_ENABLE
+db.re_node_listing_indices.enable=$RADIXDLT_RE_NODE_LISTING_INDICES_ENABLE
 db.historical_substate_values.enable=$RADIXDLT_DB_HISTORICAL_SUBSTATE_VALUES_ENABLE
 db.checkpoints_path=${RADIXDLT_DB_CHECKPOINTS_PATH}
 


### PR DESCRIPTION
## Summary

A missed flag for driving node-listing indices in the envsubst file.
(it was just always `true`).

## Details

Now it is `false` by default (because it only makes sense to enable it when planning to host the Engine State API).
