### PR TITLE
Actually execute all post-Bottlenose scenarios in tests

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "radix-blueprint-schema-init"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "bitflags 1.3.2",
  "radix-common",
@@ -1665,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "radix-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "bech32",
  "blake2",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "radix-common-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "bitflags 1.3.2",
  "colored",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "fixedstr",
 ]
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "radix-native-sdk"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "radix-common",
  "radix-engine-interface",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "radix-rust"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "radix-sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-impls"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "hex",
  "itertools",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "hex",
  "itertools",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-queries"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "hex",
  "itertools",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "radix-transaction-scenarios"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "hex",
  "itertools",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "radix-transactions"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "annotate-snippets",
  "bech32",
@@ -2097,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "sbor"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "const-sha1",
  "hex",
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -2121,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-b622cc80#b622cc80be86ee4317002adceebb0f90013eb93f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
 dependencies = [
  "const-sha1",
  "itertools",

--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "radix-blueprint-schema-init"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "bitflags 1.3.2",
  "radix-common",
@@ -1665,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "radix-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "bech32",
  "blake2",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "radix-common-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "bitflags 1.3.2",
  "colored",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "fixedstr",
 ]
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "radix-native-sdk"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "radix-common",
  "radix-engine-interface",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "radix-rust"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "radix-sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-impls"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "hex",
  "itertools",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "hex",
  "itertools",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-queries"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "hex",
  "itertools",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "radix-transaction-scenarios"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "hex",
  "itertools",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "radix-transactions"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "annotate-snippets",
  "bech32",
@@ -2097,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "sbor"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "const-sha1",
  "hex",
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -2121,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-84ff663c#84ff663c6c6b4706011351e52d8dd3fede1361e1"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-e782788b#e782788b9ebfeb27e71085b031d8c82b13f24d43"
 dependencies = [
  "const-sha1",
  "itertools",

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -23,17 +23,17 @@ resolver = "2"
 #   $ git push origin "release_name-BLAH"
 # * Then use tag="release_name-BLAH" in the below dependencies.
 # 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c", features = ["serde"] }
-radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
-radix-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
-radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c", features = ["serde"] }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
-radix-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
-radix-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
-radix-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
-radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c", features = ["serde"] }
-radix-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c", features = ["serde"] }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b", features = ["serde"] }
+radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b" }
+radix-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b" }
+radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b", features = ["serde"] }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b" }
+radix-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b" }
+radix-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b" }
+radix-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b" }
+radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b", features = ["serde"] }
+radix-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-e782788b", features = ["serde"] }
 
 itertools = { version = "=0.10.5" }
 jni = { version = "=0.19.0" }

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -23,17 +23,17 @@ resolver = "2"
 #   $ git push origin "release_name-BLAH"
 # * Then use tag="release_name-BLAH" in the below dependencies.
 # 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80", features = ["serde"] }
-radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80" }
-radix-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80" }
-radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80", features = ["serde"] }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80" }
-radix-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80" }
-radix-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80" }
-radix-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80" }
-radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80", features = ["serde"] }
-radix-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-b622cc80", features = ["serde"] }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c", features = ["serde"] }
+radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
+radix-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
+radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c", features = ["serde"] }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
+radix-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
+radix-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
+radix-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c" }
+radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c", features = ["serde"] }
+radix-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-84ff663c", features = ["serde"] }
 
 itertools = { version = "=0.10.5" }
 jni = { version = "=0.19.0" }

--- a/core-rust/state-manager/src/protocol/protocol_state.rs
+++ b/core-rust/state-manager/src/protocol/protocol_state.rs
@@ -44,36 +44,60 @@ impl ProtocolUpdateExecutor {
         }
     }
 
+    /// Executes any remaining parts of the currently-effective protocol update.
+    /// This method is meant to be called during the boot-up, to support resuming after a restart.
+    pub fn execute_remaining_protocol_update_actions(&self) {
+        match ProtocolUpdateProgress::resolve(self.database.lock().deref()) {
+            ProtocolUpdateProgress::UpdateInitiatedButNothingCommitted {
+                protocol_version_name,
+            } => {
+                info!(
+                    "Starting a {} protocol update execution",
+                    protocol_version_name
+                );
+                self.execute_protocol_update(&protocol_version_name, 0);
+            }
+            ProtocolUpdateProgress::UpdateInProgress {
+                protocol_version_name,
+                last_batch_idx,
+            } => {
+                let next_batch_idx = last_batch_idx.checked_add(1).unwrap();
+                info!(
+                    "Resuming a {} protocol update execution from batch idx {}",
+                    protocol_version_name, next_batch_idx
+                );
+                self.execute_protocol_update(&protocol_version_name, next_batch_idx);
+            }
+            ProtocolUpdateProgress::NotUpdating => {} // No protocol update in progress
+        }
+    }
+
+    /// Executes all transactions for the given new protocol update.
+    /// This method is meant to be called by the consensus process.
+    pub fn execute_new_protocol_update(&self, new_protocol_version: &ProtocolVersionName) {
+        info!("Executing {} protocol update", new_protocol_version);
+        self.execute_protocol_update(new_protocol_version, 0)
+    }
+
     /// Executes the (remaining part of the) given protocol update's transactions.
