### PR TITLE
Refactor: Moving genesis scenarios from `GenesisData` to `StateManagerConfig`

### DIFF
--- a/cli-tools/src/main/java/com/radixdlt/cli/GenerateGenesis.java
+++ b/cli-tools/src/main/java/com/radixdlt/cli/GenerateGenesis.java
@@ -111,7 +111,6 @@ public final class GenerateGenesis {
 
   private static final Set<Network> PRODUCTION_NETWORKS = Set.of(Network.MAINNET);
   private static final Set<Network> NETWORKS_TO_DISABLE_FAUCET = PRODUCTION_NETWORKS;
-  private static final Set<Network> NETWORKS_TO_DISABLE_SCENARIOS = NETWORKS_TO_DISABLE_FAUCET;
 
   private static final Set<Network> NETWORKS_TO_ENSURE_PRODUCTION_EMISSIONS =
       Set.of(
@@ -282,10 +281,6 @@ public final class GenerateGenesis {
     }
 
     final var useFaucet = !NETWORKS_TO_DISABLE_FAUCET.contains(network);
-    final var scenariosToRun =
-        NETWORKS_TO_DISABLE_SCENARIOS.contains(network)
-            ? GenesisData.NO_SCENARIOS
-            : GenesisData.ALL_SCENARIOS;
 
     return GenesisBuilder.createGenesisWithValidatorsAndXrdBalances(
         validators,
@@ -294,8 +289,7 @@ public final class GenerateGenesis {
         xrdBalances,
         consensusConfig,
         useFaucet,
-        stakingAccountOwnsAllValidators,
-        scenariosToRun);
+        stakingAccountOwnsAllValidators);
   }
 
   private static void usage(Options options) {

--- a/core-rust-bridge/src/main/java/com/radixdlt/environment/StateManagerConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/environment/StateManagerConfig.java
@@ -83,7 +83,8 @@ public record StateManagerConfig(
     LedgerProofsGcConfig ledgerProofsGcConfig,
     LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
     ProtocolConfig protocolConfig,
-    boolean noFees) {
+    boolean noFees,
+    ScenariosExecutionConfig scenariosExecutionConfig) {
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
         StateManagerConfig.class,

--- a/core-rust-bridge/src/main/java/com/radixdlt/genesis/GenesisData.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/genesis/GenesisData.java
@@ -80,23 +80,9 @@ public record GenesisData(
     long initialTimestampMs,
     GenesisConsensusManagerConfig consensusManagerConfig,
     ImmutableList<GenesisDataChunk> chunks,
-    Decimal faucetSupply,
-    ImmutableList<String> scenarios) {
+    Decimal faucetSupply) {
 
   public static final Decimal DEFAULT_TEST_FAUCET_SUPPLY = Decimal.ofNonNegative(1000_000_000_000L);
-  public static final ImmutableList<String> ALL_SCENARIOS =
-      ImmutableList.of(
-          "transfer_xrd",
-          "radiswap",
-          "metadata",
-          "fungible_resource",
-          "non_fungible_resource",
-          "account_authorized_depositors",
-          "global_n_owned",
-          "non_fungible_resource_with_remote_type",
-          "kv_store_with_remote_type",
-          "max_transaction");
-  public static final ImmutableList<String> NO_SCENARIOS = ImmutableList.of();
 
   public static void registerCodec(CodecMap codecMap) {
     codecMap.register(
@@ -127,8 +113,7 @@ public record GenesisData(
                         ImmutableList.of(
                             new GenesisStakeAllocation(
                                 UInt32.fromNonNegativeInt(0), Decimal.ONE)))))),
-        DEFAULT_TEST_FAUCET_SUPPLY,
-        NO_SCENARIOS);
+        DEFAULT_TEST_FAUCET_SUPPLY);
   }
 
   public static GenesisData testingDefaultEmpty() {
@@ -137,17 +122,6 @@ public record GenesisData(
         0,
         GenesisConsensusManagerConfig.testingDefaultEmpty(),
         ImmutableList.of(),
-        DEFAULT_TEST_FAUCET_SUPPLY,
-        NO_SCENARIOS);
-  }
-
-  public static GenesisData testingDefaultEmptyWithScenarios() {
-    return new GenesisData(
-        UInt64.fromNonNegativeLong(1L),
-        0,
-        GenesisConsensusManagerConfig.testingDefaultEmpty(),
-        ImmutableList.of(),
-        DEFAULT_TEST_FAUCET_SUPPLY,
-        ALL_SCENARIOS);
+        DEFAULT_TEST_FAUCET_SUPPLY);
   }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/sbor/NodeSborCodecs.java
