### PR TITLE
Ensure no breaking-changes in OAS

### DIFF
--- a/core-rust/core-api-server/core-api-schema.yaml
+++ b/core-rust/core-api-server/core-api-schema.yaml
@@ -3749,7 +3749,6 @@ components:
         - GlobalValidator
         - GlobalGenericComponent
         - GlobalAccount
-        - GlobalAccountLocker
         - GlobalIdentity
         - GlobalAccessController
         - GlobalVirtualSecp256k1Account
@@ -3766,6 +3765,7 @@ components:
         - GlobalTwoResourcePool
         - GlobalMultiResourcePool
         - GlobalTransactionTracker
+        - GlobalAccountLocker
     EntityAddress:
       type: string
       description: Bech32m-encoded human readable version of the entity's address (ie the entity's node id)
@@ -3871,9 +3871,7 @@ components:
     SubstateType:
       type: string
       enum:
-        - BootLoaderModuleFieldSystemBoot
         - BootLoaderModuleFieldVmBoot
-        - BootLoaderModuleFieldKernelBoot
         - TypeInfoModuleFieldTypeInfo
         - RoleAssignmentModuleFieldOwnerRole
         - RoleAssignmentModuleRuleEntry
@@ -3916,7 +3914,6 @@ components:
         - AccountVaultEntry
         - AccountResourcePreferenceEntry
         - AccountAuthorizedDepositorEntry
-        - AccountLockerAccountClaimsEntry
         - AccessControllerFieldState
         - GenericScryptoComponentFieldState
         - GenericKeyValueStoreEntry
@@ -3925,6 +3922,9 @@ components:
         - MultiResourcePoolFieldState
         - TransactionTrackerFieldState
         - TransactionTrackerCollectionEntry
+        - AccountLockerAccountClaimsEntry
+        - BootLoaderModuleFieldSystemBoot
+        - BootLoaderModuleFieldKernelBoot
 ################################################
 # GENERAL / SHARED MODELS - substate key types #
 ################################################
@@ -6524,7 +6524,6 @@ components:
             - genesis_helper_package
             - faucet_package
             - pool_package
-            - locker_package
             - consensus_manager
             - genesis_helper
             - faucet

--- a/core-rust/core-api-server/src/core_api/generated/models/entity_type.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/entity_type.rs
@@ -22,8 +22,6 @@ pub enum EntityType {
     GlobalGenericComponent,
     #[serde(rename = "GlobalAccount")]
     GlobalAccount,
-    #[serde(rename = "GlobalAccountLocker")]
-    GlobalAccountLocker,
     #[serde(rename = "GlobalIdentity")]
     GlobalIdentity,
     #[serde(rename = "GlobalAccessController")]
@@ -56,6 +54,8 @@ pub enum EntityType {
     GlobalMultiResourcePool,
     #[serde(rename = "GlobalTransactionTracker")]
     GlobalTransactionTracker,
+    #[serde(rename = "GlobalAccountLocker")]
+    GlobalAccountLocker,
 
 }
 
@@ -67,7 +67,6 @@ impl ToString for EntityType {
             Self::GlobalValidator => String::from("GlobalValidator"),
             Self::GlobalGenericComponent => String::from("GlobalGenericComponent"),
             Self::GlobalAccount => String::from("GlobalAccount"),
-            Self::GlobalAccountLocker => String::from("GlobalAccountLocker"),
             Self::GlobalIdentity => String::from("GlobalIdentity"),
             Self::GlobalAccessController => String::from("GlobalAccessController"),
             Self::GlobalVirtualSecp256k1Account => String::from("GlobalVirtualSecp256k1Account"),
@@ -84,6 +83,7 @@ impl ToString for EntityType {
             Self::GlobalTwoResourcePool => String::from("GlobalTwoResourcePool"),
             Self::GlobalMultiResourcePool => String::from("GlobalMultiResourcePool"),
             Self::GlobalTransactionTracker => String::from("GlobalTransactionTracker"),
+            Self::GlobalAccountLocker => String::from("GlobalAccountLocker"),
         }
     }
 }

