### PR TITLE
Pin a different version of openjdk17 deps in docker for ARM.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -210,6 +210,7 @@ jobs:
       cache_tag_suffix: arm64
       build-args: |
         WGET_VERSION=1.21.3-1+b1
+        OPENJDK_17_VERSION=17.0.10+7-1~deb12u1
         VERSION_BRANCH=${{ needs.setup_version_properties.outputs.VERSION_BRANCH }}
         VERSION_COMMIT=${{ needs.setup_version_properties.outputs.VERSION_COMMIT }}
         VERSION_DISPLAY=${{ needs.setup_version_properties.outputs.VERSION_DISPLAY }}
@@ -298,6 +299,7 @@ jobs:
       provenance: "false"
       build-args: |
         WGET_VERSION=1.21.3-1+b1
+        OPENJDK_17_VERSION=17.0.10+7-1~deb12u1
         VERSION_BRANCH=${{ needs.setup_version_properties.outputs.VERSION_BRANCH }}
         VERSION_COMMIT=${{ needs.setup_version_properties.outputs.VERSION_COMMIT }}
         VERSION_DISPLAY=${{ needs.setup_version_properties.outputs.VERSION_DISPLAY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV DEBIAN_FRONTEND noninteractive
 CMD ["/bin/bash"]
 
 ARG WGET_VERSION="1.21.3-1+b2"
+ARG OPENJDK_17_VERSION="17.0.11+9-1~deb12u1"
 ARG VERSION_BRANCH=""
 ARG VERSION_COMMIT=""
 ARG VERSION_DISPLAY=""
@@ -56,7 +57,7 @@ RUN apt-get update \
     wget=${WGET_VERSION} \
     software-properties-common=0.99.30-4 \
   && apt-get install -y --no-install-recommends \
-    openjdk-17-jdk=17.0.11+9-1~deb12u1 \
+    openjdk-17-jdk=OPENJDK_17_VERSION \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -257,7 +258,7 @@ LABEL org.opencontainers.image.authors="devops@radixdlt.com"
 # - https://packages.debian.org/bookworm/libc6
 RUN apt-get update -y \
   && apt-get -y --no-install-recommends install \
-    openjdk-17-jre-headless=17.0.11+9-1~deb12u1 \
+    openjdk-17-jre-headless=OPENJDK_17_VERSION \
     # https://security-tracker.debian.org/tracker/CVE-2023-38545
     curl=7.88.1-10+deb12u5 \
     gettext-base=0.21-12 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update \
     wget=${WGET_VERSION} \
     software-properties-common=0.99.30-4 \
   && apt-get install -y --no-install-recommends \
-    openjdk-17-jdk=OPENJDK_17_VERSION \
+    openjdk-17-jdk=${OPENJDK_17_VERSION} \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -258,7 +258,7 @@ LABEL org.opencontainers.image.authors="devops@radixdlt.com"
 # - https://packages.debian.org/bookworm/libc6
 RUN apt-get update -y \
   && apt-get -y --no-install-recommends install \
-    openjdk-17-jre-headless=OPENJDK_17_VERSION \
+    openjdk-17-jre-headless=${OPENJDK_17_VERSION} \
     # https://security-tracker.debian.org/tracker/CVE-2023-38545
     curl=7.88.1-10+deb12u5 \
     gettext-base=0.21-12 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -239,6 +239,8 @@ FROM debian:12.1-slim as app-container
 LABEL org.opencontainers.image.source https://github.com/radixdlt/babylon-node
 LABEL org.opencontainers.image.authors="devops@radixdlt.com"
 
+ARG OPENJDK_17_VERSION="17.0.11+9-1~deb12u1"
+
 # Install dependencies needed for building the image or running the application
 # - unzip is needed for unpacking the java build artifacts
 # - daemontools is needed at application runtime for async tasks


### PR DESCRIPTION
## Summary

Addresses a build failure spotted at https://github.com/radixdlt/babylon-node/actions/runs/8797900181/job/24143785471#step:19:527.
We recently had to bump a version, but it is not available for ARM (see https://packages.debian.org/bookworm/openjdk-17-jre-headless).

## Testing

N/A, a build problem only.