-    pub fn execute_protocol_update(&self, new_protocol_version: &ProtocolVersionName) {
-        let overrides = self
-            .protocol_update_content_overrides
-            .get(new_protocol_version);
-        let action_provider = resolve_update_definition_for_version(new_protocol_version)
-            .unwrap_or_else(|| panic!("{}", new_protocol_version.as_str().to_string()))
+    fn execute_protocol_update(&self, protocol_version: &ProtocolVersionName, from_batch_idx: u32) {
+        let overrides = self.protocol_update_content_overrides.get(protocol_version);
+        let action_provider = resolve_update_definition_for_version(protocol_version)
+            .unwrap_or_else(|| panic!("{}", protocol_version.as_str().to_string()))
             .create_action_provider_raw(&self.network, self.database.clone(), overrides);
 
         let _scenarios_to_execute = self
             .scenarios_execution_config
-            .to_run_after_protocol_update(new_protocol_version);
+            .to_run_after_protocol_update(protocol_version);
         // TODO(post-protocol update scenarios): wrap `action_provider` with a decorator which appends these Scenarios at the end
 
-        while let Some(batch_idx) = self.resolve_next_batch_idx_within(new_protocol_version) {
-            let Some(action) = action_provider.provide_action(batch_idx) else {
-                break;
-            };
+        for batch_idx in from_batch_idx..action_provider.action_count() {
             self.system_executor.execute_protocol_update_action(
-                new_protocol_version,
+                protocol_version,
                 batch_idx,
-                action,
+                action_provider.provide_action(batch_idx),
             );
         }
-    }
-
-    fn resolve_next_batch_idx_within(&self, protocol_version: &ProtocolVersionName) -> Option<u32> {
-        ProtocolUpdateProgress::resolve(self.database.lock().deref())
-            .scoped_on(protocol_version)
-            .next_batch_idx()
     }
 }
 

--- a/core-rust/state-manager/src/protocol/protocol_state.rs
+++ b/core-rust/state-manager/src/protocol/protocol_state.rs
@@ -89,20 +89,20 @@ impl ProtocolUpdateExecutor {
         let overrides = self.protocol_update_content_overrides.get(protocol_version);
         let protocol_update_transactions = resolve_update_definition_for_version(protocol_version)
             .unwrap_or_else(|| panic!("{}", protocol_version.as_str().to_string()))
-            .create_action_provider_raw(&self.network, self.database.clone(), overrides);
+            .create_batch_generator_raw(&self.network, self.database.clone(), overrides);
 
-        let transactions_and_scenarios = WithScenariosActionProvider {
-            base_action_provider: protocol_update_transactions.deref(),
+        let transactions_and_scenarios = WithScenariosNodeBatchGenerator {
+            base_batch_generator: protocol_update_transactions.deref(),
             scenario_names: self
                 .scenarios_execution_config
                 .to_run_after_protocol_update(protocol_version),
         };
 
-        for batch_idx in from_batch_idx..transactions_and_scenarios.action_count() {
+        for batch_idx in from_batch_idx..transactions_and_scenarios.batch_count() {
             self.system_executor.execute_protocol_update_action(
                 protocol_version,
                 batch_idx,
-                transactions_and_scenarios.provide_action(batch_idx),
+                transactions_and_scenarios.generate_batch(batch_idx),
             );
         }
     }

--- a/core-rust/state-manager/src/protocol/protocol_state.rs
+++ b/core-rust/state-manager/src/protocol/protocol_state.rs
@@ -82,20 +82,22 @@ impl ProtocolUpdateExecutor {
     /// Executes the (remaining part of the) given protocol update's transactions.
     fn execute_protocol_update(&self, protocol_version: &ProtocolVersionName, from_batch_idx: u32) {
         let overrides = self.protocol_update_content_overrides.get(protocol_version);
-        let action_provider = resolve_update_definition_for_version(protocol_version)
+        let protocol_update_transactions = resolve_update_definition_for_version(protocol_version)
             .unwrap_or_else(|| panic!("{}", protocol_version.as_str().to_string()))
             .create_action_provider_raw(&self.network, self.database.clone(), overrides);
 
-        let _scenarios_to_execute = self
-            .scenarios_execution_config
-            .to_run_after_protocol_update(protocol_version);
-        // TODO(post-protocol update scenarios): wrap `action_provider` with a decorator which appends these Scenarios at the end
+        let transactions_and_scenarios = WithScenariosActionProvider {
+            base_action_provider: protocol_update_transactions.deref(),
+            scenario_names: self
+                .scenarios_execution_config
+                .to_run_after_protocol_update(protocol_version),
+        };
 
-        for batch_idx in from_batch_idx..action_provider.action_count() {
+        for batch_idx in from_batch_idx..transactions_and_scenarios.action_count() {
             self.system_executor.execute_protocol_update_action(
                 protocol_version,
                 batch_idx,
-                action_provider.provide_action(batch_idx),
+                transactions_and_scenarios.provide_action(batch_idx),
             );
         }
     }

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/anemone_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/anemone_definition.rs
@@ -9,12 +9,12 @@ pub struct AnemoneProtocolUpdateDefinition;
 impl ProtocolUpdateDefinition for AnemoneProtocolUpdateDefinition {
     type Overrides = ();
 
-    fn create_action_provider(
+    fn create_batch_generator(
         &self,
         network: &NetworkDefinition,
         database: Arc<DbLock<ActualStateManagerDatabase>>,
         _overrides: Option<Self::Overrides>,
-    ) -> Box<dyn ProtocolUpdateActionProvider> {
+    ) -> Box<dyn ProtocolUpdateNodeBatchGenerator> {
         Box::new(engine_default_for_network::<AnemoneSettings>(
             network, database,
         ))

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/bottlenose_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/bottlenose_definition.rs
@@ -9,12 +9,12 @@ pub struct BottlenoseProtocolUpdateDefinition;
 impl ProtocolUpdateDefinition for BottlenoseProtocolUpdateDefinition {
     type Overrides = ();
 
-    fn create_action_provider(
+    fn create_batch_generator(
         &self,
         network: &NetworkDefinition,
         database: Arc<DbLock<ActualStateManagerDatabase>>,
         _overrides: Option<Self::Overrides>,
-    ) -> Box<dyn ProtocolUpdateActionProvider> {
+    ) -> Box<dyn ProtocolUpdateNodeBatchGenerator> {
         Box::new(engine_default_for_network::<BottlenoseSettings>(
             network, database,
         ))

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
@@ -20,30 +20,30 @@ impl CustomProtocolUpdateDefinition {
 }
 
 impl ProtocolUpdateDefinition for CustomProtocolUpdateDefinition {
-    type Overrides = Vec<ProtocolUpdateAction>;
+    type Overrides = Vec<ProtocolUpdateNodeBatch>;
 
-    fn create_action_provider(
+    fn create_batch_generator(
         &self,
         _network: &NetworkDefinition,
         _database: Arc<DbLock<ActualStateManagerDatabase>>,
         overrides: Option<Self::Overrides>,
-    ) -> Box<dyn ProtocolUpdateActionProvider> {
-        Box::new(ArbitraryActionProvider {
+    ) -> Box<dyn ProtocolUpdateNodeBatchGenerator> {
+        Box::new(ArbitraryNodeBatchGenerator {
             batches: overrides.unwrap_or_default(),
         })
     }
 }
 
-pub struct ArbitraryActionProvider {
-    pub batches: Vec<ProtocolUpdateAction>,
+pub struct ArbitraryNodeBatchGenerator {
+    pub batches: Vec<ProtocolUpdateNodeBatch>,
 }
 
-impl ProtocolUpdateActionProvider for ArbitraryActionProvider {
-    fn provide_action(&self, index: u32) -> ProtocolUpdateAction {
-        self.batches.get(index as usize).unwrap().clone()
+impl ProtocolUpdateNodeBatchGenerator for ArbitraryNodeBatchGenerator {
+    fn generate_batch(&self, batch_idx: u32) -> ProtocolUpdateNodeBatch {
+        self.batches.get(batch_idx as usize).unwrap().clone()
     }
 
-    fn action_count(&self) -> u32 {
+    fn batch_count(&self) -> u32 {
         u32::try_from(self.batches.len()).unwrap()
     }
 }

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
@@ -39,7 +39,11 @@ pub struct ArbitraryActionProvider {
 }
 
 impl ProtocolUpdateActionProvider for ArbitraryActionProvider {
-    fn provide_action(&self, index: u32) -> Option<ProtocolUpdateAction> {
-        self.batches.get(index as usize).cloned()
+    fn provide_action(&self, index: u32) -> ProtocolUpdateAction {
+        self.batches.get(index as usize).unwrap().clone()
+    }
+
+    fn action_count(&self) -> u32 {
+        u32::try_from(self.batches.len()).unwrap()
     }
 }

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
@@ -9,24 +9,24 @@ pub struct NoOpProtocolDefinition;
 impl ProtocolUpdateDefinition for NoOpProtocolDefinition {
     type Overrides = ();
 
-    fn create_action_provider(
+    fn create_batch_generator(
         &self,
         _network: &NetworkDefinition,
         _database: Arc<DbLock<ActualStateManagerDatabase>>,
         _overrides: Option<Self::Overrides>,
-    ) -> Box<dyn ProtocolUpdateActionProvider> {
-        Box::new(EmptyActionProvider)
+    ) -> Box<dyn ProtocolUpdateNodeBatchGenerator> {
+        Box::new(EmptyNodeBatchGenerator)
     }
 }
 
-pub struct EmptyActionProvider;
+struct EmptyNodeBatchGenerator;
 
-impl ProtocolUpdateActionProvider for EmptyActionProvider {
-    fn provide_action(&self, _index: u32) -> ProtocolUpdateAction {
-        panic!("no actions")
+impl ProtocolUpdateNodeBatchGenerator for EmptyNodeBatchGenerator {
+    fn generate_batch(&self, _batch_idx: u32) -> ProtocolUpdateNodeBatch {
+        panic!("no batches")
     }
 
-    fn action_count(&self) -> u32 {
+    fn batch_count(&self) -> u32 {
         0
     }
 }

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
@@ -22,7 +22,11 @@ impl ProtocolUpdateDefinition for NoOpProtocolDefinition {
 pub struct EmptyActionProvider;
 
 impl ProtocolUpdateActionProvider for EmptyActionProvider {
-    fn provide_action(&self, _index: u32) -> Option<ProtocolUpdateAction> {
-        None
+    fn provide_action(&self, _index: u32) -> ProtocolUpdateAction {
+        panic!("no actions")
+    }
+
+    fn action_count(&self) -> u32 {
+        0
     }
 }

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/mod.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/mod.rs
@@ -18,33 +18,31 @@ use node_common::locks::DbLock;
 use std::ops::Deref;
 use std::sync::Arc;
 
-/// A [`ProtocolUpdateActionProvider`] implementation for the actual Engine's protocol updates.
-pub struct EngineProtocolUpdateActionProvider<G> {
+/// A [`ProtocolUpdateNodeBatchGenerator`] implementation for the actual Engine's protocol updates.
+pub struct EngineBatchGenerator<G> {
     database: Arc<DbLock<ActualStateManagerDatabase>>,
     engine_batch_generator: G,
 }
 
-/// Creates an [`EngineProtocolUpdateActionProvider`] for the given [`UpdateSettings`], with all
+/// Creates an [`EngineBatchGenerator`] for the given [`UpdateSettings`], with all
 /// the features that Engine wants enabled by default.
 pub fn engine_default_for_network<U: UpdateSettings>(
     network: &NetworkDefinition,
     database: Arc<DbLock<ActualStateManagerDatabase>>,
-) -> EngineProtocolUpdateActionProvider<U::BatchGenerator> {
-    EngineProtocolUpdateActionProvider {
+) -> EngineBatchGenerator<U::BatchGenerator> {
+    EngineBatchGenerator {
         database,
         engine_batch_generator: U::all_enabled_as_default_for_network(network)
             .create_batch_generator(),
     }
 }
 
-impl<G: ProtocolUpdateBatchGenerator> ProtocolUpdateActionProvider
-    for EngineProtocolUpdateActionProvider<G>
-{
-    fn provide_action(&self, index: u32) -> ProtocolUpdateAction {
+impl<G: ProtocolUpdateBatchGenerator> ProtocolUpdateNodeBatchGenerator for EngineBatchGenerator<G> {
+    fn generate_batch(&self, batch_idx: u32) -> ProtocolUpdateNodeBatch {
         let ProtocolUpdateBatch { transactions } = self
             .engine_batch_generator
-            .generate_batch(self.database.lock().deref(), index);
-        ProtocolUpdateAction::FlashTransactions(
+            .generate_batch(self.database.lock().deref(), batch_idx);
+        ProtocolUpdateNodeBatch::FlashTransactions(
             transactions
                 .into_iter()
                 .map(FlashTransactionV1::from)
@@ -52,7 +50,7 @@ impl<G: ProtocolUpdateBatchGenerator> ProtocolUpdateActionProvider
         )
     }
 
-    fn action_count(&self) -> u32 {
+    fn batch_count(&self) -> u32 {
         self.engine_batch_generator.batch_count()
     }
 }

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/mod.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/mod.rs
@@ -40,18 +40,20 @@ pub fn engine_default_for_network<U: UpdateSettings>(
 impl<G: ProtocolUpdateBatchGenerator> ProtocolUpdateActionProvider
     for EngineProtocolUpdateActionProvider<G>
 {
-    fn provide_action(&self, index: u32) -> Option<ProtocolUpdateAction> {
-        self.engine_batch_generator
-            .generate_batch(self.database.lock().deref(), index)
-            .map(|batch| {
-                ProtocolUpdateAction::FlashTransactions(
-                    batch
-                        .transactions
-                        .into_iter()
-                        .map(FlashTransactionV1::from)
-                        .collect(),
-                )
-            })
+    fn provide_action(&self, index: u32) -> ProtocolUpdateAction {
+        let ProtocolUpdateBatch { transactions } = self
+            .engine_batch_generator
+            .generate_batch(self.database.lock().deref(), index);
+        ProtocolUpdateAction::FlashTransactions(
+            transactions
+                .into_iter()
+                .map(FlashTransactionV1::from)
+                .collect(),
+        )
+    }
+
+    fn action_count(&self) -> u32 {
+        self.engine_batch_generator.batch_count()
     }
 }
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/test_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/test_definition.rs
@@ -31,14 +31,14 @@ impl TestProtocolUpdateDefinition {
 impl ProtocolUpdateDefinition for TestProtocolUpdateDefinition {
     type Overrides = ();
 
-    fn create_action_provider(
+    fn create_batch_generator(
         &self,
         _network: &NetworkDefinition,
         _database: Arc<DbLock<ActualStateManagerDatabase>>,
         _overrides: Option<Self::Overrides>,
-    ) -> Box<dyn ProtocolUpdateActionProvider> {
-        Box::new(ArbitraryActionProvider {
-            batches: vec![ProtocolUpdateAction::FlashTransactions(vec![
+    ) -> Box<dyn ProtocolUpdateNodeBatchGenerator> {
+        Box::new(ArbitraryNodeBatchGenerator {
+            batches: vec![ProtocolUpdateNodeBatch::FlashTransactions(vec![
                 FlashTransactionV1 {
                     name: format!("{}-txn", self.protocol_name),
                     state_updates: StateUpdates::default(),

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_definition.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 ///
 /// Note:
 /// Currently, protocol updates are only interested in modifying the current ledger state.
-/// Consecutive "actions" to be executed and individually committed are defined by
-/// [`Self::create_action_provider()`].
+/// Consecutive transaction batches to be executed and individually committed are defined by
+/// [`Self::create_batch_generator()`].
 /// Future protocol updates may additionally want to e.g. modify the configuration of some
 /// services (like transaction validation rules). Such customizable parts will have to be
 /// represented as other methods on this trait.
@@ -20,43 +20,44 @@ pub trait ProtocolUpdateDefinition {
     type Overrides: ScryptoDecode;
 
     /// Returns a provider of on-ledger actions to be executed as part of this protocol update.
-    fn create_action_provider(
+    fn create_batch_generator(
         &self,
         network: &NetworkDefinition,
         database: Arc<DbLock<ActualStateManagerDatabase>>,
         overrides: Option<Self::Overrides>,
-    ) -> Box<dyn ProtocolUpdateActionProvider>;
+    ) -> Box<dyn ProtocolUpdateNodeBatchGenerator>;
 }
 
 /// A convenience trait for easier validation/parsing of [`ProtocolUpdateDefinition::Overrides`],
 /// automatically implemented for all [`ProtocolUpdateDefinition`].
 pub trait ConfigurableProtocolUpdateDefinition {
-    /// Parses the given raw overrides and passes them to [`Self::create_action_provider`].
+    /// Parses the given raw overrides and passes them to
+    /// [`ProtocolUpdateDefinition::create_batch_generator`].
     /// Panics on any [`DecodeError`] from [`Self::validate_overrides()`].
-    fn create_action_provider_raw(
+    fn create_batch_generator_raw(
         &self,
         network: &NetworkDefinition,
         database: Arc<DbLock<ActualStateManagerDatabase>>,
         raw_overrides: Option<&[u8]>,
-    ) -> Box<dyn ProtocolUpdateActionProvider>;
+    ) -> Box<dyn ProtocolUpdateNodeBatchGenerator>;
 
     /// Checks that the given raw overrides can be parsed.
     fn validate_raw_overrides(&self, raw_overrides: &[u8]) -> Result<(), DecodeError>;
 }
 
 impl<T: ProtocolUpdateDefinition> ConfigurableProtocolUpdateDefinition for T {
-    fn create_action_provider_raw(
+    fn create_batch_generator_raw(
         &self,
         network: &NetworkDefinition,
         database: Arc<DbLock<ActualStateManagerDatabase>>,
         raw_overrides: Option<&[u8]>,
-    ) -> Box<dyn ProtocolUpdateActionProvider> {
+    ) -> Box<dyn ProtocolUpdateNodeBatchGenerator> {
         let overrides = raw_overrides
             .map(scrypto_decode::<<Self as ProtocolUpdateDefinition>::Overrides>)
             .transpose()
             .expect("Raw overrides should have been validated before being passed to this method");
 
-        self.create_action_provider(network, database, overrides)
+        self.create_batch_generator(network, database, overrides)
     }
 
     fn validate_raw_overrides(&self, raw_overrides: &[u8]) -> Result<(), DecodeError> {

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_progress.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_progress.rs
@@ -52,31 +52,4 @@ impl ProtocolUpdateProgress {
             },
         }
     }
-
-    /// Returns the new instance scoped at the given protocol version.
-    /// This means that any other version's Protocol Update will be considered "not updating".
-    pub fn scoped_on(self, specific_protocol_version: &ProtocolVersionName) -> Self {
-        match &self {
-            ProtocolUpdateProgress::UpdateInitiatedButNothingCommitted {
-                protocol_version_name,
-            }
-            | ProtocolUpdateProgress::UpdateInProgress {
-                protocol_version_name,
-                ..
-            } if protocol_version_name == specific_protocol_version => self,
-            _ => ProtocolUpdateProgress::NotUpdating,
-        }
-    }
-
-    /// Returns an index of the next batch to be executed for an active Protocol Update (or [`None`]
-    /// if not updating).
-    pub fn next_batch_idx(&self) -> Option<u32> {
-        match self {
-            ProtocolUpdateProgress::UpdateInitiatedButNothingCommitted { .. } => Some(0),
-            ProtocolUpdateProgress::UpdateInProgress { last_batch_idx, .. } => {
-                Some(last_batch_idx.checked_add(1).unwrap())
-            }
-            ProtocolUpdateProgress::NotUpdating => None,
-        }
-    }
 }

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
@@ -17,6 +17,7 @@ pub enum ProtocolUpdateAction {
 /// overload memory if initialized all at once.
 pub trait ProtocolUpdateActionProvider {
     /// Returns an action at the given index.
+    /// Panics if the index is out of bounds (as given by the [`Self::action_count()`].
     fn provide_action(&self, index: u32) -> ProtocolUpdateAction;
 
     /// Returns the number of contained actions.

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
@@ -22,3 +22,35 @@ pub trait ProtocolUpdateActionProvider {
     /// Returns the number of contained actions.
     fn action_count(&self) -> u32;
 }
+
+/// A [`ProtocolUpdateActionProvider`] decorator which additionally executes post-update Scenarios.
+pub struct WithScenariosActionProvider<'b, B: ProtocolUpdateActionProvider + ?Sized> {
+    pub base_action_provider: &'b B,
+    pub scenario_names: Vec<String>,
+}
+
+impl<'b, B: ProtocolUpdateActionProvider + ?Sized> ProtocolUpdateActionProvider
+    for WithScenariosActionProvider<'b, B>
+{
+    fn provide_action(&self, index: u32) -> ProtocolUpdateAction {
+        let base_action_count = self.base_action_provider.action_count();
+        if index < base_action_count {
+            self.base_action_provider.provide_action(index)
+        } else {
+            let scenario_index = index.checked_sub(base_action_count).unwrap();
+            let scenario_name = self
+                .scenario_names
+                .get(scenario_index as usize)
+                .unwrap()
+                .clone();
+            ProtocolUpdateAction::Scenario(scenario_name)
+        }
+    }
+
+    fn action_count(&self) -> u32 {
+        self.base_action_provider
+            .action_count()
+            .checked_add(u32::try_from(self.scenario_names.len()).unwrap())
+            .unwrap()
+    }
+}

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_updaters.rs
@@ -16,6 +16,9 @@ pub enum ProtocolUpdateAction {
 /// This is a lazy provider (rather than a [`Vec`]), since e.g. massive flash transactions could
 /// overload memory if initialized all at once.
 pub trait ProtocolUpdateActionProvider {
-    /// Returns an action at the given index, or [`None`] if the index is out of bounds.
-    fn provide_action(&self, index: u32) -> Option<ProtocolUpdateAction>;
+    /// Returns an action at the given index.
+    fn provide_action(&self, index: u32) -> ProtocolUpdateAction;
+
+    /// Returns the number of contained actions.
+    fn action_count(&self) -> u32;
 }

--- a/core-rust/state-manager/src/protocol/test.rs
+++ b/core-rust/state-manager/src/protocol/test.rs
@@ -102,7 +102,6 @@ fn flash_protocol_update_test() {
             .enable(|anemone_settings| &mut anemone_settings.validator_fee_fix)
             .create_batch_generator()
             .generate_batch(tmp_state_manager.database.access_direct().deref(), 0)
-            .unwrap()
             .transactions
             .remove(0);
         let ProtocolUpdateTransactionDetails::FlashV1Transaction(flash) = validator_fee_fix;

--- a/core-rust/state-manager/src/protocol/test.rs
+++ b/core-rust/state-manager/src/protocol/test.rs
@@ -113,7 +113,7 @@ fn flash_protocol_update_test() {
         .protocol_update_content_overrides = ProtocolUpdateContentOverrides::empty()
         .with_custom(
             custom_v2_protocol_version.clone(),
-            vec![ProtocolUpdateAction::FlashTransactions(vec![
+            vec![ProtocolUpdateNodeBatch::FlashTransactions(vec![
                 FlashTransactionV1 {
                     name: format!("{CUSTOM_V2_PROTOCOL_VERSION}-flash"),
                     state_updates: consensus_manager_state_updates,

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -355,7 +355,7 @@ impl StateManager {
         ));
 
         // If we are booting mid-protocol-update, ensure all required transactions are committed:
-        protocol_update_executor.execute_remaining_protocol_update_actions();
+        protocol_update_executor.resume_protocol_update_if_any();
 
         // Register the periodic background task for collecting the costly raw DB metrics...
         let raw_db_metrics_collector =
@@ -414,7 +414,7 @@ impl StateManager {
         protocol_version_name: &ProtocolVersionName,
     ) -> ProtocolUpdateResult {
         self.protocol_update_executor
-            .execute_new_protocol_update(protocol_version_name);
+            .execute_protocol_update(protocol_version_name);
         self.protocol_manager
             .set_current_protocol_version(protocol_version_name);
 

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -355,11 +355,7 @@ impl StateManager {
         ));
 
         // If we are booting mid-protocol-update, ensure all required transactions are committed:
-        protocol_update_executor.execute_protocol_update(
-            &protocol_manager
-                .current_protocol_state()
-                .current_protocol_version,
-        );
+        protocol_update_executor.execute_remaining_protocol_update_actions();
 
         // Register the periodic background task for collecting the costly raw DB metrics...
         let raw_db_metrics_collector =
@@ -418,7 +414,7 @@ impl StateManager {
         protocol_version_name: &ProtocolVersionName,
     ) -> ProtocolUpdateResult {
         self.protocol_update_executor
-            .execute_protocol_update(protocol_version_name);
+            .execute_new_protocol_update(protocol_version_name);
         self.protocol_manager
             .set_current_protocol_version(protocol_version_name);
 

--- a/core-rust/state-manager/src/system_executor.rs
+++ b/core-rust/state-manager/src/system_executor.rs
@@ -80,7 +80,7 @@ use crate::store::traits::scenario::{
 };
 use crate::system_commits::*;
 
-use crate::protocol::{ProtocolUpdateAction, ProtocolVersionName};
+use crate::protocol::{ProtocolUpdateNodeBatch, ProtocolVersionName};
 use crate::traits::scenario::ExecutedScenarioV1;
 use radix_transaction_scenarios::scenarios::ALL_SCENARIOS;
 use std::sync::Arc;
@@ -214,7 +214,7 @@ impl SystemExecutor {
         &self,
         protocol_version: &ProtocolVersionName,
         batch_idx: u32,
-        action: ProtocolUpdateAction,
+        batch: ProtocolUpdateNodeBatch,
     ) {
         let database = self.database.lock();
         let latest_header = database
@@ -243,13 +243,13 @@ impl SystemExecutor {
             },
         };
 
-        match action {
-            ProtocolUpdateAction::FlashTransactions(flash_transactions) => {
+        match batch {
+            ProtocolUpdateNodeBatch::FlashTransactions(flash_transactions) => {
                 let prepare_result = self.preparator.prepare_protocol_update(flash_transactions);
                 let commit_request = system_commit_request_factory.create(prepare_result);
                 self.committer.commit_system(commit_request);
             }
-            ProtocolUpdateAction::Scenario(scenario) => {
+            ProtocolUpdateNodeBatch::Scenario(scenario) => {
                 // Note: here we use the top-of-ledger's state version as a starting nonce for the
                 // Scenario's transactions. This behavior is different than the Engine's default
                 // Scenario executor's (which increments the last nonce used by the previous

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
@@ -70,6 +70,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.google.inject.Module;
 import com.radixdlt.environment.DatabaseConfig;
+import com.radixdlt.environment.ScenariosExecutionConfig;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.harness.deterministic.DeterministicTest;
@@ -225,7 +226,8 @@ public final class MultiNodeRebootTest {
                         new REV2TransactionGenerator(), 1),
                     false,
                     noFees,
-                    ProtocolConfig.testingDefault()),
+                    ProtocolConfig.testingDefault(),
+                    ScenariosExecutionConfig.NONE),
                 // This test can, in some cases, rely on ledger sync
                 // requests timing out in reasonable time,
                 // so setting the request timeout to 100 ms

--- a/core/src/test-core/java/com/radixdlt/harness/deterministic/TestProtocolConfig.java
+++ b/core/src/test-core/java/com/radixdlt/harness/deterministic/TestProtocolConfig.java
@@ -1,0 +1,158 @@
+/* Copyright 2021 Radix Publishing Ltd incorporated in Jersey (Channel Islands).
+ *
+ * Licensed under the Radix License, Version 1.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at:
+ *
+ * radixfoundation.org/licenses/LICENSE-v1
+ *
+ * The Licensor hereby grants permission for the Canonical version of the Work to be
+ * published, distributed and used under or by reference to the Licensor’s trademark
+ * Radix ® and use of any unregistered trade names, logos or get-up.
+ *
+ * The Licensor provides the Work (and each Contributor provides its Contributions) on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ * including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ * MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Whilst the Work is capable of being deployed, used and adopted (instantiated) to create
+ * a distributed ledger it is your responsibility to test and validate the code, together
+ * with all logic and performance of that code under all foreseeable scenarios.
+ *
+ * The Licensor does not make or purport to make and hereby excludes liability for all
+ * and any representation, warranty or undertaking in any form whatsoever, whether express
+ * or implied, to any entity or person, including any representation, warranty or
+ * undertaking, as to the functionality security use, value or other characteristics of
+ * any distributed ledger nor in respect the functioning or value of any tokens which may
+ * be created stored or transferred using the Work. The Licensor does not warrant that the
+ * Work or any use of the Work complies with any law or regulation in any territory where
+ * it may be implemented or used or that it will be appropriate for any specific purpose.
+ *
+ * Neither the licensor nor any current or former employees, officers, directors, partners,
+ * trustees, representatives, agents, advisors, contractors, or volunteers of the Licensor
+ * shall be liable for any direct or indirect, special, incidental, consequential or other
+ * losses of any kind, in tort, contract or otherwise (including but not limited to loss
+ * of revenue, income or profits, or loss of use or data, or loss of reputation, or loss
+ * of any economic or other opportunity of whatsoever nature or howsoever arising), arising
+ * out of or in connection with (without limitation of any use, misuse, of any ledger system
+ * or use made or its functionality or any performance or operation of any code or protocol
+ * caused by bugs or programming or logic errors or otherwise);
+ *
+ * A. any offer, purchase, holding, use, sale, exchange or transmission of any
+ * cryptographic keys, tokens or assets created, exchanged, stored or arising from any
+ * interaction with the Work;
+ *
+ * B. any failure in a transmission or loss of any token or assets keys or other digital
+ * artefacts due to errors in transmission;
+ *
+ * C. bugs, hacks, logic errors or faults in the Work or any communication;
+ *
+ * D. system software or apparatus including but not limited to losses caused by errors
+ * in holding or transmitting tokens by any third-party;
+ *
+ * E. breaches or failure of security including hacker attacks, loss or disclosure of
+ * password, loss of private key, unauthorised use or misuse of such passwords or keys;
+ *
+ * F. any losses including loss of anticipated savings or other benefits resulting from
+ * use of the Work or any changes to the Work (however implemented).
+ *
+ * You are solely responsible for; testing, validating and evaluation of all operation
+ * logic, functionality, security and appropriateness of using the Work for any commercial
+ * or non-commercial purpose and for any reproduction or redistribution by You of the
+ * Work. You assume all risks associated with Your use of the Work and the exercise of
+ * permissions under this License.
+ */
+
+package com.radixdlt.harness.deterministic;
+
+import com.google.common.collect.ImmutableList;
+import com.radixdlt.environment.ScenariosExecutionConfig;
+import com.radixdlt.genesis.GenesisData;
+import com.radixdlt.protocol.ProtocolUpdateEnactmentCondition;
+import com.radixdlt.protocol.ProtocolUpdateTrigger;
+import java.util.Optional;
+
+public record TestProtocolConfig(
+    ImmutableList<String> genesisScenarios,
+    ImmutableList<TestProtocolUpdateConfig> protocolUpdateConfigs) {
+
+  public TestProtocolConfig() {
+    this(ImmutableList.of(), ImmutableList.of());
+  }
+
+  public TestProtocolConfig withAllProtocolUpdatesAtEarlyEpochs() {
+    return this.with(
+            TestProtocolConfig.updateTo(
+                ProtocolUpdateTrigger.ANEMONE,
+                ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(3L)))
+        .with(
+            TestProtocolConfig.updateTo(
+                ProtocolUpdateTrigger.BOTTLENOSE,
+                ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(4L)));
+  }
+
+  public TestProtocolConfig withGenesisScenarios(ImmutableList<String> scenarios) {
+    return new TestProtocolConfig(scenarios, this.protocolUpdateConfigs);
+  }
+
+  public TestProtocolConfig withAllScenariosForConfiguredProtocolUpdates() {
+    return new TestProtocolConfig(
+        GenesisData.ALL_SCENARIOS,
+        this.protocolUpdateConfigs.stream()
+            .map(TestProtocolUpdateConfig::withAllApplicableScenarios)
+            .collect(ImmutableList.toImmutableList()));
+  }
+
+  public TestProtocolConfig with(TestProtocolUpdateConfig protocolUpdateConfig) {
+    return new TestProtocolConfig(
+        this.genesisScenarios,
+        ImmutableList.<TestProtocolUpdateConfig>builder()
+            .addAll(this.protocolUpdateConfigs)
+            .add(protocolUpdateConfig)
+            .build());
+  }
+
+  public static TestProtocolUpdateConfig updateTo(
+      String protocolVersionName, ProtocolUpdateEnactmentCondition enactmentCondition) {
+    return new TestProtocolUpdateConfig(
+        protocolVersionName, enactmentCondition, Optional.empty(), ImmutableList.of());
+  }
+
+  public long lastProtocolUpdateEnactmentEpoch() {
+    return this.protocolUpdateConfigs.stream()
+        .mapToLong(TestProtocolUpdateConfig::enactmentEpoch)
+        .max()
+        .orElse(0);
+  }
+
+  public record TestProtocolUpdateConfig(
+      String name,
+      ProtocolUpdateEnactmentCondition enactmentCondition,
+      Optional<byte[]> rawOverride,
+      ImmutableList<String> postProtocolUpdateScenarios) {
+
+    public TestProtocolUpdateConfig withAllApplicableScenarios() {
+      final var allApplicableScenarios =
+          ScenariosExecutionConfig.ALL.afterProtocolUpdates().stream()
+              .filter(pu -> pu.protocolVersionName().equals(name))
+              .flatMap(pu -> pu.scenarioNames().stream())
+              .collect(ImmutableList.toImmutableList());
+      return this.withScenarios(allApplicableScenarios);
+    }
+
+    public TestProtocolUpdateConfig withScenarios(ImmutableList<String> scenarios) {
+      return new TestProtocolUpdateConfig(
+          this.name, this.enactmentCondition, this.rawOverride, scenarios);
+    }
+
+    public long enactmentEpoch() {
+      if (this.enactmentCondition
+          instanceof
+          ProtocolUpdateEnactmentCondition.EnactAtStartOfEpochUnconditionally
+          epochCondition) {
+        return epochCondition.epoch().toLong();
+      } else {
+        throw new IllegalStateException("not an unconditional epoch-based enactment");
+      }
+    }
+  }
+}

--- a/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
+++ b/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
@@ -147,7 +147,8 @@ public sealed interface StateComputerConfig {
       REV2ProposerConfig proposerConfig,
       boolean debugLogging,
       boolean noFees,
-      ProtocolConfig protocolConfig) {
+      ProtocolConfig protocolConfig,
+      ScenariosExecutionConfig scenariosExecutionConfig) {
     return rev2(
         networkId,
         genesis,
@@ -157,7 +158,7 @@ public sealed interface StateComputerConfig {
         noFees,
         protocolConfig,
         StateTreeGcConfig.forTesting(),
-        ScenariosExecutionConfig.NONE);
+        scenariosExecutionConfig);
   }
 
   static StateComputerConfig rev2(

--- a/core/src/test/java/com/radixdlt/api/core/NetworkScenariosTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/NetworkScenariosTest.java
@@ -64,14 +64,16 @@
 
 package com.radixdlt.api.core;
 
+import static com.radixdlt.harness.predicates.NodesPredicate.allAtOrOverEpoch;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Longs;
 import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
+import com.radixdlt.harness.deterministic.TestProtocolConfig;
+import com.radixdlt.protocol.ProtocolUpdateEnactmentCondition;
+import com.radixdlt.protocol.ProtocolUpdateTrigger;
 import java.util.List;
 import java.util.stream.LongStream;
 import org.junit.Test;
@@ -80,42 +82,131 @@ public class NetworkScenariosTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_network_scenarios() throws Exception {
     // pick a custom subset/permutation (different than "all scenarios"):
-    final var names = ImmutableList.of("radiswap", "transfer_xrd");
-    try (var test = buildRunningServerTestWithScenarios(names)) {
+    final var protocolConfig =
+        new TestProtocolConfig()
+            .withGenesisScenarios(ImmutableList.of("radiswap", "transfer_xrd", "royalties"))
+            .with(
+                TestProtocolConfig.updateTo(
+                    ProtocolUpdateTrigger.ANEMONE,
+                    ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(3L)))
+            .with(
+                TestProtocolConfig.updateTo(
+                        ProtocolUpdateTrigger.BOTTLENOSE,
+                        ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(4L))
+                    .withScenarios(ImmutableList.of("maya_router", "access-controller-v2")));
+    try (var test = buildRunningServerTestWithProtocolConfig(30, protocolConfig)) {
       test.suppressUnusedWarning();
 
-      // query all scenarios
-      final var scenarios =
+      // Query scenarios right after genesis
+      final var genesisScenarios =
           getStatusApi()
               .statusScenariosPost(new ScenariosRequest().network(networkLogicalName))
               .getExecutedScenarios();
+      assertThat(genesisScenarios).hasSize(3); // there is 3 of them
+
+      // Wait for all protocol updates:
+      test.runUntilState(allAtOrOverEpoch(protocolConfig.lastProtocolUpdateEnactmentEpoch()));
+
+      // query all scenarios
+      final var allScenarios =
+          getStatusApi()
+              .statusScenariosPost(new ScenariosRequest().network(networkLogicalName))
+              .getExecutedScenarios();
+      assertThat(allScenarios).hasSize(5); // there is 3 genesis + 2 bottlenose
 
       // assert some selected properties of the known scenarios
-      assertThat(scenarios).hasSize(2);
       assertScenario(
-          scenarios,
+          allScenarios,
           0,
           "radiswap",
-          ImmutableSet.of("radiswap-add-liquidity", "radiswap-swap-tokens"),
-          ImmutableSet.of("radiswap_dapp_definition_account", "pool_1_resource_1"));
+          ImmutableList.of(
+              "radiswap-create-new-resources",
+              "radiswap-create-owner-badge-and-dapp-definition-account",
+              "radiswap-publish-and-create-pools",
+              "radiswap-add-liquidity",
+              "radiswap-distribute-tokens",
+              "radiswap-swap-tokens",
+              "radiswap-remove-tokens",
+              "radiswap-set-two-way-linking"),
+          ImmutableList.of(
+              "radiswap_dapp_definition_account",
+              "radiswap_dapp_owner_badge",
+              "storing_account",
+              "user_account_1",
+              "user_account_2",
+              "user_account_3",
+              "radiswap_package",
+              "pool_1_radiswap",
+              "pool_1_pool",
+              "pool_1_resource_1",
+              "pool_1_resource_2",
+              "pool_1_pool_unit",
+              "pool_2_radiswap",
+              "pool_2_pool",
+              "pool_2_resource_1",
+              "pool_2_resource_2",
+              "pool_2_pool_unit"));
       assertScenario(
-          scenarios,
+          allScenarios,
           1,
           "transfer_xrd",
-          ImmutableSet.of("faucet-top-up", "self-transfer--deposit_batch"),
-          ImmutableSet.of("from_account", "to_account_1"));
-
-      // assert that the captured transaction state versions are consecutive
-      final var storedStateVersions =
-          scenarios.stream()
-              .map(ExecutedScenario::getCommittedTransactions)
-              .flatMap(List::stream)
-              .mapToLong(ExecutedScenarioTransaction::getStateVersion)
-              .toArray();
-      final var consecutiveStateVersions =
-          LongStream.rangeClosed(Longs.min(storedStateVersions), Longs.max(storedStateVersions))
-              .toArray();
-      assertThat(storedStateVersions).containsExactly(consecutiveStateVersions);
+          ImmutableList.of(
+              "faucet-top-up",
+              "transfer--try_deposit_or_abort",
+              "transfer--try_deposit_or_refund",
+              "transfer--try_deposit_batch_or_abort",
+              "transfer--try_deposit_batch_or_refund",
+              "self-transfer--deposit_batch",
+              "multi-transfer--deposit_batch"),
+          ImmutableList.of("from_account", "to_account_1", "to_account_2"));
+      assertScenario(
+          allScenarios,
+          2,
+          "royalties",
+          ImmutableList.of(
+              "royalties--publish-package",
+              "royalties--instantiate-components",
+              "royalties--set-components-royalty",
+              "royalties--call_all_components_all_methods"),
+          ImmutableList.of(
+              "royalty_package_address",
+              "no_royalty_component_address",
+              "xrd_royalty_component_address",
+              "usd_royalty_component_address"));
+      assertScenario(
+          allScenarios,
+          3,
+          "maya_router",
+          ImmutableList.of(
+              "maya-router-create-accounts",
+              "faucet-top-up",
+              "maya-router-create-resources",
+              "maya-router-publish-and-instantiate",
+              "maya-router-deposit-to-asgard-vault-1",
+              "maya-router-transfer-out-from-asgard-vault-1",
+              "maya-router-transfer-out-from-asgard-vault-1-resource-3-failed-asset-not-available",
+              "maya-router-transfer-out-failed-auth-error",
+              "maya-router-transfer-between-asgard-vaults",
+              "maya-router-transfer-out-from-asgard-vault-1-resource-1-failed-asset-not-available",
+              "maya-router-deposit-to-asgard-vault-2",
+              "maya-router-transfer-out-asgard-vault-2"),
+          ImmutableList.of(
+              "owner_account",
+              "swapper_account",
+              "maya_router_package",
+              "maya_router_address",
+              "XRD",
+              "resource_1",
+              "resource_2"));
+      assertScenario(
+          allScenarios,
+          4,
+          "access-controller-v2",
+          ImmutableList.of(
+              "access-controller-v2-instantiate",
+              "access-controller-v2-deposit-fees-xrd",
+              "access-controller-v2-lock-fee-and-recover"),
+          ImmutableList.of("access_controller_v2_component_address"));
     }
   }
 
@@ -123,16 +214,28 @@ public class NetworkScenariosTest extends DeterministicCoreApiTestBase {
       List<ExecutedScenario> scenarios,
       int index,
       String scenarioName,
-      // we deliberately do not want to assert on exact list matches below, to avoid brittle tests
-      ImmutableSet<String> exampleTransactionNames,
-      ImmutableSet<String> exampleAddressNames) {
+      ImmutableList<String> expectedTransactionNames,
+      ImmutableList<String> expectedAddressNames) {
     final var scenario = scenarios.get(index);
     assertThat(scenario.getSequenceNumber()).isEqualTo(index);
     assertThat(scenario.getLogicalName()).isEqualTo(scenarioName);
-    assertThat(
-            Lists.transform(
-                scenario.getCommittedTransactions(), ExecutedScenarioTransaction::getLogicalName))
-        .containsAll(exampleTransactionNames);
-    assertThat(scenario.getAddresses().keySet()).containsAll(exampleAddressNames);
+
+    final var transactionNames =
+        Lists.transform(
+            scenario.getCommittedTransactions(), ExecutedScenarioTransaction::getLogicalName);
+    assertThat(transactionNames).hasSameElementsAs(expectedTransactionNames);
+    final var transactionStateVersions =
+        Lists.transform(
+            scenario.getCommittedTransactions(), ExecutedScenarioTransaction::getStateVersion);
+    assertThat(transactionStateVersions).isNotEmpty();
+    assertThat(transactionStateVersions).doesNotHaveDuplicates();
+    assertThat(transactionStateVersions).isSorted();
+    final var consecutiveVersions =
+        LongStream.rangeClosed(
+            transactionStateVersions.get(0),
+            transactionStateVersions.get(transactionStateVersions.size() - 1));
+    assertThat(transactionStateVersions).hasSameElementsAs(consecutiveVersions.boxed().toList());
+
+    assertThat(scenario.getAddresses().keySet()).hasSameElementsAs(expectedAddressNames);
   }
 }

--- a/core/src/test/java/com/radixdlt/api/core/ProofStreamTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/ProofStreamTest.java
@@ -67,10 +67,9 @@ package com.radixdlt.api.core;
 import static com.radixdlt.harness.predicates.NodesPredicate.allAtOrOverEpoch;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
-import com.radixdlt.protocol.ProtocolConfig;
+import com.radixdlt.harness.deterministic.TestProtocolConfig;
 import com.radixdlt.protocol.ProtocolUpdateEnactmentCondition;
 import com.radixdlt.protocol.ProtocolUpdateTrigger;
 import org.junit.Test;
@@ -79,11 +78,11 @@ public class ProofStreamTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_proof_stream() throws Exception {
     final var protocolConfig =
-        new ProtocolConfig(
-            ImmutableList.of(
-                new ProtocolUpdateTrigger(
+        new TestProtocolConfig()
+            .with(
+                TestProtocolConfig.updateTo(
                     ProtocolUpdateTrigger.ANEMONE,
-                    ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(3L))));
+                    ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(3L)));
 
     try (var test = buildRunningServerTestWithProtocolConfig(10, protocolConfig)) {
       test.runUntilState(allAtOrOverEpoch(5L));

--- a/core/src/test/java/com/radixdlt/rev2/protocol/BottlenoseProtocolUpdateTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/protocol/BottlenoseProtocolUpdateTest.java
@@ -77,6 +77,10 @@ import com.radixdlt.api.core.generated.api.TransactionApi;
 import com.radixdlt.api.core.generated.client.ApiException;
 import com.radixdlt.api.core.generated.models.*;
 import com.radixdlt.api.core.generated.models.TransactionStatus;
+import com.radixdlt.environment.DatabaseConfig;
+import com.radixdlt.environment.LedgerProofsGcConfig;
+import com.radixdlt.environment.ScenariosExecutionConfig;
+import com.radixdlt.environment.StateTreeGcConfig;
 import com.radixdlt.environment.deterministic.network.MessageMutator;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
@@ -90,6 +94,7 @@ import com.radixdlt.protocol.ProtocolUpdateTrigger;
 import com.radixdlt.rev2.*;
 import com.radixdlt.statecomputer.RustStateComputer;
 import com.radixdlt.sync.TransactionsAndProofReader;
+import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 import java.util.Arrays;
 import org.junit.Rule;
 import org.junit.Test;
@@ -123,14 +128,21 @@ public final class BottlenoseProtocolUpdateTest {
                 FunctionalRadixNodeModule.SafetyRecoveryConfig.BERKELEY_DB,
                 FunctionalRadixNodeModule.ConsensusConfig.of(1000),
                 FunctionalRadixNodeModule.LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
+                    new StateComputerConfig.REv2StateComputerConfig(
                         Network.INTEGRATIONTESTNET.getId(),
                         GenesisBuilder.createTestGenesisWithNumValidators(
                             1,
                             Decimal.ONE,
                             GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(5)),
+                        new DatabaseConfig(true, false, false, false),
                         StateComputerConfig.REV2ProposerConfig.Mempool.singleTransaction(),
-                        PROTOCOL_CONFIG))));
+                        false,
+                        StateTreeGcConfig.forTesting(),
+                        LedgerProofsGcConfig.forTesting(),
+                        LedgerSyncLimitsConfig.defaults(),
+                        PROTOCOL_CONFIG,
+                        false,
+                        ScenariosExecutionConfig.ALL))));
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/rev2/protocol/ProtocolUpdateWithEpochBoundsTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/protocol/ProtocolUpdateWithEpochBoundsTest.java
@@ -73,6 +73,7 @@ import static com.radixdlt.rev2.protocol.ProtocolUpdateWithEpochBoundsTest.TestE
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.radixdlt.environment.DatabaseConfig;
+import com.radixdlt.environment.ScenariosExecutionConfig;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.harness.deterministic.DeterministicTest;
@@ -307,7 +308,8 @@ public final class ProtocolUpdateWithEpochBoundsTest {
                         StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
                         false,
                         true,
-                        protocolConfig))));
+                        protocolConfig,
+                        ScenariosExecutionConfig.NONE))));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This closes https://radixdlt.atlassian.net/browse/NODE-618.
Additionally I bump the Engine dep to `bottlenose-e782788b` here (which was promised to be _the final_ Bottlenose version).

## Details

The change is rather easy (after recent refactors).
The line count comes from:
- slightly moving around some code related to Scenario execution
- some new test infra + extensive test asserts about all Scenarios being executed at right protocol states

## Testing

New tests added.