@@ -124,6 +124,7 @@ public final class NodeSborCodecs {
     NetworkDefinition.registerCodec(codecMap);
     LoggingConfig.registerCodec(codecMap);
     StateManagerConfig.registerCodec(codecMap);
+    ScenariosExecutionConfig.registerCodec(codecMap);
     ProtocolConfig.registerCodec(codecMap);
     ProtocolUpdateTrigger.registerCodec(codecMap);
     ProtocolUpdateEnactmentCondition.registerCodec(codecMap);

--- a/core-rust/state-manager/src/jni/state_computer.rs
+++ b/core-rust/state-manager/src/jni/state_computer.rs
@@ -86,7 +86,6 @@ pub struct JavaGenesisData {
     pub initial_config: JavaConsensusManagerConfig,
     pub chunks: Vec<GenesisDataChunk>,
     pub faucet_supply: Decimal,
-    pub scenarios_to_run: Vec<String>,
 }
 
 #[derive(Debug, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -139,7 +138,6 @@ extern "system" fn Java_com_radixdlt_statecomputer_RustStateComputer_executeGene
                 genesis_data.initial_timestamp_ms,
                 genesis_data_hash,
                 genesis_data.faucet_supply,
-                genesis_data.scenarios_to_run,
             );
             Ok(resultant_proof)
         },

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -111,6 +111,13 @@ pub struct StateManagerConfig {
     pub ledger_sync_limits_config: LedgerSyncLimitsConfig,
     pub protocol_config: ProtocolConfig,
     pub no_fees: bool,
+    pub scenarios_execution_config: ScenariosExecutionConfig,
+}
+
+#[derive(Debug, Clone, Default, Sbor)]
+pub struct ScenariosExecutionConfig {
+    pub genesis_scenarios: Vec<String>,
+    // TODO(protocol-update-scenarios): This is the place to define Scenarios to run after PUs.
 }
 
 #[derive(Debug, Clone, Default, Sbor)]
@@ -134,6 +141,7 @@ impl StateManagerConfig {
             ledger_sync_limits_config: LedgerSyncLimitsConfig::default(),
             protocol_config: ProtocolConfig::new_with_no_updates(),
             no_fees: false,
+            scenarios_execution_config: ScenariosExecutionConfig::default(),
         }
     }
 }
@@ -274,6 +282,7 @@ impl StateManager {
             lock_factory.named("state_computer"),
             &initial_state_computer_config,
             initial_protocol_state,
+            config.scenarios_execution_config.clone(),
         ));
 
         // Register the periodic background task for collecting the costly raw DB metrics...

