### PR TITLE
Update Bottlenose from earlier release branches

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,6 +12,8 @@ From the repository root, run the following - replacing 2 with the number of val
 ./docker/scripts/rundocker.sh 2
 ```
 
+This script requires [`../core-rust`](../core-rust) to be compiled.
+
 ## The Dockerfile
 
 ![The structure of the docker image](babylon-node-docker-build.png)

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -5,9 +5,10 @@ Once you have read the [contributing guide](../CONTRIBUTING.md), if you want to 
 
 > [!NOTE]
 >
-> As of 2024-02-12, the strictly ordered list of supported base branches, starting from earliest/furthest upstream, is:
+> As of 2024-05-15, the strictly ordered list of supported base branches, starting from earliest/furthest upstream, is:
 > 
-> * `release/anemone` - This is currently running on mainnet.
+> * `release/bottlenose` - This is currently running on mainnet.
+> * `release/anemone`
 > * `main`
 > * `develop`
 > 

--- a/testnet-node/docker-compose.yml
+++ b/testnet-node/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   core:
     container_name: radixdlt-stokenet-node
     #### Chose to either uncomment "image" or "build" to either pull the image from dockerhub or build locally from source
-    image: radixdlt/babylon-node:v1.1.3.1
+    image: radixdlt/babylon-node:v1.2.0
     # build:
     #   context: ..
     #   dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

This addresses a couple minor items of the checklist https://radixdlt.atlassian.net/browse/NODE-640.

## Details

- pull `main` and `anemone-1.1.3`
  - note: technically we could also pull `develop`, but it has only 1 newer refactor PR which merged today, so I prefer to consider it "past the Bottlenose cut-off point"
- Update [babylon-node/docs/branching-strategy.md at main · radixdlt/babylon-node](https://github.com/radixdlt/babylon-node/blob/main/docs/branching-strategy.md) on the latest supported branch.
- Update the version in testnet-node/docker-compose.yml to the eventually-to-be-published-version. 
- A few other items turned out to be no-op:
  - No need to bump version in `system-api-schema.yml` (no changes from previous release)
  - The version in `core-api-schema.yml` is already at 1.2.0
  - The version in `engine-state-api-schema.yml` is at 0.1-beta and can stay this way

## Testing

Only regression tests should pass.
