### PR TITLE
Bump Bottlenose's Engine dep to `b82a7db0`

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "radix-blueprint-schema-init"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "bitflags 1.3.2",
  "radix-common",
@@ -1504,7 +1504,7 @@ dependencies = [
 [[package]]
 name = "radix-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "bech32",
  "blake2",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "radix-common-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "bitflags 1.3.2",
  "colored",
@@ -1573,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "fixedstr",
 ]
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1613,7 +1613,7 @@ dependencies = [
 [[package]]
 name = "radix-native-sdk"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "radix-common",
  "radix-engine-interface",
@@ -1624,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "radix-rust"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "radix-sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1644,7 +1644,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-impls"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "hex",
  "itertools",
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "hex",
  "itertools",
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-queries"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "hex",
  "itertools",
@@ -1686,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "radix-transaction-scenarios"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "hex",
  "itertools",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "radix-transactions"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "annotate-snippets",
  "bech32",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "sbor"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "const-sha1",
  "hex",
@@ -1949,16 +1949,17 @@ dependencies = [
 [[package]]
 name = "sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "sbor-derive-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-d02dac77#d02dac77b37a9b909c821c1c790e4677781cf7b9"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b82a7db0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
 dependencies = [
  "const-sha1",
  "itertools",

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -22,17 +22,17 @@ resolver = "2"
 #   $ git push origin "release_name-BLAH"
 # * Then use tag="release_name-BLAH" in the below dependencies.
 # 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77", features = ["serde"] }
-radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77" }
-radix-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77" }
-radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77", features = ["serde"] }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77" }
-radix-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77" }
-radix-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77" }
-radix-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77" }
-radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77", features = ["serde"] }
-radix-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-d02dac77", features = ["serde"] }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0", features = ["serde"] }
+radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0" }
+radix-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0" }
+radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0", features = ["serde"] }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0" }
+radix-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0" }
+radix-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0" }
+radix-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0" }
+radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0", features = ["serde"] }
+radix-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b82a7db0", features = ["serde"] }
 
 itertools = { version = "=0.10.5" }
 jni = { version = "=0.19.0" }

--- a/core-rust/core-api-server/src/core_api/conversions/receipt.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/receipt.rs
@@ -572,7 +572,10 @@ impl StateMappingLookups {
                     package_address,
                     blueprint_name: blueprint_name.clone(),
                 },
-                definition.into_latest().interface.types,
+                definition
+                    .fully_update_and_into_latest_version()
+                    .interface
+                    .types,
             );
         }
         Ok(blueprint_type_lookups)