--- a/core/src/main/java/com/radixdlt/genesis/GenesisBuilder.java
+++ b/core/src/main/java/com/radixdlt/genesis/GenesisBuilder.java
@@ -92,31 +92,20 @@ public final class GenesisBuilder {
         0,
         builder.build(),
         ImmutableList.of(validatorsAndStakesChunks.first(), validatorsAndStakesChunks.last()),
-        GenesisData.DEFAULT_TEST_FAUCET_SUPPLY,
-        GenesisData.NO_SCENARIOS);
+        GenesisData.DEFAULT_TEST_FAUCET_SUPPLY);
   }
 
   public static GenesisData createTestGenesisWithNumValidators(
       int numValidators, Decimal initialStake, GenesisConsensusManagerConfig.Builder builder) {
     return createTestGenesisWithNumValidatorsAndXrdBalances(
-        numValidators, initialStake, Map.of(), builder, GenesisData.NO_SCENARIOS);
-  }
-
-  public static GenesisData createTestGenesisWithNumValidators(
-      int numValidators,
-      Decimal initialStake,
-      GenesisConsensusManagerConfig.Builder builder,
-      ImmutableList<String> scenariosToRun) {
-    return createTestGenesisWithNumValidatorsAndXrdBalances(
-        numValidators, initialStake, Map.of(), builder, scenariosToRun);
+        numValidators, initialStake, Map.of(), builder);
   }
 
   public static GenesisData createTestGenesisWithNumValidatorsAndXrdBalances(
       int numValidators,
       Decimal initialStake,
       Map<ECDSASecp256k1PublicKey, Decimal> xrdBalances,
-      GenesisConsensusManagerConfig.Builder configBuilder,
-      ImmutableList<String> scenariosToRun) {
+      GenesisConsensusManagerConfig.Builder configBuilder) {
     final var chunksBuilder = ImmutableList.<GenesisDataChunk>builder();
 
     if (!xrdBalances.isEmpty()) {
@@ -138,8 +127,7 @@ public final class GenesisBuilder {
         0,
         configBuilder.build(),
         chunksBuilder.build(),
-        GenesisData.DEFAULT_TEST_FAUCET_SUPPLY,
-        scenariosToRun);
+        GenesisData.DEFAULT_TEST_FAUCET_SUPPLY);
   }
 
   public static GenesisData createGenesisWithValidatorsAndXrdBalances(
@@ -149,8 +137,7 @@ public final class GenesisBuilder {
       Map<ECDSASecp256k1PublicKey, Decimal> xrdBalances,
       GenesisConsensusManagerConfig.Builder configBuilder,
       boolean useFaucet,
-      boolean stakingAccountOwnsAllValidators,
-      ImmutableList<String> scenariosToRun) {
+      boolean stakingAccountOwnsAllValidators) {
     final var chunksBuilder = ImmutableList.<GenesisDataChunk>builder();
 
     if (!xrdBalances.isEmpty()) {
@@ -173,8 +160,7 @@ public final class GenesisBuilder {
         0,
         configBuilder.build(),
         chunksBuilder.build(),
-        useFaucet ? GenesisData.DEFAULT_TEST_FAUCET_SUPPLY : Decimal.ZERO,
-        scenariosToRun);
+        useFaucet ? GenesisData.DEFAULT_TEST_FAUCET_SUPPLY : Decimal.ZERO);
   }
 
   private static GenesisDataChunk.XrdBalances prepareXrdBalancesChunk(

--- a/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
+++ b/core/src/main/java/com/radixdlt/rev2/modules/REv2StateManagerModule.java
@@ -101,7 +101,6 @@ import com.radixdlt.transaction.REv2TransactionAndProofStore;
 import com.radixdlt.transactions.NotarizedTransactionHash;
 import com.radixdlt.transactions.PreparedNotarizedTransaction;
 import com.radixdlt.transactions.RawNotarizedTransaction;
-import com.radixdlt.utils.properties.RuntimeProperties;
 import java.io.File;
 
 public final class REv2StateManagerModule extends AbstractModule {
@@ -116,6 +115,7 @@ public final class REv2StateManagerModule extends AbstractModule {
   private final LedgerSyncLimitsConfig ledgerSyncLimitsConfig;
   private final ProtocolConfig protocolConfig;
   private final boolean noFees;
+  private final ScenariosExecutionConfig scenariosExecutionConfig;
 
   private REv2StateManagerModule(
       ProposalLimitsConfig proposalLimitsConfig,
@@ -127,7 +127,8 @@ public final class REv2StateManagerModule extends AbstractModule {
       LedgerProofsGcConfig ledgerProofsGcConfig,
       LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
       ProtocolConfig protocolConfig,
-      boolean noFees) {
+      boolean noFees,
+      ScenariosExecutionConfig scenariosExecutionConfig) {
     this.proposalLimitsConfig = proposalLimitsConfig;
     this.vertexLimitsConfigOpt = vertexLimitsConfigOpt;
     this.databaseConfig = databaseConfig;
@@ -138,6 +139,7 @@ public final class REv2StateManagerModule extends AbstractModule {
     this.ledgerSyncLimitsConfig = ledgerSyncLimitsConfig;
     this.protocolConfig = protocolConfig;
     this.noFees = noFees;
+    this.scenariosExecutionConfig = scenariosExecutionConfig;
   }
 
   public static REv2StateManagerModule create(
@@ -159,7 +161,8 @@ public final class REv2StateManagerModule extends AbstractModule {
         ledgerProofsGcConfig,
         ledgerSyncLimitsConfig,
         protocolConfig,
-        false);
+        false,
+        ScenariosExecutionConfig.NONE);
   }
 
   public static REv2StateManagerModule createForTesting(
@@ -171,7 +174,8 @@ public final class REv2StateManagerModule extends AbstractModule {
       LedgerProofsGcConfig ledgerProofsGcConfig,
       LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
       ProtocolConfig protocolConfig,
-      boolean noFees) {
+      boolean noFees,
+      ScenariosExecutionConfig scenariosExecutionConfig) {
     return new REv2StateManagerModule(
         proposalLimitsConfig,
         Option.none(),
@@ -182,7 +186,8 @@ public final class REv2StateManagerModule extends AbstractModule {
         ledgerProofsGcConfig,
         ledgerSyncLimitsConfig,
         protocolConfig,
-        noFees);
+        noFees,
+        scenariosExecutionConfig);
   }
 
   @Override
@@ -200,7 +205,7 @@ public final class REv2StateManagerModule extends AbstractModule {
           @Provides
           @Singleton
           DatabaseBackendConfig databaseBackendConfig(
-              @NodeStorageLocation String nodeStorageLocation, RuntimeProperties properties) {
+              @NodeStorageLocation String nodeStorageLocation) {
             return new DatabaseBackendConfig(
                 new File(nodeStorageLocation, "state_manager").getPath());
           }
@@ -227,7 +232,8 @@ public final class REv2StateManagerModule extends AbstractModule {
                     ledgerProofsGcConfig,
                     ledgerSyncLimitsConfig,
                     protocolConfig,
-                    noFees));
+                    noFees,
+                    scenariosExecutionConfig));
           }
 
           @Provides

--- a/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
@@ -425,7 +425,8 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         rev2Config.ledgerProofsGcConfig(),
                         rev2Config.ledgerSyncLimitsConfig(),
                         rev2Config.protocolConfig(),
-                        rev2Config.noFees()));
+                        rev2Config.noFees(),
+                        rev2Config.scenariosExecutionConfig()));
               }
               case REV2ProposerConfig.Mempool mempool -> {
                 install(new MempoolRelayerModule(mempool.mempoolRelayerConfig()));
@@ -442,7 +443,8 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
                         rev2Config.ledgerProofsGcConfig(),
                         rev2Config.ledgerSyncLimitsConfig(),
                         rev2Config.protocolConfig(),
-                        rev2Config.noFees()));
+                        rev2Config.noFees(),
+                        rev2Config.scenariosExecutionConfig()));
               }
             }
           }

