### PR TITLE
Do not assume latest version of outputted substate values

### DIFF
--- a/core-rust/core-api-server/src/core_api/conversions/errors.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/errors.rs
@@ -22,7 +22,6 @@ pub enum MappingError {
         bytes: Vec<u8>,
         message: String,
     },
-    ObsoleteSubstateVersion,
     UnexpectedPersistedData {
         message: String,
     },


### PR DESCRIPTION
## Summary

The `ObsoleteSubstateVersion` should not really be emitted in situations where we have a way of upgrading the substate values to their newest versions.

## Details

See https://rdxworks.slack.com/archives/C071XGF4G6M/p1715614458883139?thread_ts=1715600014.359329&cid=C071XGF4G6M.

## Testing

A thorough "can return old-version substates upgraded to newest" test is due in a future PR.