--- a/core-rust/core-api-server/src/core_api/conversions/substates/mod.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/mod.rs
@@ -102,7 +102,7 @@ macro_rules! field_substate_versioned {
                 is_locked: matches!($substate.lock_status(), LockStatus::Locked),
                 value: {
                     // NB: We should use compiler to unpack to ensure we map all fields
-                    let $value_unpacking = $substate.payload().as_latest_ref()
+                    let $value_unpacking = $substate.payload().as_latest_version()
                         .ok_or(MappingError::ObsoleteSubstateVersion)?;
                     $($($mapping)+)?;
                     Box::new(models::[<$substate_type Value>] $fields)
@@ -180,7 +180,7 @@ macro_rules! key_value_store_optional_substate_versioned {
                     .map(|opt| -> Result<_, MappingError> {
                         #[allow(clippy::let_unit_value)]
                         let $value_unpacking = opt
-                            .as_latest_ref()
+                            .as_latest_version()
                             .ok_or(MappingError::ObsoleteSubstateVersion)?;
                         Ok(Box::new(models::[<$substate_type Value>] $fields))
                     })
@@ -221,7 +221,7 @@ macro_rules! key_value_store_mandatory_substate_versioned {
     ) => {
         paste::paste! {
             {
-                let $value_unpacking = $substate.get_definitely_present_value()?.as_latest_ref()
+                let $value_unpacking = $substate.get_definitely_present_value()?.as_latest_version()
                     .ok_or(MappingError::ObsoleteSubstateVersion)?;
                 models::Substate::[<$substate_type Substate>] {
                     is_locked: matches!($substate.lock_status(), LockStatus::Locked),
@@ -261,7 +261,7 @@ macro_rules! index_substate_versioned {
     ) => {
         paste::paste! {
             {
-                let $value_unpacking = $substate.value().as_latest_ref()
+                let $value_unpacking = $substate.value().as_latest_version()
                     .ok_or(MappingError::ObsoleteSubstateVersion)?;
                 models::Substate::[<$substate_type Substate>] {
                     is_locked: false,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/resource.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/resource.rs
@@ -189,8 +189,8 @@ pub fn to_api_non_fungible_resource_manager_data_substate(
         models::LocalNonFungibleKey {
             non_fungible_local_id: Box::new(to_api_non_fungible_local_id(non_fungible_local_id)),
         },
-        NonFungibleResourceManagerDataEntryPayload { content: value } => {
-            data_struct: Box::new(to_api_data_struct_from_scrypto_value(context, value)?),
+        payload => {
+            data_struct: Box::new(to_api_data_struct_from_scrypto_value(context, payload.as_ref())?),
         }
     ))
 }

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_deposit_behaviour.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_deposit_behaviour.rs
@@ -57,7 +57,12 @@ pub(crate) async fn handle_lts_state_account_deposit_behaviour(
         AccountPartitionOffset::Field.as_main_partition(),
         &AccountField::DepositRule.into(),
     )
-    .map(|substate| substate.into_payload().into_latest().default_deposit_rule);
+    .map(|substate| {
+        substate
+            .into_payload()
+            .fully_update_and_into_latest_version()
+            .default_deposit_rule
+    });
 
     // If it does not exist, then either it is an empty virtual account, or a bad account address:
     let Some(default_deposit_rule) = default_deposit_rule else {
@@ -102,7 +107,7 @@ pub(crate) async fn handle_lts_state_account_deposit_behaviour(
                     AccountCollection::ResourcePreferenceKeyValue.collection_index(),
                     &resource_address_substate_key,
                 )
-                .map(|payload| payload.into_latest());
+                .map(|payload| payload.fully_update_and_into_latest_version());
             let vault_exists =
                 read_optional_collection_substate_value::<AccountResourceVaultEntryPayload>(
                     database.deref(),

--- a/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/state_account_resource_balance.rs
@@ -89,14 +89,14 @@ pub(crate) async fn handle_lts_state_account_fungible_resource_balance(
                 let vault = substate
                     .into_value()
                     .ok_or(MappingError::KeyValueStoreEntryUnexpectedlyAbsent)?
-                    .into_latest();
+                    .fully_update_and_into_latest_version();
                 read_mandatory_main_field_substate::<FungibleVaultBalanceFieldPayload>(
                     database.deref(),
                     vault.0.as_node_id(),
                     &FungibleVaultField::Balance.into(),
                 )?
                 .into_payload()
-                .into_latest()
+                .fully_update_and_into_latest_version()
                 .amount()
             }
             _ => Decimal::ZERO,

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_construction.rs
@@ -20,7 +20,7 @@ pub(crate) async fn handle_lts_transaction_construction(
             &ConsensusManagerField::State.into(),
         )?
         .into_payload()
-        .into_latest();
+        .fully_update_and_into_latest_version();
 
     let timestamp_substate =
         read_mandatory_main_field_substate::<ConsensusManagerProposerMilliTimestampFieldPayload>(
@@ -29,7 +29,7 @@ pub(crate) async fn handle_lts_transaction_construction(
             &ConsensusManagerField::ProposerMilliTimestamp.into(),
         )?
         .into_payload()
-        .into_latest();
+        .fully_update_and_into_latest_version();
 
     Ok(Json(models::LtsTransactionConstructionResponse {
         current_epoch: to_api_epoch(&mapping_context, consensus_manager_substate.epoch)?,

--- a/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_consensus_manager.rs
@@ -91,7 +91,9 @@ fn collect_current_validators_by_signalled_protocol_version(
     substate: ConsensusManagerCurrentValidatorSetFieldSubstate,
 ) -> Result<ValidatorsBySignalledProtocolVersion, ResponseError<()>> {
     let mut validators = ValidatorsBySignalledProtocolVersion::default();
-    let payload = substate.into_payload().into_latest();
+    let payload = substate
+        .into_payload()
+        .fully_update_and_into_latest_version();
     for (index, entry) in payload
         .validator_set
         .validators_by_stake_desc
@@ -107,7 +109,7 @@ fn collect_current_validators_by_signalled_protocol_version(
             &ValidatorField::ProtocolUpdateReadinessSignal.into(),
         )?
         .into_payload()
-        .into_latest()
+        .fully_update_and_into_latest_version()
         .protocol_version_name;
         validators.insert(
             ValidatorIndex::try_from(index).expect("validator set size guarantees this"),

--- a/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/state_non_fungible.rs
@@ -34,7 +34,7 @@ pub(crate) async fn handle_state_non_fungible(
         )
         .ok_or_else(|| not_found_error("Resource not found".to_string()))?
         .into_payload()
-        .into_latest();
+        .fully_update_and_into_latest_version();
 
     let non_fungible_id =
         extract_non_fungible_id_from_simple_representation(&request.non_fungible_id)

--- a/core-rust/state-manager/src/accumulator_tree/slice_merger.rs
+++ b/core-rust/state-manager/src/accumulator_tree/slice_merger.rs
@@ -63,6 +63,7 @@
  */
 
 use super::storage::TreeSlice;
+use crate::engine_prelude::*;
 
 /// A merger (compactor) of consecutive `TreeSlice`s.
 pub struct AccuTreeSliceMerger<N> {

--- a/core-rust/state-manager/src/accumulator_tree/storage.rs
+++ b/core-rust/state-manager/src/accumulator_tree/storage.rs
@@ -91,6 +91,7 @@ impl<T: ReadableAccuTreeStore<K, N> + WriteableAccuTreeStore<K, N>, K, N> AccuTr
 /// This is an "incremental" persistence part of a tree representing a batch of appended leaf nodes
 /// and the resulting merkle updates, propagating up to a single root.
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[sbor(categorize_types = "N")]
 pub struct TreeSlice<N> {
     /// The tree-levels of this slice, arranged from leaves to root.
     pub levels: Vec<TreeSliceLevel<N>>,
@@ -122,6 +123,7 @@ impl<N> TreeSlice<N> {
 /// Effectively this means that it is a horizontal slice of a corresponding level of an entire
 /// accumulator tree.
 #[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[sbor(categorize_types = "N")]
 pub struct TreeSliceLevel<N> {
     /// The cached left sibling of the first node of that level slice, i.e. present if and only if
     /// the `nodes` actually start with a right child.

--- a/core-rust/state-manager/src/jni/state_reader.rs
+++ b/core-rust/state-manager/src/jni/state_reader.rs
@@ -94,7 +94,11 @@ extern "system" fn Java_com_radixdlt_state_RustStateReader_getValidatorProtocolU
                     MAIN_BASE_PARTITION,
                     &ValidatorField::ProtocolUpdateReadinessSignal.into()
                 );
-            Ok(result.and_then(|f| f.into_payload().content.into_latest().protocol_version_name))
+            Ok(result.and_then(|f| {
+                f.into_payload()
+                    .fully_update_and_into_latest_version()
+                    .protocol_version_name
+            }))
         },
     )
 }

--- a/core-rust/state-manager/src/jni/test_state_reader.rs
+++ b/core-rust/state-manager/src/jni/test_state_reader.rs
@@ -238,7 +238,7 @@ extern "system" fn Java_com_radixdlt_testutil_TestStateReader_validatorInfo(
                 )
                 .unwrap()
                 .into_payload()
-                .into_latest();
+                .fully_update_and_into_latest_version();
 
             JavaValidatorInfo {
                 stake_unit_resource: validator_state.stake_unit_resource,

--- a/core-rust/state-manager/src/protocol/test.rs
+++ b/core-rust/state-manager/src/protocol/test.rs
@@ -162,7 +162,7 @@ fn flash_protocol_update_test() {
     assert_eq!(
         config_substate
             .into_payload()
-            .into_latest()
+            .fully_update_and_into_latest_version()
             .config
             .validator_creation_usd_cost,
         dec!("100")

--- a/core-rust/state-manager/src/query/state_manager_substate_queries.rs
+++ b/core-rust/state-manager/src/query/state_manager_substate_queries.rs
@@ -14,7 +14,7 @@ impl<T: SubstateDatabase> StateManagerSubstateQueries for T {
             )
             .unwrap()
             .into_payload()
-            .into_latest();
+            .fully_update_and_into_latest_version();
         (consensus_manager_state.epoch, consensus_manager_state.round)
     }
 }

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -10,7 +10,7 @@ use crate::{
 
 define_single_versioned! {
     #[derive(Debug, Clone, Sbor)]
-    pub enum VersionedCommittedTransactionIdentifiers => CommittedTransactionIdentifiers = CommittedTransactionIdentifiersV1
+    pub VersionedCommittedTransactionIdentifiers(CommittedTransactionIdentifiersVersions) => CommittedTransactionIdentifiers = CommittedTransactionIdentifiersV1
 }
 
 #[derive(Debug, Clone, Sbor)]
@@ -202,7 +202,7 @@ pub struct LocalTransactionReceipt {
 
 define_single_versioned! {
     #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-    pub enum VersionedLedgerTransactionReceipt => LedgerTransactionReceipt = LedgerTransactionReceiptV1
+    pub VersionedLedgerTransactionReceipt(LedgerTransactionReceiptVersions) => LedgerTransactionReceipt = LedgerTransactionReceiptV1
 }
 
 /// A part of the [`LocalTransactionReceipt`] which is completely stored on ledger. It contains only
@@ -224,7 +224,7 @@ pub struct LedgerTransactionReceiptV1 {
 
 define_single_versioned! {
     #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-    pub enum VersionedLocalTransactionExecution => LocalTransactionExecution = LocalTransactionExecutionV1
+    pub VersionedLocalTransactionExecution(LocalTransactionExecutionVersions) => LocalTransactionExecution = LocalTransactionExecutionV1
 }
 
 /// A computable/non-critical/non-deterministic part of the `LocalTransactionReceipt` (e.g. logs,
@@ -309,6 +309,7 @@ impl LocalTransactionReceipt {
 /// This simply offers a less wasteful representation of a `Vec<(PartitionReference, T)>`, by
 /// avoiding the repeated [`NodeId`]s (within [`PartitionReference`]s).
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[sbor(categorize_types = "T")]
 pub struct ByPartition<T> {
     by_node_id: IndexMap<NodeId, IndexMap<PartitionNumber, T>>,
 }
@@ -367,6 +368,7 @@ impl<T> Default for ByPartition<T> {
 /// This simply offers a less wasteful representation of a `Vec<(SubstateReference, T)>`, by
 /// avoiding the repeated [`NodeId`]s and [`PartitionNumber`]s (within [`SubstateReference`]s).
 #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
+#[sbor(categorize_types = "T")]
 pub struct BySubstate<T> {
     by_node_id: IndexMap<NodeId, IndexMap<PartitionNumber, IndexMap<SubstateKey, T>>>,
 }

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -489,7 +489,7 @@ impl GlobalBalanceSummary {
                     scrypto_decode::<FungibleVaultBalanceFieldSubstate>(resultant_balance_substate)
                         .expect("cannot decode vault balance substate")
                         .into_payload()
-                        .into_latest()
+                        .fully_update_and_into_latest_version()
                         .amount();
                 let balance_existed = resultant_fungible_account_balances
                     .entry(root_address)

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -919,7 +919,7 @@ impl<R: WriteableRocks> StateManagerDatabase<R> {
             .map(|bytes| {
                 scrypto_decode::<VersionedStateTreeAssociatedValuesStatus>(&bytes)
                     .unwrap()
-                    .into_latest()
+                    .fully_update_and_into_latest_version()
             });
 
         if self.config.enable_historical_substate_values {
@@ -1023,7 +1023,7 @@ impl<R: ReadableRocks> ConfigurableDatabase for StateManagerDatabase<R> {
             .map(|bytes| {
                 scrypto_decode::<VersionedStateTreeAssociatedValuesStatus>(&bytes)
                     .unwrap()
-                    .into_latest()
+                    .fully_update_and_into_latest_version()
             })
             .expect("state history feature metadata not found")
             .historical_substate_values_available_from
@@ -1822,7 +1822,7 @@ impl<R: WriteableRocks> StateTreeGcStore for StateManagerDatabase<R> {
             .map(|bytes| {
                 scrypto_decode::<VersionedStateTreeAssociatedValuesStatus>(&bytes)
                     .unwrap()
-                    .into_latest()
+                    .fully_update_and_into_latest_version()
             });
         let Some(mut status) = status else {
             // The state history feature is simply not enabled.

--- a/core-rust/state-manager/src/store/traits.rs
+++ b/core-rust/state-manager/src/store/traits.rs
@@ -178,7 +178,7 @@ pub mod vertex {
 
     define_single_versioned! {
         #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-        pub enum VersionedVertexStoreBlob => VertexStoreBlob = VertexStoreBlobV1
+        pub VersionedVertexStoreBlob(VertexStoreBlobVersions) => VertexStoreBlob = VertexStoreBlobV1
     }
 
     #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -226,7 +226,7 @@ pub mod substate {
 
     define_single_versioned! {
         #[derive(Debug, Clone, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-        pub enum VersionedSubstateNodeAncestryRecord => SubstateNodeAncestryRecord = SubstateNodeAncestryRecordV1
+        pub VersionedSubstateNodeAncestryRecord(SubstateNodeAncestryRecordVersions) => SubstateNodeAncestryRecord = SubstateNodeAncestryRecordV1
     }
 
     /// Ancestry information of a RE Node.
@@ -501,7 +501,7 @@ pub mod commit {
 
     define_single_versioned! {
         #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-        pub enum VersionedStaleTreeParts => StaleTreeParts = StaleTreePartsV1
+        pub VersionedStaleTreeParts(StaleTreePartsVersions) => StaleTreeParts = StaleTreePartsV1
     }
 
     #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -545,7 +545,7 @@ pub mod commit {
 
     define_single_versioned! {
         #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-        pub enum VersionedTransactionAccuTreeSlice => TransactionAccuTreeSlice = TransactionAccuTreeSliceV1
+        pub VersionedTransactionAccuTreeSlice(TransactionAccuTreeSliceVersions) => TransactionAccuTreeSlice = TransactionAccuTreeSliceV1
     }
 
     #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -553,7 +553,7 @@ pub mod commit {
 
     define_single_versioned! {
         #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-        pub enum VersionedReceiptAccuTreeSlice => ReceiptAccuTreeSlice = ReceiptAccuTreeSliceV1
+        pub VersionedReceiptAccuTreeSlice(ReceiptAccuTreeSliceVersions) => ReceiptAccuTreeSlice = ReceiptAccuTreeSliceV1
     }
 
     #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
@@ -571,7 +571,7 @@ pub mod scenario {
 
     define_single_versioned! {
         #[derive(Debug, Clone, Categorize, Encode, Decode)]
-        pub enum VersionedExecutedGenesisScenario => ExecutedGenesisScenario = ExecutedGenesisScenarioV1
+        pub VersionedExecutedGenesisScenario(ExecutedGenesisScenarioVersions) => ExecutedGenesisScenario = ExecutedGenesisScenarioV1
     }
 
     #[derive(Debug, Clone, Categorize, Encode, Decode)]
@@ -632,7 +632,7 @@ pub mod extensions {
 
     define_single_versioned! {
         #[derive(Debug, Clone, Sbor)]
-        pub enum VersionedStateTreeAssociatedValuesStatus => StateTreeAssociatedValuesStatus = StateTreeAssociatedValuesStatusV1
+        pub VersionedStateTreeAssociatedValuesStatus(StateTreeAssociatedValuesStatusVersions) => StateTreeAssociatedValuesStatus = StateTreeAssociatedValuesStatusV1
     }
 
     #[derive(Debug, Clone, Sbor)]
@@ -749,7 +749,7 @@ pub mod gc {
 
     define_single_versioned! {
         #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-        pub enum VersionedLedgerProofsGcProgress => LedgerProofsGcProgress = LedgerProofsGcProgressV1
+        pub VersionedLedgerProofsGcProgress(LedgerProofsGcProgressVersions) => LedgerProofsGcProgress = LedgerProofsGcProgressV1
     }
 
     /// A state of the GC's progress.

--- a/core-rust/state-manager/src/types.rs
+++ b/core-rust/state-manager/src/types.rs
@@ -407,7 +407,7 @@ pub struct TimestampedValidatorSignature {
 
 define_versioned!(
     #[derive(Debug, Clone, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
-    pub enum VersionedLedgerProof {
+    pub VersionedLedgerProof(LedgerProofVersions) {
         previous_versions: [
             1 => LedgerProofV1: { updates_to: 2 },
         ],


### PR DESCRIPTION
## Summary

This just keeps the scrypto dep fresh for https://radixdlt.atlassian.net/browse/NODE-619.

## Details

Tedious but not very risky update - most changes were needed due to SBOR infra/macro refactors.

## Testing

No behavior changes, just regression tests need to pass.