--- a/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
+++ b/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
@@ -75,6 +75,7 @@ import com.radixdlt.consensus.liveness.ProposerElections;
 import com.radixdlt.consensus.liveness.WeightedRotatingLeaders;
 import com.radixdlt.environment.DatabaseConfig;
 import com.radixdlt.environment.LedgerProofsGcConfig;
+import com.radixdlt.environment.ScenariosExecutionConfig;
 import com.radixdlt.environment.StateTreeGcConfig;
 import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.harness.simulation.application.TransactionGenerator;
@@ -155,7 +156,8 @@ public sealed interface StateComputerConfig {
         debugLogging,
         noFees,
         protocolConfig,
-        StateTreeGcConfig.forTesting());
+        StateTreeGcConfig.forTesting(),
+        ScenariosExecutionConfig.NONE);
   }
 
   static StateComputerConfig rev2(
@@ -166,7 +168,8 @@ public sealed interface StateComputerConfig {
       boolean debugLogging,
       boolean noFees,
       ProtocolConfig protocolConfig,
-      StateTreeGcConfig stateTreeGcConfig) {
+      StateTreeGcConfig stateTreeGcConfig,
+      ScenariosExecutionConfig scenariosExecutionConfig) {
     return new REv2StateComputerConfig(
         networkId,
         genesis,
@@ -177,7 +180,8 @@ public sealed interface StateComputerConfig {
         LedgerProofsGcConfig.forTesting(),
         LedgerSyncLimitsConfig.defaults(),
         protocolConfig,
-        noFees);
+        noFees,
+        scenariosExecutionConfig);
   }
 
   static StateComputerConfig rev2(
@@ -195,7 +199,8 @@ public sealed interface StateComputerConfig {
         LedgerProofsGcConfig.forTesting(),
         LedgerSyncLimitsConfig.defaults(),
         ProtocolConfig.testingDefault(),
-        false);
+        false,
+        ScenariosExecutionConfig.NONE);
   }
 
   static StateComputerConfig rev2(
@@ -218,7 +223,8 @@ public sealed interface StateComputerConfig {
         LedgerProofsGcConfig.forTesting(),
         LedgerSyncLimitsConfig.defaults(),
         protocolConfig,
-        false);
+        false,
+        ScenariosExecutionConfig.NONE);
   }
 
   sealed interface MockedMempoolConfig {
@@ -290,7 +296,8 @@ public sealed interface StateComputerConfig {
       LedgerProofsGcConfig ledgerProofsGcConfig,
       LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
       ProtocolConfig protocolConfig,
-      boolean noFees)
+      boolean noFees,
+      ScenariosExecutionConfig scenariosExecutionConfig)
       implements StateComputerConfig {}
 
   sealed interface REV2ProposerConfig {

--- a/core/src/test/java/com/radixdlt/api/DeterministicCoreApiTestBase.java
+++ b/core/src/test/java/com/radixdlt/api/DeterministicCoreApiTestBase.java
@@ -68,7 +68,6 @@ import static com.radixdlt.environment.deterministic.network.MessageSelector.fir
 import static org.assertj.core.api.Assertions.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.ClassPath;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.ProvidesIntoSet;
@@ -81,7 +80,6 @@ import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.environment.*;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
-import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.harness.deterministic.DeterministicTest;
 import com.radixdlt.harness.deterministic.PhysicalNodeConfig;
 import com.radixdlt.lang.Functions;
@@ -122,23 +120,27 @@ public abstract class DeterministicCoreApiTestBase {
 
   protected DeterministicTest buildRunningServerTest() {
     return buildRunningServerTest(
-        1000000, TEST_DATABASE_CONFIG, GenesisData.NO_SCENARIOS, ProtocolConfig.testingDefault());
+        1000000,
+        TEST_DATABASE_CONFIG,
+        ScenariosExecutionConfig.NONE,
+        ProtocolConfig.testingDefault());
   }
 
   protected DeterministicTest buildRunningServerTestWithProtocolConfig(
       int roundsPerEpoch, ProtocolConfig protocolConfig) {
     return buildRunningServerTest(
-        roundsPerEpoch, TEST_DATABASE_CONFIG, GenesisData.NO_SCENARIOS, protocolConfig);
+        roundsPerEpoch, TEST_DATABASE_CONFIG, ScenariosExecutionConfig.NONE, protocolConfig);
   }
 