--- a/core-rust/core-api-server/src/core_api/generated/models/network_configuration_response_well_known_addresses.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/network_configuration_response_well_known_addresses.rs
@@ -60,8 +60,8 @@ pub struct NetworkConfigurationResponseWellKnownAddresses {
     pub faucet_package: String,
     #[serde(rename = "pool_package")]
     pub pool_package: String,
-    #[serde(rename = "locker_package")]
-    pub locker_package: String,
+    #[serde(rename = "locker_package", skip_serializing_if = "Option::is_none")]
+    pub locker_package: Option<String>,
     #[serde(rename = "consensus_manager")]
     pub consensus_manager: String,
     #[serde(rename = "genesis_helper")]
@@ -74,7 +74,7 @@ pub struct NetworkConfigurationResponseWellKnownAddresses {
 
 impl NetworkConfigurationResponseWellKnownAddresses {
     /// Key addresses for this network.
-    pub fn new(xrd: String, secp256k1_signature_virtual_badge: String, ed25519_signature_virtual_badge: String, package_of_direct_caller_virtual_badge: String, global_caller_virtual_badge: String, system_transaction_badge: String, package_owner_badge: String, validator_owner_badge: String, account_owner_badge: String, identity_owner_badge: String, package_package: String, resource_package: String, account_package: String, identity_package: String, consensus_manager_package: String, access_controller_package: String, transaction_processor_package: String, metadata_module_package: String, royalty_module_package: String, role_assignment_module_package: String, genesis_helper_package: String, faucet_package: String, pool_package: String, locker_package: String, consensus_manager: String, genesis_helper: String, faucet: String, transaction_tracker: String) -> NetworkConfigurationResponseWellKnownAddresses {
+    pub fn new(xrd: String, secp256k1_signature_virtual_badge: String, ed25519_signature_virtual_badge: String, package_of_direct_caller_virtual_badge: String, global_caller_virtual_badge: String, system_transaction_badge: String, package_owner_badge: String, validator_owner_badge: String, account_owner_badge: String, identity_owner_badge: String, package_package: String, resource_package: String, account_package: String, identity_package: String, consensus_manager_package: String, access_controller_package: String, transaction_processor_package: String, metadata_module_package: String, royalty_module_package: String, role_assignment_module_package: String, genesis_helper_package: String, faucet_package: String, pool_package: String, consensus_manager: String, genesis_helper: String, faucet: String, transaction_tracker: String) -> NetworkConfigurationResponseWellKnownAddresses {
         NetworkConfigurationResponseWellKnownAddresses {
             xrd,
             secp256k1_signature_virtual_badge,
@@ -99,7 +99,7 @@ impl NetworkConfigurationResponseWellKnownAddresses {
             genesis_helper_package,
             faucet_package,
             pool_package,
-            locker_package,
+            locker_package: None,
             consensus_manager,
             genesis_helper,
             faucet,

--- a/core-rust/core-api-server/src/core_api/generated/models/substate_type.rs
+++ b/core-rust/core-api-server/src/core_api/generated/models/substate_type.rs
@@ -12,12 +12,8 @@
 /// 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, serde::Serialize, serde::Deserialize)]
 pub enum SubstateType {
-    #[serde(rename = "BootLoaderModuleFieldSystemBoot")]
-    BootLoaderModuleFieldSystemBoot,
     #[serde(rename = "BootLoaderModuleFieldVmBoot")]
     BootLoaderModuleFieldVmBoot,
-    #[serde(rename = "BootLoaderModuleFieldKernelBoot")]
-    BootLoaderModuleFieldKernelBoot,
     #[serde(rename = "TypeInfoModuleFieldTypeInfo")]
     TypeInfoModuleFieldTypeInfo,
     #[serde(rename = "RoleAssignmentModuleFieldOwnerRole")]
@@ -102,8 +98,6 @@ pub enum SubstateType {
     AccountResourcePreferenceEntry,
     #[serde(rename = "AccountAuthorizedDepositorEntry")]
     AccountAuthorizedDepositorEntry,
-    #[serde(rename = "AccountLockerAccountClaimsEntry")]
-    AccountLockerAccountClaimsEntry,
     #[serde(rename = "AccessControllerFieldState")]
     AccessControllerFieldState,
     #[serde(rename = "GenericScryptoComponentFieldState")]
@@ -120,15 +114,19 @@ pub enum SubstateType {
     TransactionTrackerFieldState,
     #[serde(rename = "TransactionTrackerCollectionEntry")]
     TransactionTrackerCollectionEntry,
+    #[serde(rename = "AccountLockerAccountClaimsEntry")]
+    AccountLockerAccountClaimsEntry,
+    #[serde(rename = "BootLoaderModuleFieldSystemBoot")]
+    BootLoaderModuleFieldSystemBoot,
+    #[serde(rename = "BootLoaderModuleFieldKernelBoot")]
+    BootLoaderModuleFieldKernelBoot,
 
 }
 
 impl ToString for SubstateType {
     fn to_string(&self) -> String {
         match self {
-            Self::BootLoaderModuleFieldSystemBoot => String::from("BootLoaderModuleFieldSystemBoot"),
             Self::BootLoaderModuleFieldVmBoot => String::from("BootLoaderModuleFieldVmBoot"),
-            Self::BootLoaderModuleFieldKernelBoot => String::from("BootLoaderModuleFieldKernelBoot"),
             Self::TypeInfoModuleFieldTypeInfo => String::from("TypeInfoModuleFieldTypeInfo"),
             Self::RoleAssignmentModuleFieldOwnerRole => String::from("RoleAssignmentModuleFieldOwnerRole"),
             Self::RoleAssignmentModuleRuleEntry => String::from("RoleAssignmentModuleRuleEntry"),
@@ -171,7 +169,6 @@ impl ToString for SubstateType {
             Self::AccountVaultEntry => String::from("AccountVaultEntry"),
             Self::AccountResourcePreferenceEntry => String::from("AccountResourcePreferenceEntry"),
             Self::AccountAuthorizedDepositorEntry => String::from("AccountAuthorizedDepositorEntry"),
-            Self::AccountLockerAccountClaimsEntry => String::from("AccountLockerAccountClaimsEntry"),
             Self::AccessControllerFieldState => String::from("AccessControllerFieldState"),
             Self::GenericScryptoComponentFieldState => String::from("GenericScryptoComponentFieldState"),
             Self::GenericKeyValueStoreEntry => String::from("GenericKeyValueStoreEntry"),
@@ -180,13 +177,16 @@ impl ToString for SubstateType {
             Self::MultiResourcePoolFieldState => String::from("MultiResourcePoolFieldState"),
             Self::TransactionTrackerFieldState => String::from("TransactionTrackerFieldState"),
             Self::TransactionTrackerCollectionEntry => String::from("TransactionTrackerCollectionEntry"),
+            Self::AccountLockerAccountClaimsEntry => String::from("AccountLockerAccountClaimsEntry"),
+            Self::BootLoaderModuleFieldSystemBoot => String::from("BootLoaderModuleFieldSystemBoot"),
+            Self::BootLoaderModuleFieldKernelBoot => String::from("BootLoaderModuleFieldKernelBoot"),
         }
     }
 }
 
 impl Default for SubstateType {
     fn default() -> SubstateType {
-        Self::BootLoaderModuleFieldSystemBoot
+        Self::BootLoaderModuleFieldVmBoot
     }
 }
 

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_configuration.rs
@@ -77,7 +77,7 @@ pub(crate) async fn handle_status_network_configuration(
                 .unwrap(),
             faucet_package: bech32_encoder.encode(FAUCET_PACKAGE.as_ref()).unwrap(),
             pool_package: bech32_encoder.encode(POOL_PACKAGE.as_ref()).unwrap(),
-            locker_package: bech32_encoder.encode(LOCKER_PACKAGE.as_ref()).unwrap(),
+            locker_package: Some(bech32_encoder.encode(LOCKER_PACKAGE.as_ref()).unwrap()),
             consensus_manager: bech32_encoder.encode(CONSENSUS_MANAGER.as_ref()).unwrap(),
             genesis_helper: bech32_encoder.encode(GENESIS_HELPER.as_ref()).unwrap(),
             faucet: bech32_encoder.encode(FAUCET.as_ref()).unwrap(),

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/EntityType.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/EntityType.java
@@ -38,8 +38,6 @@ public enum EntityType {
   
   GLOBALACCOUNT("GlobalAccount"),
   
-  GLOBALACCOUNTLOCKER("GlobalAccountLocker"),
-  
   GLOBALIDENTITY("GlobalIdentity"),
   
   GLOBALACCESSCONTROLLER("GlobalAccessController"),
@@ -70,7 +68,9 @@ public enum EntityType {
   
   GLOBALMULTIRESOURCEPOOL("GlobalMultiResourcePool"),
   
-  GLOBALTRANSACTIONTRACKER("GlobalTransactionTracker");
+  GLOBALTRANSACTIONTRACKER("GlobalTransactionTracker"),
+  
+  GLOBALACCOUNTLOCKER("GlobalAccountLocker");
 
   private String value;
 

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/NetworkConfigurationResponseWellKnownAddresses.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/NetworkConfigurationResponseWellKnownAddresses.java
@@ -757,10 +757,10 @@ public class NetworkConfigurationResponseWellKnownAddresses {
    * Get lockerPackage
    * @return lockerPackage
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
   @JsonProperty(JSON_PROPERTY_LOCKER_PACKAGE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public String getLockerPackage() {
     return lockerPackage;
@@ -768,7 +768,7 @@ public class NetworkConfigurationResponseWellKnownAddresses {
 
 
   @JsonProperty(JSON_PROPERTY_LOCKER_PACKAGE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public void setLockerPackage(String lockerPackage) {
     this.lockerPackage = lockerPackage;
   }

--- a/core/src/test-core/java/com/radixdlt/api/core/generated/models/SubstateType.java
+++ b/core/src/test-core/java/com/radixdlt/api/core/generated/models/SubstateType.java
@@ -28,11 +28,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 public enum SubstateType {
   
-  BOOTLOADERMODULEFIELDSYSTEMBOOT("BootLoaderModuleFieldSystemBoot"),
-  
   BOOTLOADERMODULEFIELDVMBOOT("BootLoaderModuleFieldVmBoot"),
-  
-  BOOTLOADERMODULEFIELDKERNELBOOT("BootLoaderModuleFieldKernelBoot"),
   
   TYPEINFOMODULEFIELDTYPEINFO("TypeInfoModuleFieldTypeInfo"),
   
@@ -118,8 +114,6 @@ public enum SubstateType {
   
   ACCOUNTAUTHORIZEDDEPOSITORENTRY("AccountAuthorizedDepositorEntry"),
   
-  ACCOUNTLOCKERACCOUNTCLAIMSENTRY("AccountLockerAccountClaimsEntry"),
-  
   ACCESSCONTROLLERFIELDSTATE("AccessControllerFieldState"),
   
   GENERICSCRYPTOCOMPONENTFIELDSTATE("GenericScryptoComponentFieldState"),
@@ -134,7 +128,13 @@ public enum SubstateType {
   
   TRANSACTIONTRACKERFIELDSTATE("TransactionTrackerFieldState"),
   
-  TRANSACTIONTRACKERCOLLECTIONENTRY("TransactionTrackerCollectionEntry");
+  TRANSACTIONTRACKERCOLLECTIONENTRY("TransactionTrackerCollectionEntry"),
+  
+  ACCOUNTLOCKERACCOUNTCLAIMSENTRY("AccountLockerAccountClaimsEntry"),
+  
+  BOOTLOADERMODULEFIELDSYSTEMBOOT("BootLoaderModuleFieldSystemBoot"),
+  
+  BOOTLOADERMODULEFIELDKERNELBOOT("BootLoaderModuleFieldKernelBoot");
 
   private String value;
 

--- a/sdk/typescript/lib/generated/models/EntityType.ts
+++ b/sdk/typescript/lib/generated/models/EntityType.ts
@@ -23,7 +23,6 @@ export const EntityType = {
     GlobalValidator: 'GlobalValidator',
     GlobalGenericComponent: 'GlobalGenericComponent',
     GlobalAccount: 'GlobalAccount',
-    GlobalAccountLocker: 'GlobalAccountLocker',
     GlobalIdentity: 'GlobalIdentity',
     GlobalAccessController: 'GlobalAccessController',
     GlobalVirtualSecp256k1Account: 'GlobalVirtualSecp256k1Account',
@@ -39,7 +38,8 @@ export const EntityType = {
     GlobalOneResourcePool: 'GlobalOneResourcePool',
     GlobalTwoResourcePool: 'GlobalTwoResourcePool',
     GlobalMultiResourcePool: 'GlobalMultiResourcePool',
-    GlobalTransactionTracker: 'GlobalTransactionTracker'
+    GlobalTransactionTracker: 'GlobalTransactionTracker',
+    GlobalAccountLocker: 'GlobalAccountLocker'
 } as const;
 export type EntityType = typeof EntityType[keyof typeof EntityType];
 

--- a/sdk/typescript/lib/generated/models/NetworkConfigurationResponseWellKnownAddresses.ts
+++ b/sdk/typescript/lib/generated/models/NetworkConfigurationResponseWellKnownAddresses.ts
@@ -162,7 +162,7 @@ export interface NetworkConfigurationResponseWellKnownAddresses {
      * @type {string}
      * @memberof NetworkConfigurationResponseWellKnownAddresses
      */
-    locker_package: string;
+    locker_package?: string;
     /**
      * 
      * @type {string}
@@ -217,7 +217,6 @@ export function instanceOfNetworkConfigurationResponseWellKnownAddresses(value: 
     isInstance = isInstance && "genesis_helper_package" in value;
     isInstance = isInstance && "faucet_package" in value;
     isInstance = isInstance && "pool_package" in value;
-    isInstance = isInstance && "locker_package" in value;
     isInstance = isInstance && "consensus_manager" in value;
     isInstance = isInstance && "genesis_helper" in value;
     isInstance = isInstance && "faucet" in value;
@@ -259,7 +258,7 @@ export function NetworkConfigurationResponseWellKnownAddressesFromJSONTyped(json
         'genesis_helper_package': json['genesis_helper_package'],
         'faucet_package': json['faucet_package'],
         'pool_package': json['pool_package'],
-        'locker_package': json['locker_package'],
+        'locker_package': !exists(json, 'locker_package') ? undefined : json['locker_package'],
         'consensus_manager': json['consensus_manager'],
         'genesis_helper': json['genesis_helper'],
         'faucet': json['faucet'],

--- a/sdk/typescript/lib/generated/models/SubstateType.ts
+++ b/sdk/typescript/lib/generated/models/SubstateType.ts
@@ -18,9 +18,7 @@
  * @export
  */
 export const SubstateType = {
-    BootLoaderModuleFieldSystemBoot: 'BootLoaderModuleFieldSystemBoot',
     BootLoaderModuleFieldVmBoot: 'BootLoaderModuleFieldVmBoot',
-    BootLoaderModuleFieldKernelBoot: 'BootLoaderModuleFieldKernelBoot',
     TypeInfoModuleFieldTypeInfo: 'TypeInfoModuleFieldTypeInfo',
     RoleAssignmentModuleFieldOwnerRole: 'RoleAssignmentModuleFieldOwnerRole',
     RoleAssignmentModuleRuleEntry: 'RoleAssignmentModuleRuleEntry',
@@ -63,7 +61,6 @@ export const SubstateType = {
     AccountVaultEntry: 'AccountVaultEntry',
     AccountResourcePreferenceEntry: 'AccountResourcePreferenceEntry',
     AccountAuthorizedDepositorEntry: 'AccountAuthorizedDepositorEntry',
-    AccountLockerAccountClaimsEntry: 'AccountLockerAccountClaimsEntry',
     AccessControllerFieldState: 'AccessControllerFieldState',
     GenericScryptoComponentFieldState: 'GenericScryptoComponentFieldState',
     GenericKeyValueStoreEntry: 'GenericKeyValueStoreEntry',
@@ -71,7 +68,10 @@ export const SubstateType = {
     TwoResourcePoolFieldState: 'TwoResourcePoolFieldState',
     MultiResourcePoolFieldState: 'MultiResourcePoolFieldState',
     TransactionTrackerFieldState: 'TransactionTrackerFieldState',
-    TransactionTrackerCollectionEntry: 'TransactionTrackerCollectionEntry'
+    TransactionTrackerCollectionEntry: 'TransactionTrackerCollectionEntry',
+    AccountLockerAccountClaimsEntry: 'AccountLockerAccountClaimsEntry',
+    BootLoaderModuleFieldSystemBoot: 'BootLoaderModuleFieldSystemBoot',
+    BootLoaderModuleFieldKernelBoot: 'BootLoaderModuleFieldKernelBoot'
 } as const;
 export type SubstateType = typeof SubstateType[keyof typeof SubstateType];
 


### PR DESCRIPTION
# Context
- As enums are often represented by numbers under the hood adding something in the middle of the list can potentially cause non-trivial errors.
- Properties cannot be required by default as it will break existing SDKs.