### PR TITLE
Add a note about `core-rust` dependency of the rundocker script

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,6 +12,8 @@ From the repository root, run the following - replacing 2 with the number of val
 ./docker/scripts/rundocker.sh 2
 ```
 
+This script requires [`../core-rust`](../core-rust) to be compiled.
+
 ## The Dockerfile
 
 ![The structure of the docker image](babylon-node-docker-build.png)


### PR DESCRIPTION
## Summary

I was trying to run the `rundocker.sh` script and noticed this implicit dependency. I think it makes sense to make it explicit.