-  protected DeterministicTest buildRunningServerTestWithScenarios(ImmutableList<String> scenarios) {
+  protected DeterministicTest buildRunningServerTestWithScenarios(
+      ScenariosExecutionConfig scenarios) {
     return buildRunningServerTest(
         1000000, TEST_DATABASE_CONFIG, scenarios, ProtocolConfig.testingDefault());
   }
 
   protected DeterministicTest buildRunningServerTest(DatabaseConfig databaseConfig) {
     return buildRunningServerTest(
-        1000000, databaseConfig, GenesisData.NO_SCENARIOS, ProtocolConfig.testingDefault());
+        1000000, databaseConfig, ScenariosExecutionConfig.NONE, ProtocolConfig.testingDefault());
   }
 
   protected DeterministicTest buildRunningServerTest(
@@ -146,7 +148,7 @@ public abstract class DeterministicCoreApiTestBase {
     return buildRunningServerTest(
         1000000,
         databaseConfig,
-        GenesisData.NO_SCENARIOS,
+        ScenariosExecutionConfig.NONE,
         ProtocolConfig.testingDefault(),
         stateTreeGcConfig);
   }
@@ -155,14 +157,14 @@ public abstract class DeterministicCoreApiTestBase {
     return buildRunningServerTest(
         roundsPerEpoch,
         TEST_DATABASE_CONFIG,
-        GenesisData.NO_SCENARIOS,
+        ScenariosExecutionConfig.NONE,
         ProtocolConfig.testingDefault());
   }
 
   protected DeterministicTest buildRunningServerTest(
       int roundsPerEpoch,
       DatabaseConfig databaseConfig,
-      ImmutableList<String> scenariosToRun,
+      ScenariosExecutionConfig scenariosExecutionConfig,
       ProtocolConfig protocolConfig,
       StateTreeGcConfig stateTreeGcConfig) {
     return buildRunningServerTest(
@@ -172,20 +174,20 @@ public abstract class DeterministicCoreApiTestBase {
                 1,
                 Decimal.ONE,
                 GenesisConsensusManagerConfig.Builder.testDefaults()
-                    .epochExactRoundCount(roundsPerEpoch),
-                scenariosToRun),
+                    .epochExactRoundCount(roundsPerEpoch)),
             databaseConfig,
             StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
             false,
             false,
             protocolConfig,
-            stateTreeGcConfig));
+            stateTreeGcConfig,
+            scenariosExecutionConfig));
   }
 
   protected DeterministicTest buildRunningServerTest(
       int roundsPerEpoch,
       DatabaseConfig databaseConfig,
-      ImmutableList<String> scenariosToRun,
+      ScenariosExecutionConfig scenariosExecutionConfig,
       ProtocolConfig protocolConfig) {
     return buildRunningServerTest(
         StateComputerConfig.rev2(
@@ -194,13 +196,14 @@ public abstract class DeterministicCoreApiTestBase {
                 1,
                 Decimal.ONE,
                 GenesisConsensusManagerConfig.Builder.testDefaults()
-                    .epochExactRoundCount(roundsPerEpoch),
-                scenariosToRun),
+                    .epochExactRoundCount(roundsPerEpoch)),
             databaseConfig,
             StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
             false,
             false,
-            protocolConfig));
+            protocolConfig,
+            StateTreeGcConfig.forTesting(),
+            scenariosExecutionConfig));
   }
 
   protected DeterministicTest buildRunningServerTest(StateComputerConfig stateComputerConfig) {

--- a/core/src/test/java/com/radixdlt/api/core/LtsTransactionOutcomesTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/LtsTransactionOutcomesTest.java
@@ -70,7 +70,7 @@ import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.environment.DatabaseConfig;
-import com.radixdlt.genesis.GenesisData;
+import com.radixdlt.environment.ScenariosExecutionConfig;
 import com.radixdlt.identifiers.Address;
 import com.radixdlt.lang.Option;
 import com.radixdlt.rev2.*;
@@ -147,7 +147,7 @@ public class LtsTransactionOutcomesTest extends DeterministicCoreApiTestBase {
   public void test_resultant_account_balances() throws Exception {
     // We run all scenarios for the case when RE decides to change invariants (i.e. no vault
     // substate is deleted).
-    try (var test = buildRunningServerTestWithScenarios(GenesisData.ALL_SCENARIOS)) {
+    try (var test = buildRunningServerTestWithScenarios(ScenariosExecutionConfig.ALL)) {
       test.suppressUnusedWarning();
 
       var account1KeyPair = ECKeyPair.generateNew();

--- a/core/src/test/java/com/radixdlt/api/core/TransactionStreamTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/TransactionStreamTest.java
@@ -75,7 +75,7 @@ import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
 import com.radixdlt.crypto.EdDSAEd25519PublicKey;
 import com.radixdlt.crypto.PublicKey;
-import com.radixdlt.genesis.GenesisData;
+import com.radixdlt.environment.ScenariosExecutionConfig;
 import com.radixdlt.harness.deterministic.TransactionExecutor;
 import com.radixdlt.message.CurveDecryptorSet;
 import com.radixdlt.message.Decryptor;
@@ -98,7 +98,7 @@ public class TransactionStreamTest extends DeterministicCoreApiTestBase {
       throws Exception {
     // This test checks that the transaction stream doesn't return errors when mapping genesis and
     // the scenarios
-    try (var test = buildRunningServerTestWithScenarios(GenesisData.ALL_SCENARIOS)) {
+    try (var test = buildRunningServerTestWithScenarios(ScenariosExecutionConfig.ALL)) {
       test.suppressUnusedWarning();
       var transaction = TransactionBuilder.forTests().prepare();
 

--- a/core/src/test/java/com/radixdlt/rev2/LedgerProofsGcTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/LedgerProofsGcTest.java
@@ -69,6 +69,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.radixdlt.environment.DatabaseConfig;
 import com.radixdlt.environment.LedgerProofsGcConfig;
+import com.radixdlt.environment.ScenariosExecutionConfig;
 import com.radixdlt.environment.StateTreeGcConfig;
 import com.radixdlt.environment.deterministic.network.MessageMutator;
 import com.radixdlt.genesis.GenesisBuilder;
@@ -151,7 +152,8 @@ public final class LedgerProofsGcTest {
                             UInt32.fromNonNegativeInt(maxTxnCountUnderProof),
                             UInt32.fromNonNegativeInt(maxTxnPayloadSizeUnderProof)),
                         ProtocolConfig.testingDefault(),
-                        false),
+                        false,
+                        ScenariosExecutionConfig.NONE),
                     SyncRelayConfig.of(100, 2, 200L))));
   }
 

--- a/core/src/test/java/com/radixdlt/rev2/REv2GenesisTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2GenesisTest.java
@@ -70,6 +70,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.radixdlt.crypto.ECDSASecp256k1PublicKey;
 import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.environment.DatabaseConfig;
+import com.radixdlt.environment.ScenariosExecutionConfig;
+import com.radixdlt.environment.StateTreeGcConfig;
 import com.radixdlt.environment.deterministic.network.MessageMutator;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
@@ -83,6 +86,7 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.networks.Network;
+import com.radixdlt.protocol.ProtocolConfig;
 import com.radixdlt.testutil.TestStateReader;
 import java.util.Map;
 import org.junit.Rule;
@@ -152,9 +156,14 @@ public final class REv2GenesisTest {
                             1,
                             INITIAL_STAKE,
                             Map.of(XRD_ALLOC_ACCOUNT_PUB_KEY, XRD_ALLOC_AMOUNT),
-                            GenesisConsensusManagerConfig.Builder.testDefaults(),
-                            GenesisData.ALL_SCENARIOS),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.zero()))));
+                            GenesisConsensusManagerConfig.Builder.testDefaults()),
+                        new DatabaseConfig(true, false, false),
+                        StateComputerConfig.REV2ProposerConfig.Mempool.zero(),
+                        false,
+                        false,
+                        ProtocolConfig.testingDefault(),
+                        StateTreeGcConfig.forTesting(),
+                        ScenariosExecutionConfig.ALL))));
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2StateComputerTest.java
@@ -78,7 +78,6 @@ import com.radixdlt.consensus.vertexstore.VertexStoreState;
 import com.radixdlt.environment.*;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
