### PR TITLE
Render `ScryptoInstant` with only a second-precision

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -2392,8 +2392,8 @@ components:
           type: string
           description: |
             The RFC 3339 / ISO 8601 string representation of the timestamp. Will always use "Z"
-            (denoting UTC) and include milliseconds (which are always `000`).
-            E.g.: `2023-01-26T18:30:09.000Z`.
+            (denoting UTC) and a second-precision (i.e. *skipping* the `.000` milliseconds part).
+            E.g.: `2023-01-26T18:30:09Z`.
             
             Note: This field will *not* be present if the actual on-ledger `unix_timestamp_seconds`
             value is outside the basic range supported by the RFC 3339 / ISO 8601 standard, which

--- a/core-rust/core-api-server/src/core_api/conversions/numerics.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/numerics.rs
@@ -164,7 +164,7 @@ pub fn to_api_scrypto_instant(instant: &Instant) -> Result<models::ScryptoInstan
         .filter(|date_time| ISO_8601_YEAR_RANGE.contains(&date_time.year()));
     Ok(models::ScryptoInstant {
         unix_timestamp_seconds: to_api_i64_as_string(timestamp_seconds),
-        date_time: date_time.map(to_canonical_rfc3339_string),
+        date_time: date_time.map(to_second_precision_rfc3339_string),
     })
 }
 
