### PR TITLE
Bottlenose enactment configs for all environments

### DIFF
--- a/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/config_printer.rs
@@ -22,15 +22,15 @@ fn print_protocol_config_code() {
     let calculator = CalculationParameters {
         expected_epoch_length: Duration::minutes(5),
         // This data can come from the Core API /core/state/consensus-manager response
-        base_epoch: Epoch::of(66516),
-        base_epoch_effective_start: DateTime::<Utc>::from_str("2024-01-24T14:05:57.229Z").unwrap(),
+        base_epoch: Epoch::of(97091),
+        base_epoch_effective_start: DateTime::<Utc>::from_str("2024-05-09T18:01:00.000Z").unwrap(),
     };
 
-    let version = ANEMONE_PROTOCOL_VERSION;
-    let version_const = stringify!(ANEMONE_PROTOCOL_VERSION);
-    let target_start = DateTime::<Utc>::from_str("2024-02-05T18:00:00.000Z").unwrap();
-    let enactment_window = Duration::days(14);
-    let proposed_thresholds = [(dec!(0.75), Duration::days(4))];
+    let version = BOTTLENOSE_PROTOCOL_VERSION;
+    let version_const = stringify!(BOTTLENOSE_PROTOCOL_VERSION);
+    let target_start = DateTime::<Utc>::from_str("2024-06-03T18:00:00.000Z").unwrap();
+    let enactment_window = Duration::days(28);
+    let proposed_thresholds = [(dec!(0.75), Duration::days(14))];
 
     // OUTPUT
     let start_epoch = calculator

--- a/core-rust/state-manager/src/protocol/protocol_configs/dumunet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/dumunet_protocol_config.rs
@@ -16,6 +16,18 @@ pub fn dumunet_protocol_config() -> ProtocolConfig {
                 required_ratio_of_stake_supported: dec!("0.80"),
                 required_consecutive_completed_epochs_of_support: 10,
             }],
+        },
+        BOTTLENOSE_PROTOCOL_VERSION => EnactAtStartOfEpochIfValidatorsReady {
+            // =================================================================
+            // PROTOCOL_VERSION: "bottlenose"
+            // READINESS_SIGNAL: "35701a6147bfd870000000bottlenose"
+            // =================================================================
+            lower_bound_inclusive: Epoch::of(1),
+            upper_bound_exclusive: Epoch::of(1000000),
+            readiness_thresholds: vec![SignalledReadinessThreshold {
+                required_ratio_of_stake_supported: dec!("0.80"),
+                required_consecutive_completed_epochs_of_support: 10,
+            }],
         }
     })
 }

--- a/core-rust/state-manager/src/protocol/protocol_configs/mainnet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/mainnet_protocol_config.rs
@@ -25,5 +25,24 @@ pub fn mainnet_protocol_config() -> ProtocolConfig {
                 },
             ],
         },
+        BOTTLENOSE_PROTOCOL_VERSION => EnactAtStartOfEpochIfValidatorsReady {
+            // =================================================================
+            // PROTOCOL_VERSION: "bottlenose"
+            // READINESS_SIGNAL: "86894b9104afb73a000000bottlenose"
+            // =================================================================
+            // The below estimates are based off:
+            // - Calculating relative to epoch 97091
+            // - Using that epoch 97091 started at 2024-05-09T18:01:00.000Z
+            // - Assuming epoch length will be 5 mins
+            // =================================================================
+            lower_bound_inclusive: Epoch::of(104291), // estimated: 2024-06-03T18:01:00.000Z
+            upper_bound_exclusive: Epoch::of(112355), // estimated: 2024-07-01T18:01:00.000Z
+            readiness_thresholds: vec![
+                SignalledReadinessThreshold {
+                    required_ratio_of_stake_supported: dec!(0.75),
+                    required_consecutive_completed_epochs_of_support: 4032, // estimated: 2 weeks
+                },
+            ],
+        },
     })
 }

--- a/core-rust/state-manager/src/protocol/protocol_configs/stokenet_protocol_config.rs
+++ b/core-rust/state-manager/src/protocol/protocol_configs/stokenet_protocol_config.rs
@@ -3,13 +3,24 @@ use crate::engine_prelude::*;
 use crate::protocol::*;
 use ProtocolUpdateEnactmentCondition::*;
 
-// See
 pub fn stokenet_protocol_config() -> ProtocolConfig {
     ProtocolConfig::new_with_triggers(hashmap! {
         ANEMONE_PROTOCOL_VERSION => EnactAtStartOfEpochIfValidatorsReady {
             // =================================================================
             // PROTOCOL_VERSION: "anemone"
             // READINESS_SIGNAL: "811c31d2bc6a2631000000000anemone"
+            // =================================================================
+            lower_bound_inclusive: Epoch::of(1),
+            upper_bound_exclusive: Epoch::of(1000000),
+            readiness_thresholds: vec![SignalledReadinessThreshold {
+                required_ratio_of_stake_supported: dec!("0.80"),
+                required_consecutive_completed_epochs_of_support: 10,
+            }],
+        },
+        BOTTLENOSE_PROTOCOL_VERSION => EnactAtStartOfEpochIfValidatorsReady {
+            // =================================================================
+            // PROTOCOL_VERSION: "bottlenose"
+            // READINESS_SIGNAL: "35701a6147bfd870000000bottlenose"
             // =================================================================
             lower_bound_inclusive: Epoch::of(1),
             upper_bound_exclusive: Epoch::of(1000000),


### PR DESCRIPTION
⚠️ Builds on top of https://github.com/radixdlt/babylon-node/pull/940.

## Summary

As planned in https://radixdlt.atlassian.net/browse/NODE-643.

## Details

Configs generated by existing scripts, with dates coming from Bottlenose announcement and Protocol Update policy.

## Testing

Configuration change only.