-import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.genesis.RawGenesisDataWithHash;
 import com.radixdlt.identifiers.Address;
 import com.radixdlt.lang.Option;
@@ -129,7 +128,8 @@ public class REv2StateComputerTest {
             LedgerProofsGcConfig.forTesting(),
             LedgerSyncLimitsConfig.defaults(),
             ProtocolConfig.testingDefault(),
-            false),
+            false,
+            ScenariosExecutionConfig.NONE),
         new REv2LedgerInitializerModule(
             RawGenesisDataWithHash.fromGenesisData(
                 GenesisBuilder.createGenesisWithValidatorsAndXrdBalances(
@@ -139,8 +139,7 @@ public class REv2StateComputerTest {
                     Map.of(),
                     GenesisConsensusManagerConfig.Builder.testDefaults(),
                     true,
-                    false,
-                    GenesisData.NO_SCENARIOS))),
+                    false))),
         new REv2LedgerRecoveryModule(),
         new AbstractModule() {
           @Override

--- a/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/RustMempoolTest.java
@@ -137,7 +137,8 @@ public final class RustMempoolTest {
             LedgerProofsGcConfig.forTesting(),
             LedgerSyncLimitsConfig.defaults(),
             ProtocolConfig.testingDefault(),
-            false);
+            false,
+            ScenariosExecutionConfig.NONE);
     final var metrics = new MetricsInitializer().initialize();
 
     try (var stateManager = new NodeRustEnvironment(NOOP_DISPATCHER, NOOP_HANDLER, config)) {
@@ -195,7 +196,8 @@ public final class RustMempoolTest {
             LedgerProofsGcConfig.forTesting(),
             LedgerSyncLimitsConfig.defaults(),
             ProtocolConfig.testingDefault(),
-            false);
+            false,
+            ScenariosExecutionConfig.NONE);
     final var metrics = new MetricsInitializer().initialize();
 
     try (var stateManager = new NodeRustEnvironment(NOOP_DISPATCHER, NOOP_HANDLER, config)) {
@@ -336,7 +338,8 @@ public final class RustMempoolTest {
             LedgerProofsGcConfig.forTesting(),
             LedgerSyncLimitsConfig.defaults(),
             ProtocolConfig.testingDefault(),
-            false);
+            false,
+            ScenariosExecutionConfig.NONE);
     final var metrics = new MetricsInitializer().initialize();
 
     try (var stateManager = new NodeRustEnvironment(NOOP_DISPATCHER, NOOP_HANDLER, config)) {

--- a/core/src/test/java/com/radixdlt/rev2/StateTreeGcTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/StateTreeGcTest.java
@@ -68,6 +68,7 @@ import static com.radixdlt.environment.deterministic.network.MessageSelector.fir
 
 import com.radixdlt.environment.DatabaseConfig;
 import com.radixdlt.environment.LedgerProofsGcConfig;
+import com.radixdlt.environment.ScenariosExecutionConfig;
 import com.radixdlt.environment.StateTreeGcConfig;
 import com.radixdlt.environment.deterministic.network.MessageMutator;
 import com.radixdlt.genesis.GenesisBuilder;
@@ -128,7 +129,8 @@ public final class StateTreeGcTest {
                         LedgerProofsGcConfig.forTesting(),
                         LedgerSyncLimitsConfig.defaults(),
                         ProtocolConfig.testingDefault(),
-                        false))));
+                        false,
+                        ScenariosExecutionConfig.NONE))));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This is the first step towards https://radixdlt.atlassian.net/browse/NODE-618.
A pure refactoring - the entire scope is in the title.
The next PR will simply add `after_protocol_update_scenarios: Map<ProtocolUpdateName, List<ScenarioName>>`.

## Testing

A refactoring - just the existing tests must pass.