@@ -183,6 +183,10 @@ pub fn to_api_clamped_instant_from_epoch_milli(
 
 fn to_canonical_rfc3339_string(date_time: NaiveDateTime) -> String {
     DateTime::<Utc>::from_utc(date_time, Utc).to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn to_second_precision_rfc3339_string(date_time: NaiveDateTime) -> String {
+    DateTime::<Utc>::from_utc(date_time, Utc).to_rfc3339_opts(SecondsFormat::Secs, true)
 }
 
 pub fn extract_api_state_version(
@@ -355,7 +359,7 @@ mod tests {
             to_api_scrypto_instant(&Instant::new(0)).unwrap(),
             models::ScryptoInstant {
                 unix_timestamp_seconds: "0".to_string(),
-                date_time: Some("1970-01-01T00:00:00.000Z".to_string()),
+                date_time: Some("1970-01-01T00:00:00Z".to_string()),
             }
         );
 
@@ -364,14 +368,14 @@ mod tests {
             to_api_scrypto_instant(&Instant::new(1)).unwrap(),
             models::ScryptoInstant {
                 unix_timestamp_seconds: "1".to_string(),
-                date_time: Some("1970-01-01T00:00:01.000Z".to_string()),
+                date_time: Some("1970-01-01T00:00:01Z".to_string()),
             }
         );
         assert_eq!(
             to_api_scrypto_instant(&Instant::new(-1)).unwrap(),
             models::ScryptoInstant {
                 unix_timestamp_seconds: "-1".to_string(),
-                date_time: Some("1969-12-31T23:59:59.000Z".to_string()),
+                date_time: Some("1969-12-31T23:59:59Z".to_string()),
             }
         );
 
@@ -380,14 +384,14 @@ mod tests {
             to_api_scrypto_instant(&Instant::new(253402300799)).unwrap(),
             models::ScryptoInstant {
                 unix_timestamp_seconds: "253402300799".to_string(),
-                date_time: Some("9999-12-31T23:59:59.000Z".to_string()),
+                date_time: Some("9999-12-31T23:59:59Z".to_string()),
             }
         );
         assert_eq!(
             to_api_scrypto_instant(&Instant::new(-12212553600)).unwrap(),
             models::ScryptoInstant {
                 unix_timestamp_seconds: "-12212553600".to_string(),
-                date_time: Some("1583-01-01T00:00:00.000Z".to_string()),
+                date_time: Some("1583-01-01T00:00:00Z".to_string()),
             }
         );
 

--- a/core-rust/core-api-server/src/core_api/generated/models/scrypto_instant.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/scrypto_instant.rs
@@ -16,7 +16,7 @@ pub struct ScryptoInstant {
     /// A decimal string-encoded 64-bit signed integer, marking the unix timestamp in seconds.  Note: this field accurately represents the full range of possible on-ledger values (i.e. `-2^63 <= seconds < 2^63`). This is contrary to the `InstantMs` type used in other places of this API. 
     #[serde(rename = "unix_timestamp_seconds")]
     pub unix_timestamp_seconds: String,
-    /// The RFC 3339 / ISO 8601 string representation of the timestamp. Will always use \"Z\" (denoting UTC) and include milliseconds (which are always `000`). E.g.: `2023-01-26T18:30:09.000Z`.  Note: This field will *not* be present if the actual on-ledger `unix_timestamp_seconds` value cannot be expressed as a RFC 3339 / ISO 8601 string (i.e. in case of extreme signed 64-bit integer values). 
+    /// The RFC 3339 / ISO 8601 string representation of the timestamp. Will always use \"Z\" (denoting UTC) and a second-precision (i.e. *skipping* the `.000` milliseconds part). E.g.: `2023-01-26T18:30:09Z`.  Note: This field will *not* be present if the actual on-ledger `unix_timestamp_seconds` value is outside the basic range supported by the RFC 3339 / ISO 8601 standard, which starts at year 1583 (i.e. the beginning of the Gregorian calendar) and ends at year 9999 (inclusive). 
     #[serde(rename = "date_time", skip_serializing_if = "Option::is_none")]
     pub date_time: Option<String>,
 }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/ScryptoInstant.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/ScryptoInstant.java
@@ -77,11 +77,11 @@ public class ScryptoInstant {
   }
 
    /**
-   * The RFC 3339 / ISO 8601 string representation of the timestamp. Will always use \&quot;Z\&quot; (denoting UTC) and include milliseconds (which are always &#x60;000&#x60;). E.g.: &#x60;2023-01-26T18:30:09.000Z&#x60;.  Note: This field will *not* be present if the actual on-ledger &#x60;unix_timestamp_seconds&#x60; value cannot be expressed as a RFC 3339 / ISO 8601 string (i.e. in case of extreme signed 64-bit integer values). 
+   * The RFC 3339 / ISO 8601 string representation of the timestamp. Will always use \&quot;Z\&quot; (denoting UTC) and a second-precision (i.e. *skipping* the &#x60;.000&#x60; milliseconds part). E.g.: &#x60;2023-01-26T18:30:09Z&#x60;.  Note: This field will *not* be present if the actual on-ledger &#x60;unix_timestamp_seconds&#x60; value is outside the basic range supported by the RFC 3339 / ISO 8601 standard, which starts at year 1583 (i.e. the beginning of the Gregorian calendar) and ends at year 9999 (inclusive). 
    * @return dateTime
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "The RFC 3339 / ISO 8601 string representation of the timestamp. Will always use \"Z\" (denoting UTC) and include milliseconds (which are always `000`). E.g.: `2023-01-26T18:30:09.000Z`.  Note: This field will *not* be present if the actual on-ledger `unix_timestamp_seconds` value cannot be expressed as a RFC 3339 / ISO 8601 string (i.e. in case of extreme signed 64-bit integer values). ")
+  @ApiModelProperty(value = "The RFC 3339 / ISO 8601 string representation of the timestamp. Will always use \"Z\" (denoting UTC) and a second-precision (i.e. *skipping* the `.000` milliseconds part). E.g.: `2023-01-26T18:30:09Z`.  Note: This field will *not* be present if the actual on-ledger `unix_timestamp_seconds` value is outside the basic range supported by the RFC 3339 / ISO 8601 standard, which starts at year 1583 (i.e. the beginning of the Gregorian calendar) and ends at year 9999 (inclusive). ")
   @JsonProperty(JSON_PROPERTY_DATE_TIME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/sdk/typescript/lib/generated/models/ScryptoInstant.ts
+++ b/sdk/typescript/lib/generated/models/ScryptoInstant.ts
@@ -31,12 +31,13 @@ export interface ScryptoInstant {
     unix_timestamp_seconds: string;
     /**
      * The RFC 3339 / ISO 8601 string representation of the timestamp. Will always use "Z"
-     * (denoting UTC) and include milliseconds (which are always `000`).
-     * E.g.: `2023-01-26T18:30:09.000Z`.
+     * (denoting UTC) and a second-precision (i.e. *skipping* the `.000` milliseconds part).
+     * E.g.: `2023-01-26T18:30:09Z`.
      * 
      * Note: This field will *not* be present if the actual on-ledger `unix_timestamp_seconds`
-     * value cannot be expressed as a RFC 3339 / ISO 8601 string (i.e. in case of extreme
-     * signed 64-bit integer values).
+     * value is outside the basic range supported by the RFC 3339 / ISO 8601 standard, which
+     * starts at year 1583 (i.e. the beginning of the Gregorian calendar) and ends at year
+     * 9999 (inclusive).
      * @type {string}
      * @memberof ScryptoInstant
      */


### PR DESCRIPTION
## Summary

Addresses the https://radixdlt.atlassian.net/browse/NODE-632 for Core API.

## Testing

Adjusted the detailed unit test.