### PR TITLE
Apply a builder pattern for test configs

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/environment/DatabaseConfig.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/environment/DatabaseConfig.java
@@ -78,4 +78,9 @@ public record DatabaseConfig(
         DatabaseConfig.class,
         codecs -> StructCodec.fromRecordComponents(DatabaseConfig.class, codecs));
   }
+
+  public static DatabaseConfig forTesting() {
+    // Many test assert on transaction execution details, so we keep this one on by default:
+    return new DatabaseConfig(true, false, false, false);
+  }
 }

--- a/core-rust-bridge/src/main/java/com/radixdlt/genesis/GenesisData.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/genesis/GenesisData.java
@@ -140,14 +140,4 @@ public record GenesisData(
         DEFAULT_TEST_FAUCET_SUPPLY,
         NO_SCENARIOS);
   }
-
-  public static GenesisData testingDefaultEmptyWithScenarios() {
-    return new GenesisData(
-        UInt64.fromNonNegativeLong(1L),
-        0,
-        GenesisConsensusManagerConfig.testingDefaultEmpty(),
-        ImmutableList.of(),
-        DEFAULT_TEST_FAUCET_SUPPLY,
-        ALL_SCENARIOS);
-  }
 }

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/bft_sync/SyncToTimeoutQcTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/bft_sync/SyncToTimeoutQcTest.java
@@ -129,11 +129,10 @@ public class SyncToTimeoutQcTest {
                     FunctionalRadixNodeModule.ConsensusConfig.of(),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(10),
-                            EpochNodeWeightMapping.constant(NUM_NODES),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool(),
-                            StateComputerConfig.ProposerElectionMode
-                                .WITH_ROTATE_ONCE_BUT_NO_SHUFFLE))));
+                                10, EpochNodeWeightMapping.constant(NUM_NODES))
+                            .withProposerElection(
+                                StateComputerConfig.ProposerElectionMode
+                                    .WITH_ROTATE_ONCE_BUT_NO_SHUFFLE))));
 
     test.startAllNodes();
     test.runUntilMessage(DeterministicTest.roundUpdateOnNode(Round.of(2), 0), 10000);

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/DifferentTimestampsCauseTimeoutTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/DifferentTimestampsCauseTimeoutTest.java
@@ -83,7 +83,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.MockedMempoolConfig;
 import com.radixdlt.utils.KeyComparator;
 import com.radixdlt.utils.Pair;
 import java.util.Map;
@@ -108,11 +107,10 @@ public class DifferentTimestampsCauseTimeoutTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(),
                     LedgerConfig.stateComputerNoSync(
-                        StateComputerConfig.mockedNoEpochs(
-                            numValidatorNodes,
-                            MockedMempoolConfig.noMempool(),
-                            StateComputerConfig.ProposerElectionMode
-                                .WITH_ROTATE_ONCE_BUT_NO_SHUFFLE))))
+                        StateComputerConfig.mockedNoEpochs(numValidatorNodes)
+                            .withProposerElection(
+                                StateComputerConfig.ProposerElectionMode
+                                    .WITH_ROTATE_ONCE_BUT_NO_SHUFFLE))))
             .createExecutor();
 
     executor.start();
@@ -160,11 +158,10 @@ public class DifferentTimestampsCauseTimeoutTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(),
                     LedgerConfig.stateComputerNoSync(
-                        StateComputerConfig.mockedNoEpochs(
-                            numValidatorNodes,
-                            MockedMempoolConfig.noMempool(),
-                            StateComputerConfig.ProposerElectionMode
-                                .WITH_ROTATE_ONCE_BUT_NO_SHUFFLE))))
+                        StateComputerConfig.mockedNoEpochs(numValidatorNodes)
+                            .withProposerElection(
+                                StateComputerConfig.ProposerElectionMode
+                                    .WITH_ROTATE_ONCE_BUT_NO_SHUFFLE))))
             .createExecutor();
 
     executor.start();

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/FProposalDropperResponsiveTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/FProposalDropperResponsiveTest.java
@@ -77,7 +77,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.MockedMempoolConfig;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -109,8 +108,7 @@ public class FProposalDropperResponsiveTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(),
                     LedgerConfig.stateComputerMockedSync(
-                        StateComputerConfig.mockedNoEpochs(
-                            numValidatorNodes, MockedMempoolConfig.noMempool()))));
+                        StateComputerConfig.mockedNoEpochs(numValidatorNodes))));
 
     test.startAllNodes();
     test.runForCount(30_000);

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/OneProposalDropperResponsiveTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/OneProposalDropperResponsiveTest.java
@@ -76,7 +76,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.MockedMempoolConfig;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -102,8 +101,7 @@ public class OneProposalDropperResponsiveTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(),
                     LedgerConfig.stateComputerMockedSync(
-                        StateComputerConfig.mockedNoEpochs(
-                            numValidatorNodes, MockedMempoolConfig.noMempool()))));
+                        StateComputerConfig.mockedNoEpochs(numValidatorNodes))));
 
     test.startAllNodes();
     test.runForCount(30_000);

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/OneProposalTimeoutResponsiveTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/OneProposalTimeoutResponsiveTest.java
@@ -78,7 +78,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.MockedMempoolConfig;
 import com.radixdlt.monitoring.Metrics;
 import java.util.Random;
 import org.junit.Test;
@@ -99,8 +98,7 @@ public class OneProposalTimeoutResponsiveTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(200L, 0L),
                     LedgerConfig.stateComputerNoSync(
-                        StateComputerConfig.mockedNoEpochs(
-                            numValidatorNodes, MockedMempoolConfig.noMempool()))));
+                        StateComputerConfig.mockedNoEpochs(numValidatorNodes))));
 
     test.startAllNodes();
     test.runUntilMessage(

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/PacemakerRoundUpdateRaceConditionTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/PacemakerRoundUpdateRaceConditionTest.java
@@ -86,7 +86,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.ConsensusConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.MockedMempoolConfig;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.utils.KeyComparator;
 import io.reactivex.rxjava3.schedulers.Timed;
@@ -161,8 +160,7 @@ public class PacemakerRoundUpdateRaceConditionTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(pacemakerTimeout, 0L),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerNoSync(
-                        StateComputerConfig.mockedNoEpochs(
-                            numValidatorNodes, MockedMempoolConfig.noMempool()))));
+                        StateComputerConfig.mockedNoEpochs(numValidatorNodes))));
 
     test.startAllNodes();
     test.runUntilMessage(nodeUnderTestReachesRound(Round.of(3)), 1000);

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/ProposerLoadBalancedTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/ProposerLoadBalancedTest.java
@@ -68,7 +68,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.radixdlt.consensus.EpochNodeWeightMapping;
-import com.radixdlt.consensus.LedgerHashes;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.environment.deterministic.network.MessageMutator;
 import com.radixdlt.environment.deterministic.network.MessageSelector;
@@ -80,7 +79,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.MockedMempoolConfig;
 import com.radixdlt.monitoring.Metrics;
 import com.radixdlt.utils.UInt192;
 import java.util.List;
@@ -106,12 +104,9 @@ public class ProposerLoadBalancedTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(),
                     LedgerConfig.stateComputerNoSync(
-                        StateComputerConfig.mockedWithEpochs(
-                            Round.of(10000000),
-                            mapping,
-                            LedgerHashes.zero(),
-                            MockedMempoolConfig.noMempool(),
-                            StateComputerConfig.ProposerElectionMode.ONLY_WEIGHTED_BY_STAKE))));
+                        StateComputerConfig.mockedWithEpochs(10000000, mapping)
+                            .withProposerElection(
+                                StateComputerConfig.ProposerElectionMode.ONLY_WEIGHTED_BY_STAKE))));
     test.startAllNodes();
     test.runUntilMessage(
         DeterministicTest.hasReachedRound(Round.of(numRounds)),

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/QuorumWithoutALeaderWithTimeoutsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/QuorumWithoutALeaderWithTimeoutsTest.java
@@ -78,7 +78,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.MockedMempoolConfig;
 import com.radixdlt.monitoring.Metrics;
 import java.util.Random;
 import org.junit.Test;
@@ -105,8 +104,7 @@ public class QuorumWithoutALeaderWithTimeoutsTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(),
                     LedgerConfig.stateComputerNoSync(
-                        StateComputerConfig.mockedNoEpochs(
-                            numValidatorNodes, MockedMempoolConfig.noMempool()))));
+                        StateComputerConfig.mockedNoEpochs(numValidatorNodes))));
     test.startAllNodes();
     test.runUntilMessage(
         DeterministicTest.hasReachedRound(Round.of(numRounds)),

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/RandomChannelOrderResponsiveTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus/RandomChannelOrderResponsiveTest.java
@@ -79,7 +79,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.MockedMempoolConfig;
 import com.radixdlt.monitoring.Metrics;
 import java.util.List;
 import java.util.Random;
@@ -106,11 +105,10 @@ public class RandomChannelOrderResponsiveTest {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(),
                     LedgerConfig.stateComputerNoSync(
-                        StateComputerConfig.mockedNoEpochs(
-                            numValidatorNodes,
-                            MockedMempoolConfig.noMempool(),
-                            StateComputerConfig.ProposerElectionMode
-                                .WITH_ROTATE_ONCE_BUT_NO_SHUFFLE))));
+                        StateComputerConfig.mockedNoEpochs(numValidatorNodes)
+                            .withProposerElection(
+                                StateComputerConfig.ProposerElectionMode
+                                    .WITH_ROTATE_ONCE_BUT_NO_SHUFFLE))));
 
     test.startAllNodes();
     test.runUntilMessage(

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus_ledger_epochs/MovingWindowValidatorsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/consensus_ledger_epochs/MovingWindowValidatorsTest.java
@@ -96,7 +96,7 @@ public class MovingWindowValidatorsTest {
             .map(index -> (int) (epoch - 1 + index) % totalValidatorCount);
   }
 
-  private void run(int numNodes, int windowSize, int maxEpoch, Round epochMaxRound) {
+  private void run(int numNodes, int windowSize, int maxEpoch, int epochMaxRound) {
     DeterministicTest bftTest =
         DeterministicTest.builder()
             .addPhysicalNodes(PhysicalNodeConfig.createBatchWithFakeAddresses(numNodes))
@@ -112,13 +112,12 @@ public class MovingWindowValidatorsTest {
                         StateComputerConfig.mockedWithEpochs(
                             epochMaxRound,
                             EpochNodeWeightMapping.constant(
-                                windowedEpochToNodesMapper(windowSize, numNodes)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))));
+                                windowedEpochToNodesMapper(windowSize, numNodes))))));
 
     bftTest.startAllNodes();
     bftTest.runUntilMessage(
-        DeterministicTest.hasReachedEpochRound(EpochRound.of(maxEpoch, epochMaxRound)),
-        maxEpoch * ((int) epochMaxRound.number()) * numNodes * numNodes * 10);
+        DeterministicTest.hasReachedEpochRound(EpochRound.of(maxEpoch, Round.of(epochMaxRound))),
+        maxEpoch * epochMaxRound * numNodes * numNodes * 10);
 
     LinkedList<Metrics> testCounters = metrics(bftTest);
     assertThat(testCounters)
@@ -128,7 +127,7 @@ public class MovingWindowValidatorsTest {
         .extracting(sc -> (long) sc.bft().pacemaker().timeoutsSent().get())
         .containsOnly(0L);
 
-    long maxCount = maxProcessedFor(numNodes, windowSize, maxEpoch, epochMaxRound.number());
+    long maxCount = maxProcessedFor(numNodes, windowSize, maxEpoch, epochMaxRound);
 
     assertThat(testCounters)
         .extracting(sc -> (long) sc.bft().committedVertices().getSum())
@@ -161,25 +160,25 @@ public class MovingWindowValidatorsTest {
   @Test
   public void
       given_correct_1_node_bft_with_4_total_nodes_with_changing_epochs_per_100_rounds__then_should_pass_bft_and_postconditions() {
-    run(4, 1, 100, Round.of(100));
+    run(4, 1, 100, 100);
   }
 
   @Test
   public void
       given_correct_3_node_bft_with_4_total_nodes_with_changing_epochs_per_100_rounds__then_should_pass_bft_and_postconditions() {
-    run(4, 3, 120, Round.of(100));
+    run(4, 3, 120, 100);
   }
 
   @Test
   public void
       given_correct_25_node_bft_with_50_total_nodes_with_changing_epochs_per_100_rounds__then_should_pass_bft_and_postconditions() {
-    run(50, 25, 100, Round.of(100));
+    run(50, 25, 100, 100);
   }
 
   @Test
   public void
       given_correct_25_node_bft_with_100_total_nodes_with_changing_epochs_per_1_round__then_should_pass_bft_and_postconditions() {
-    run(100, 25, 100, Round.of(1));
+    run(100, 25, 100, 1);
   }
 
   private static long maxProcessedFor(

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/ledger_sync/FullNodeSyncTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/ledger_sync/FullNodeSyncTest.java
@@ -70,7 +70,6 @@ import static com.radixdlt.harness.predicates.NodePredicate.atOrOverStateVersion
 import static com.radixdlt.harness.predicates.NodesPredicate.*;
 
 import com.radixdlt.consensus.EpochNodeWeightMapping;
-import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.harness.deterministic.DeterministicTest;
 import com.radixdlt.harness.deterministic.PhysicalNodeConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule;
@@ -83,7 +82,7 @@ import org.junit.Test;
 
 public class FullNodeSyncTest {
   private static DeterministicTest createTest(
-      int numValidators, int numFullNodes, Round epochMaxRound) {
+      int numValidators, int numFullNodes, int epochMaxRound) {
     final var syncConfig =
         new SyncRelayConfig(
             500L,
@@ -104,8 +103,8 @@ public class FullNodeSyncTest {
                 LedgerConfig.stateComputerWithSyncRelay(
                     StateComputerConfig.mockedWithEpochs(
                         epochMaxRound,
-                        EpochNodeWeightMapping.constant(epoch -> IntStream.range(0, numValidators)),
-                        new StateComputerConfig.MockedMempoolConfig.NoMempool()),
+                        EpochNodeWeightMapping.constant(
+                            epoch -> IntStream.range(0, numValidators))),
                     syncConfig)));
   }
 
@@ -132,21 +131,21 @@ public class FullNodeSyncTest {
 
   @Test
   public void test_5_validators_and_1_full_node() {
-    try (var test = createTest(5, 1, Round.of(100))) {
+    try (var test = createTest(5, 1, 100)) {
       run(test, 5, 100L);
     }
   }
 
   @Test
   public void test_3_validators_and_2_full_nodes() {
-    try (var test = createTest(3, 2, Round.of(100))) {
+    try (var test = createTest(3, 2, 100)) {
       run(test, 3, 101L);
     }
   }
 
   @Test
   public void test_4_validators_and_50_full_nodes_and_two_rounds_per_epoch() {
-    try (var test = createTest(4, 50, Round.of(2))) {
+    try (var test = createTest(4, 50, 2)) {
       run(test, 4, 100L);
     }
   }

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/IncreasingValidatorsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/IncreasingValidatorsTest.java
@@ -91,7 +91,6 @@ import com.radixdlt.mempool.MempoolRelayerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.*;
 import com.radixdlt.sync.SyncRelayConfig;
 import com.radixdlt.transactions.RawNotarizedTransaction;
@@ -119,15 +118,17 @@ public final class IncreasingValidatorsTest {
                 FunctionalRadixNodeModule.SafetyRecoveryConfig.BERKELEY_DB,
                 FunctionalRadixNodeModule.ConsensusConfig.of(1000),
                 FunctionalRadixNodeModule.LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.defaults()
-                            .withReceiverConfig(new MempoolReceiverConfig(5))
-                            .withRelayerConfig(MempoolRelayerConfig.defaults().withMaxPeers(5))),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.Mempool.defaults()
+                                .withReceiverConfig(new MempoolReceiverConfig(5))
+                                .withRelayerConfig(
+                                    MempoolRelayerConfig.defaults().withMaxPeers(5))),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/RandomValidatorsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/RandomValidatorsTest.java
@@ -85,7 +85,6 @@ import com.radixdlt.mempool.MempoolReceiverConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.*;
 import com.radixdlt.sync.SyncRelayConfig;
 import com.radixdlt.testutil.TestStateReader;
@@ -122,11 +121,11 @@ public final class RandomValidatorsTest {
                 FunctionalRadixNodeModule.SafetyRecoveryConfig.BERKELEY_DB,
                 FunctionalRadixNodeModule.ConsensusConfig.of(1000),
                 FunctionalRadixNodeModule.LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GENESIS,
-                        StateComputerConfig.REV2ProposerConfig.Mempool.defaults()
-                            .withReceiverConfig(MempoolReceiverConfig.of(5))),
+                    StateComputerConfig.rev2()
+                        .withGenesis(GENESIS)
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.Mempool.defaults()
+                                .withReceiverConfig(MempoolReceiverConfig.of(5))),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/RandomVoteDropperTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/RandomVoteDropperTest.java
@@ -80,7 +80,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule;
 import com.radixdlt.modules.FunctionalRadixNodeModule.*;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.sync.SyncRelayConfig;
 import org.junit.Rule;
@@ -104,14 +103,15 @@ public final class RandomVoteDropperTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            10,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.defaults()
-                            .withReceiverConfig(MempoolReceiverConfig.of(5))),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                10,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.Mempool.defaults()
+                                .withReceiverConfig(MempoolReceiverConfig.of(5))),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/SanityTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/SanityTest.java
@@ -81,8 +81,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.sync.SyncRelayConfig;
@@ -132,14 +130,13 @@ public final class SanityTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            10,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
-                                roundsPerEpoch)),
-                        REV2ProposerConfig.Mempool.defaults()),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                10,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    roundsPerEpoch))),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger/MultiNodeRecoveryTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger/MultiNodeRecoveryTest.java
@@ -80,7 +80,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import java.util.Collection;
@@ -138,15 +137,16 @@ public final class MultiNodeRecoveryTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            NUM_VALIDATORS,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
-                                this.roundsPerEpoch)),
-                        StateComputerConfig.REV2ProposerConfig.transactionGenerator(
-                            new REV2TransactionGenerator(), 1)))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                NUM_VALIDATORS,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    roundsPerEpoch)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.transactionGenerator(
+                                new REV2TransactionGenerator(), 1)))));
   }
 
   @Test

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/MultiNodeRebootTest.java
@@ -69,7 +69,6 @@ import static com.radixdlt.harness.deterministic.invariants.DeterministicMonitor
 import static org.assertj.core.api.Assertions.*;
 
 import com.google.inject.Module;
-import com.radixdlt.environment.DatabaseConfig;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.harness.deterministic.DeterministicTest;
@@ -82,8 +81,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
-import com.radixdlt.protocol.ProtocolConfig;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.rev2.modules.MockedVertexStoreModule;
@@ -212,20 +209,18 @@ public final class MultiNodeRebootTest {
             safetyRecoveryConfig,
             ConsensusConfig.of(1000, 0L),
             LedgerConfig.stateComputerWithSyncRelay(
-                StateComputerConfig.rev2(
-                    Network.INTEGRATIONTESTNET.getId(),
-                    GenesisBuilder.createTestGenesisWithNumValidators(
-                        numValidators,
-                        Decimal.ONE,
-                        GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
-                                this.roundsPerEpoch)
-                            .totalEmissionXrdPerEpoch(Decimal.ofNonNegative(0))),
-                    new DatabaseConfig(true, false, false, false),
-                    StateComputerConfig.REV2ProposerConfig.transactionGenerator(
-                        new REV2TransactionGenerator(), 1),
-                    false,
-                    noFees,
-                    ProtocolConfig.testingDefault()),
+                StateComputerConfig.rev2()
+                    .withGenesis(
+                        GenesisBuilder.createTestGenesisWithNumValidators(
+                            numValidators,
+                            Decimal.ONE,
+                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    this.roundsPerEpoch)
+                                .totalEmissionXrdPerEpoch(Decimal.ofNonNegative(0))))
+                    .withProposerConfig(
+                        StateComputerConfig.REV2ProposerConfig.transactionGenerator(
+                            new REV2TransactionGenerator(), 1))
+                    .withNoFees(noFees),
                 // This test can, in some cases, rely on ledger sync
                 // requests timing out in reasonable time,
                 // so setting the request timeout to 100 ms

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/SimpleFuzzerTransactionsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/deterministic/rev2/consensus_ledger_sync/SimpleFuzzerTransactionsTest.java
@@ -79,7 +79,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
 import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.NetworkDefinition;
 import com.radixdlt.rev2.REv2SimpleFuzzerTransactionGenerator;
@@ -106,13 +105,14 @@ public final class SimpleFuzzerTransactionsTest {
                 SafetyRecoveryConfig.MOCKED,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            10,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                        REV2ProposerConfig.transactionGenerator(transactionGenerator, 10)),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                10,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)))
+                        .withProposerConfig(
+                            REV2ProposerConfig.transactionGenerator(transactionGenerator, 10)),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger/TimeoutPreviousVoteWithDroppedProposalsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger/TimeoutPreviousVoteWithDroppedProposalsTest.java
@@ -112,9 +112,7 @@ public class TimeoutPreviousVoteWithDroppedProposalsTest {
                   false,
                   SafetyRecoveryConfig.MOCKED,
                   ConsensusConfig.of(1000L),
-                  LedgerConfig.stateComputerNoSync(
-                      StateComputerConfig.mockedNoEpochs(
-                          3, new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                  LedgerConfig.stateComputerNoSync(StateComputerConfig.mockedNoEpochs(3))))
           .addTestModules(
               ConsensusMonitors.safety(),
               LedgerMonitors.consensusToLedger(),

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/MovingWindowValidatorsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/MovingWindowValidatorsTest.java
@@ -114,9 +114,8 @@ public class MovingWindowValidatorsTest {
                     ConsensusConfig.of(5000),
                     LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(100),
-                            EpochNodeWeightMapping.constant(windowedEpochToNodesMapper(1, 4)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                            100,
+                            EpochNodeWeightMapping.constant(windowedEpochToNodesMapper(1, 4))))))
             .addTestModules(
                 ConsensusMonitors.liveness(5, TimeUnit.SECONDS),
                 ConsensusMonitors.epochMaxRound(Round.of(100)))
@@ -139,9 +138,8 @@ public class MovingWindowValidatorsTest {
                     ConsensusConfig.of(1000),
                     LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(100),
-                            EpochNodeWeightMapping.constant(windowedEpochToNodesMapper(3, 4)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                            100,
+                            EpochNodeWeightMapping.constant(windowedEpochToNodesMapper(3, 4))))))
             .addTestModules(
                 ConsensusMonitors.liveness(1, TimeUnit.SECONDS),
                 ConsensusMonitors.epochMaxRound(Round.of(100)))
@@ -164,9 +162,8 @@ public class MovingWindowValidatorsTest {
                     ConsensusConfig.of(5000),
                     LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(100),
-                            EpochNodeWeightMapping.constant(windowedEpochToNodesMapper(25, 50)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                            100,
+                            EpochNodeWeightMapping.constant(windowedEpochToNodesMapper(25, 50))))))
             .addTestModules(
                 ConsensusMonitors.liveness(
                     5, TimeUnit.SECONDS), // High timeout to make Travis happy
@@ -191,9 +188,8 @@ public class MovingWindowValidatorsTest {
                     ConsensusConfig.of(5000),
                     LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(1),
-                            EpochNodeWeightMapping.constant(windowedEpochToNodesMapper(25, 50)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                            1,
+                            EpochNodeWeightMapping.constant(windowedEpochToNodesMapper(25, 50))))))
             .addTestModules(
                 ConsensusMonitors.epochMaxRound(Round.of(1)),
                 ConsensusMonitors.liveness(5, TimeUnit.SECONDS) // High timeout to make Travis happy

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/OneNodeNeverSendEpochResponseTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/OneNodeNeverSendEpochResponseTest.java
@@ -67,7 +67,6 @@ package com.radixdlt.integration.steady_state.simulation.consensus_ledger_epochs
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.radixdlt.consensus.EpochNodeWeightMapping;
-import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.harness.simulation.NetworkDroppers;
 import com.radixdlt.harness.simulation.NetworkLatencies;
 import com.radixdlt.harness.simulation.NetworkOrdering;
@@ -112,9 +111,7 @@ public class OneNodeNeverSendEpochResponseTest {
                   ConsensusConfig.of(1000),
                   FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                       StateComputerConfig.mockedWithEpochs(
-                          Round.of(4),
-                          EpochNodeWeightMapping.constant(randomEpochToNodesMapper()),
-                          new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                          4, EpochNodeWeightMapping.constant(randomEpochToNodesMapper())))))
           .addTestModules(
               ConsensusMonitors.safety(),
               ConsensusMonitors.liveness(5, TimeUnit.SECONDS),

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/ProposerTimestampInaccurateClockAndLeaderDownTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/ProposerTimestampInaccurateClockAndLeaderDownTest.java
@@ -131,10 +131,9 @@ public final class ProposerTimestampInaccurateClockAndLeaderDownTest {
                     ConsensusConfig.of(1000, 0L),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(10),
+                            10,
                             EpochNodeWeightMapping.constant(
-                                e -> IntStream.range(0, NUM_VALIDATORS)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))));
+                                e -> IntStream.range(0, NUM_VALIDATORS))))));
 
     // One node has an inaccurate clock: 10s rushing
     // A little "hack" with AtomicReference to get the lucky node's key out of the closure

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/ProposerTimestampSanityTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/ProposerTimestampSanityTest.java
@@ -71,7 +71,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.radixdlt.consensus.EpochNodeWeightMapping;
-import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.harness.simulation.NetworkLatencies;
 import com.radixdlt.harness.simulation.NetworkOrdering;
 import com.radixdlt.harness.simulation.SimulationTest;
@@ -110,9 +109,7 @@ public final class ProposerTimestampSanityTest {
                     ConsensusConfig.of(1000),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(10),
-                            EpochNodeWeightMapping.constant(e -> IntStream.range(0, 4)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))));
+                            10, EpochNodeWeightMapping.constant(e -> IntStream.range(0, 4))))));
 
     /* One node delayed */
     modifyNthNodeTimeSupplier(0, () -> System.currentTimeMillis() - 4000, builder);
@@ -143,9 +140,7 @@ public final class ProposerTimestampSanityTest {
                     ConsensusConfig.of(1000),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(10),
-                            EpochNodeWeightMapping.constant(e -> IntStream.range(0, 4)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))));
+                            10, EpochNodeWeightMapping.constant(e -> IntStream.range(0, 4))))));
 
     /* One node rushing within acceptable bounds */
     modifyNthNodeTimeSupplier(0, () -> System.currentTimeMillis() + 500, builder);
@@ -176,10 +171,9 @@ public final class ProposerTimestampSanityTest {
                     ConsensusConfig.of(1000),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(10),
-                            EpochNodeWeightMapping.constant(e -> IntStream.range(0, 4)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool(),
-                            StateComputerConfig.ProposerElectionMode.ONLY_WEIGHTED_BY_STAKE))));
+                                10, EpochNodeWeightMapping.constant(e -> IntStream.range(0, 4)))
+                            .withProposerElection(
+                                StateComputerConfig.ProposerElectionMode.ONLY_WEIGHTED_BY_STAKE))));
 
     /* One node rushing */
     modifyNthNodeTimeSupplier(0, () -> System.currentTimeMillis() - 4000, builder);

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/RandomValidatorsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/RandomValidatorsTest.java
@@ -143,9 +143,7 @@ public class RandomValidatorsTest {
                     ConsensusConfig.of(5000),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(100),
-                            EpochNodeWeightMapping.constant(goodRandomEpochToNodesMapper()),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                            100, EpochNodeWeightMapping.constant(goodRandomEpochToNodesMapper())))))
             .build();
 
     final var checkResults = bftTest.run().awaitCompletion();
@@ -165,9 +163,7 @@ public class RandomValidatorsTest {
                     ConsensusConfig.of(5000),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(100),
-                            EpochNodeWeightMapping.constant(badRandomEpochToNodesMapper()),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                            100, EpochNodeWeightMapping.constant(badRandomEpochToNodesMapper())))))
             .build();
 
     final var checkResults = bftTest.run().awaitCompletion();

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/StaticValidatorsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_epochs/StaticValidatorsTest.java
@@ -96,7 +96,7 @@ public class StaticValidatorsTest {
               LedgerMonitors.ordered());
 
   private Map<Monitor, Optional<TestInvariant.TestInvariantError>> runTest(
-      long epochRounds, long epochRoundsCheck) {
+      int epochRounds, long epochRoundsCheck) {
     SimulationTest bftTest =
         bftTestBuilder
             .functionalNodeModule(
@@ -107,9 +107,8 @@ public class StaticValidatorsTest {
                     ConsensusConfig.of(1000),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                         StateComputerConfig.mockedWithEpochs(
-                            Round.of(epochRounds),
-                            EpochNodeWeightMapping.constant(e -> IntStream.range(0, 4)),
-                            new StateComputerConfig.MockedMempoolConfig.NoMempool()))))
+                            epochRounds,
+                            EpochNodeWeightMapping.constant(e -> IntStream.range(0, 4))))))
             .addTestModules(ConsensusMonitors.epochMaxRound(Round.of(epochRoundsCheck)))
             .build();
     return bftTest.run().awaitCompletion();

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_sync/FallBehindMultipleEpochsLedgerSyncTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_sync/FallBehindMultipleEpochsLedgerSyncTest.java
@@ -104,7 +104,7 @@ public class FallBehindMultipleEpochsLedgerSyncTest {
             .networkModules(NetworkOrdering.inOrder(), NetworkLatencies.fixed(10))
             .ledgerAndEpochsAndSync(
                 ConsensusConfig.of(3000),
-                Round.of(10),
+                10,
                 (unused) -> IntStream.of(0, 1),
                 SyncRelayConfig.of(200L, 10, 2000L))
             .addTestModules(

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_sync_epochs/FullNodeSyncingWithAnotherFullNodeTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_sync_epochs/FullNodeSyncingWithAnotherFullNodeTest.java
@@ -129,7 +129,7 @@ public class FullNodeSyncingWithAnotherFullNodeTest {
             .networkModules(NetworkOrdering.inOrder(), NetworkLatencies.fixed(10))
             .ledgerAndEpochsAndSync(
                 ConsensusConfig.of(3000),
-                Round.of(100),
+                100,
                 (unused) -> VALIDATORS_INDICES.stream().mapToInt(i -> i),
                 new SyncRelayConfig(1000L, 10, 500L, 10, Long.MAX_VALUE))
             .addTestModules(

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_sync_epochs/OneNodeFallingBehindTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_sync_epochs/OneNodeFallingBehindTest.java
@@ -66,7 +66,6 @@ package com.radixdlt.integration.steady_state.simulation.consensus_ledger_sync_e
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.harness.simulation.NetworkDroppers;
 import com.radixdlt.harness.simulation.NetworkLatencies;
 import com.radixdlt.harness.simulation.NetworkOrdering;
@@ -99,10 +98,7 @@ public class OneNodeFallingBehindTest {
               NetworkLatencies.fixed(),
               NetworkDroppers.dropAllMessagesForOneNode(10000, 10000))
           .ledgerAndEpochsAndSync(
-              ConsensusConfig.of(3000),
-              Round.of(100),
-              epoch -> IntStream.range(0, 10),
-              syncRelayConfig)
+              ConsensusConfig.of(3000), 100, epoch -> IntStream.range(0, 10), syncRelayConfig)
           .addTestModules(
               ConsensusMonitors.safety(),
               ConsensusMonitors.liveness(30, TimeUnit.SECONDS),

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_sync_epochs/RandomValidatorsTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/consensus_ledger_sync_epochs/RandomValidatorsTest.java
@@ -93,7 +93,7 @@ public class RandomValidatorsTest {
           .networkModules(NetworkOrdering.inOrder(), NetworkLatencies.fixed())
           .ledgerAndEpochsAndSync(
               ConsensusConfig.of(5000),
-              Round.of(3),
+              3,
               goodRandomEpochToNodesMapper(),
               syncRelayConfig) // TODO: investigate why this fails with Round.of(10)
           .numPhysicalNodes(numNodes)

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/rev2/consensus_mempool_ledger/SanityTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/rev2/consensus_mempool_ledger/SanityTest.java
@@ -80,8 +80,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import java.util.concurrent.TimeUnit;
@@ -104,13 +102,13 @@ public class SanityTest {
                 SafetyRecoveryConfig.MOCKED,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            4,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(100000)),
-                        REV2ProposerConfig.Mempool.defaults()))))
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                4,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    100000))))))
         .addTestModules(
             ConsensusMonitors.safety(),
             ConsensusMonitors.proposerTimestampChecker(),

--- a/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/rev2/consensus_mempool_ledger_sync/SanityTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/steady_state/simulation/rev2/consensus_mempool_ledger_sync/SanityTest.java
@@ -80,8 +80,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.sync.SyncRelayConfig;
@@ -105,13 +103,13 @@ public class SanityTest {
                 SafetyRecoveryConfig.MOCKED,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            4,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(100000)),
-                        REV2ProposerConfig.Mempool.defaults()),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                4,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    100000))),
                     SyncRelayConfig.of(5000, 10, 3000L))))
         .addTestModules(
             ConsensusMonitors.safety(),

--- a/core/src/integration/java/com/radixdlt/integration/targeted/consensus/DelayAfterFormingTcAndFormAQcTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/consensus/DelayAfterFormingTcAndFormAQcTest.java
@@ -130,9 +130,7 @@ public final class DelayAfterFormingTcAndFormAQcTest {
                 ConsensusConfig.of(),
                 LedgerConfig.stateComputerMockedSync(
                     StateComputerConfig.mockedWithEpochs(
-                        Round.of(10000),
-                        EpochNodeWeightMapping.constant(4),
-                        new StateComputerConfig.MockedMempoolConfig.NoMempool()))));
+                        10000, EpochNodeWeightMapping.constant(4)))));
   }
 
   private MessageSelector prioritizeVotesFrom(int nodeIdx) {

--- a/core/src/integration/java/com/radixdlt/integration/targeted/consensus/EpochTimeoutCertTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/consensus/EpochTimeoutCertTest.java
@@ -68,7 +68,6 @@ import static com.radixdlt.harness.deterministic.invariants.DeterministicMonitor
 
 import com.radixdlt.consensus.EpochNodeWeightMapping;
 import com.radixdlt.consensus.Proposal;
-import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.environment.deterministic.network.ControlledMessage;
 import com.radixdlt.environment.deterministic.network.MessageSelector;
 import com.radixdlt.harness.deterministic.DeterministicTest;
@@ -87,7 +86,7 @@ import org.junit.Test;
  */
 public final class EpochTimeoutCertTest {
 
-  private static final long ROUNDS_PER_EPOCH = 100;
+  private static final int ROUNDS_PER_EPOCH = 100;
   private static final int NUM_NODES = 4;
 
   private DeterministicTest createTest() {
@@ -113,9 +112,7 @@ public final class EpochTimeoutCertTest {
                 FunctionalRadixNodeModule.ConsensusConfig.of(),
                 FunctionalRadixNodeModule.LedgerConfig.stateComputerNoSync(
                     StateComputerConfig.mockedWithEpochs(
-                        Round.of(ROUNDS_PER_EPOCH),
-                        EpochNodeWeightMapping.constant(NUM_NODES),
-                        new StateComputerConfig.MockedMempoolConfig.NoMempool()))));
+                        ROUNDS_PER_EPOCH, EpochNodeWeightMapping.constant(NUM_NODES)))));
   }
 
   public static Predicate<Timed<ControlledMessage>> proposalAtRound(long round) {

--- a/core/src/integration/java/com/radixdlt/integration/targeted/consensus/PacemakerRoundProlongationTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/consensus/PacemakerRoundProlongationTest.java
@@ -70,7 +70,6 @@ import com.radixdlt.consensus.EpochNodeWeightMapping;
 import com.radixdlt.consensus.Proposal;
 import com.radixdlt.consensus.Vote;
 import com.radixdlt.consensus.bft.BFTInsertUpdate;
-import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.environment.deterministic.network.MessageMutator;
 import com.radixdlt.environment.deterministic.network.MessageSelector;
 import com.radixdlt.harness.deterministic.DeterministicTest;
@@ -101,9 +100,7 @@ public final class PacemakerRoundProlongationTest {
                 ConsensusConfig.of(PACEMAKER_BASE_TIMEOUT_MS, ADDITIONAL_TIME_MS),
                 LedgerConfig.stateComputerMockedSync(
                     StateComputerConfig.mockedWithEpochs(
-                        Round.of(10000),
-                        EpochNodeWeightMapping.constant(1),
-                        new StateComputerConfig.MockedMempoolConfig.NoMempool()))));
+                        10000, EpochNodeWeightMapping.constant(1)))));
   }
 
   // spotless:off

--- a/core/src/integration/java/com/radixdlt/integration/targeted/consensus/ProcessCachedEventsWithTimeoutCertTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/consensus/ProcessCachedEventsWithTimeoutCertTest.java
@@ -110,9 +110,7 @@ public class ProcessCachedEventsWithTimeoutCertTest {
                 FunctionalRadixNodeModule.ConsensusConfig.of(),
                 FunctionalRadixNodeModule.LedgerConfig.stateComputerMockedSync(
                     StateComputerConfig.mockedWithEpochs(
-                        Round.of(100),
-                        EpochNodeWeightMapping.constant(5),
-                        new StateComputerConfig.MockedMempoolConfig.NoMempool()))));
+                        100, EpochNodeWeightMapping.constant(5)))));
   }
 
   @Test

--- a/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolFillAndEmptyTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolFillAndEmptyTest.java
@@ -83,7 +83,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.sync.SyncRelayConfig;
@@ -121,17 +120,20 @@ public final class REv2MempoolFillAndEmptyTest {
                 SafetyRecoveryConfig.MOCKED,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(100000)),
-                        StateComputerConfig.REV2ProposerConfig.mempool(
-                            ProposalLimitsConfig.testDefaults(),
-                            new RustMempoolConfig(100 * 1024 * 1024, MAX_MEMPOOL_TRANSACTION_COUNT),
-                            new MempoolReceiverConfig(0),
-                            MempoolRelayerConfig.defaults())),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    100000)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.mempool(
+                                ProposalLimitsConfig.testDefaults(),
+                                new RustMempoolConfig(
+                                    100 * 1024 * 1024, MAX_MEMPOOL_TRANSACTION_COUNT),
+                                new MempoolReceiverConfig(0),
+                                MempoolRelayerConfig.defaults())),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolRelayerTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/rev2/mempool/REv2MempoolRelayerTest.java
@@ -82,7 +82,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.sync.SyncRelayConfig;
@@ -109,17 +108,20 @@ public final class REv2MempoolRelayerTest {
                 SafetyRecoveryConfig.MOCKED,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(100000)),
-                        StateComputerConfig.REV2ProposerConfig.mempool(
-                            ProposalLimitsConfig.zero(),
-                            new RustMempoolConfig(MEMPOOL_TX_SIZE * 1024 * 1024, MEMPOOL_TX_SIZE),
-                            new MempoolReceiverConfig(0),
-                            MempoolRelayerConfig.defaults())),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    100000)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.mempool(
+                                ProposalLimitsConfig.zero(),
+                                new RustMempoolConfig(
+                                    MEMPOOL_TX_SIZE * 1024 * 1024, MEMPOOL_TX_SIZE),
+                                new MempoolReceiverConfig(0),
+                                MempoolRelayerConfig.defaults())),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/integration/java/com/radixdlt/integration/targeted/rev2/recovery/RecoveryAfterTimeoutQuorumTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/rev2/recovery/RecoveryAfterTimeoutQuorumTest.java
@@ -87,7 +87,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.sync.SyncRelayConfig;
@@ -120,14 +119,15 @@ public final class RecoveryAfterTimeoutQuorumTest {
             SafetyRecoveryConfig.BERKELEY_DB,
             ConsensusConfig.of(1000),
             LedgerConfig.stateComputerWithSyncRelay(
-                StateComputerConfig.rev2(
-                    Network.INTEGRATIONTESTNET.getId(),
-                    GenesisBuilder.createTestGenesisWithNumValidators(
-                        NUM_VALIDATORS,
-                        Decimal.ONE,
-                        GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                    StateComputerConfig.REV2ProposerConfig.transactionGenerator(
-                        new REV2TransactionGenerator(), 1)),
+                StateComputerConfig.rev2()
+                    .withGenesis(
+                        GenesisBuilder.createTestGenesisWithNumValidators(
+                            NUM_VALIDATORS,
+                            Decimal.ONE,
+                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)))
+                    .withProposerConfig(
+                        StateComputerConfig.REV2ProposerConfig.transactionGenerator(
+                            new REV2TransactionGenerator(), 1)),
                 SyncRelayConfig.of(5000, 10, 5000L)));
 
     try (var test = builder.functionalNodeModule(functionalNodeModule)) {

--- a/core/src/integration/java/com/radixdlt/integration/targeted/rev2/storage/TransactionDBSizeStressTest.java
+++ b/core/src/integration/java/com/radixdlt/integration/targeted/rev2/storage/TransactionDBSizeStressTest.java
@@ -79,7 +79,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
 import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.NetworkDefinition;
 import com.radixdlt.rev2.REv2LargeTransactionGenerator;
@@ -110,15 +109,16 @@ public final class TransactionDBSizeStressTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                        REV2ProposerConfig.transactionGenerator(
-                            new REv2LargeTransactionGenerator(NetworkDefinition.INT_TEST_NET),
-                            1)))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)))
+                        .withProposerConfig(
+                            REV2ProposerConfig.transactionGenerator(
+                                new REv2LargeTransactionGenerator(NetworkDefinition.INT_TEST_NET),
+                                1)))));
   }
 
   @Test

--- a/core/src/test-core/java/com/radixdlt/harness/simulation/SimulationTest.java
+++ b/core/src/test-core/java/com/radixdlt/harness/simulation/SimulationTest.java
@@ -261,15 +261,13 @@ public final class SimulationTest {
               SafetyRecoveryConfig.MOCKED,
               consensusConfig,
               LedgerConfig.stateComputerWithSyncRelay(
-                  StateComputerConfig.mockedNoEpochs(
-                      numValidators, new StateComputerConfig.MockedMempoolConfig.NoMempool()),
-                  syncRelayConfig));
+                  StateComputerConfig.mockedNoEpochs(numValidators), syncRelayConfig));
       return this;
     }
 
     public Builder ledgerAndEpochsAndSync(
         ConsensusConfig consensusConfig,
-        Round epochMaxRound,
+        int epochMaxRound,
         Function<Long, IntStream> epochToNodeIndexMapper,
         SyncRelayConfig syncRelayConfig) {
       this.functionalNodeModule =
@@ -280,9 +278,7 @@ public final class SimulationTest {
               consensusConfig,
               LedgerConfig.stateComputerWithSyncRelay(
                   StateComputerConfig.mockedWithEpochs(
-                      epochMaxRound,
-                      EpochNodeWeightMapping.constant(epochToNodeIndexMapper),
-                      new StateComputerConfig.MockedMempoolConfig.NoMempool()),
+                      epochMaxRound, EpochNodeWeightMapping.constant(epochToNodeIndexMapper)),
                   syncRelayConfig));
       return this;
     }
@@ -295,8 +291,8 @@ public final class SimulationTest {
               SafetyRecoveryConfig.MOCKED,
               consensusConfig,
               LedgerConfig.stateComputerNoSync(
-                  StateComputerConfig.mockedNoEpochs(
-                      numValidators, new StateComputerConfig.MockedMempoolConfig.LocalOnly(10))));
+                  StateComputerConfig.mockedNoEpochs(numValidators)
+                      .withMempool(new StateComputerConfig.MockedMempoolConfig.LocalOnly(10))));
       this.modules.add(MempoolReceiverConfig.of(10).asModule());
       return this;
     }

--- a/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
+++ b/core/src/test-core/java/com/radixdlt/modules/FunctionalRadixNodeModule.java
@@ -290,9 +290,7 @@ public final class FunctionalRadixNodeModule extends AbstractModule {
         false,
         SafetyRecoveryConfig.MOCKED,
         ConsensusConfig.of(),
-        LedgerConfig.stateComputerNoSync(
-            StateComputerConfig.mockedNoEpochs(
-                numValidators, new MockedMempoolConfig.NoMempool())));
+        LedgerConfig.stateComputerNoSync(StateComputerConfig.mockedNoEpochs(numValidators)));
   }
 
   public boolean supportsEpochs() {

--- a/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
+++ b/core/src/test-core/java/com/radixdlt/modules/StateComputerConfig.java
@@ -81,6 +81,7 @@ import com.radixdlt.harness.simulation.application.TransactionGenerator;
 import com.radixdlt.mempool.MempoolReceiverConfig;
 import com.radixdlt.mempool.MempoolRelayerConfig;
 import com.radixdlt.mempool.RustMempoolConfig;
+import com.radixdlt.networks.Network;
 import com.radixdlt.protocol.ProtocolConfig;
 import com.radixdlt.transaction.LedgerSyncLimitsConfig;
 import com.radixdlt.transactions.RawNotarizedTransaction;
@@ -90,106 +91,29 @@ import java.util.stream.Stream;
 
 /** Configuration options for the state computer */
 public sealed interface StateComputerConfig {
-  static StateComputerConfig mockedWithEpochs(
-      Round epochMaxRound, EpochNodeWeightMapping mapping, MockedMempoolConfig mempoolType) {
-    return mockedWithEpochs(epochMaxRound, mapping, LedgerHashes.zero(), mempoolType);
-  }
-
-  static StateComputerConfig mockedWithEpochs(
-      Round epochMaxRound,
-      EpochNodeWeightMapping mapping,
-      MockedMempoolConfig mempoolType,
-      ProposerElectionMode proposerElectionMode) {
-    return mockedWithEpochs(
-        epochMaxRound, mapping, LedgerHashes.zero(), mempoolType, proposerElectionMode);
-  }
-
-  static StateComputerConfig mockedWithEpochs(
-      Round epochMaxRound,
-      EpochNodeWeightMapping mapping,
-      LedgerHashes preGenesisLedgerHashes,
-      MockedMempoolConfig mempoolType) {
-    return mockedWithEpochs(
-        epochMaxRound,
+  static MockedStateComputerConfig mockedWithEpochs(
+      int epochMaxRound, EpochNodeWeightMapping mapping) {
+    return new MockedStateComputerConfigWithEpochs(
+        Round.of(epochMaxRound),
         mapping,
-        preGenesisLedgerHashes,
-        mempoolType,
+        LedgerHashes.zero(),
+        new StateComputerConfig.MockedMempoolConfig.NoMempool(),
         ProposerElectionMode.WITH_DEFAULT_ROTATION);
   }
 
-  static StateComputerConfig mockedWithEpochs(
-      Round epochMaxRound,
-      EpochNodeWeightMapping mapping,
-      LedgerHashes preGenesisLedgerHashes,
-      MockedMempoolConfig mempoolType,
-      ProposerElectionMode proposerElectionMode) {
-    return new MockedStateComputerConfigWithEpochs(
-        epochMaxRound, mapping, preGenesisLedgerHashes, mempoolType, proposerElectionMode);
-  }
-
-  static StateComputerConfig mockedNoEpochs(int numValidators, MockedMempoolConfig mempoolType) {
+  static MockedStateComputerConfig mockedNoEpochs(int numValidators) {
     return new MockedStateComputerConfigNoEpochs(
-        numValidators, mempoolType, ProposerElectionMode.WITH_DEFAULT_ROTATION);
+        numValidators,
+        new StateComputerConfig.MockedMempoolConfig.NoMempool(),
+        ProposerElectionMode.WITH_DEFAULT_ROTATION);
   }
 
-  static StateComputerConfig mockedNoEpochs(
-      int numValidators,
-      MockedMempoolConfig mempoolType,
-      ProposerElectionMode proposerElectionMode) {
-    return new MockedStateComputerConfigNoEpochs(numValidators, mempoolType, proposerElectionMode);
-  }
-
-  static StateComputerConfig rev2(
-      int networkId,
-      GenesisData genesis,
-      DatabaseConfig databaseConfig,
-      REV2ProposerConfig proposerConfig,
-      boolean debugLogging,
-      boolean noFees,
-      ProtocolConfig protocolConfig) {
-    return rev2(
-        networkId,
-        genesis,
-        databaseConfig,
-        proposerConfig,
-        debugLogging,
-        noFees,
-        protocolConfig,
-        StateTreeGcConfig.forTesting());
-  }
-
-  static StateComputerConfig rev2(
-      int networkId,
-      GenesisData genesis,
-      DatabaseConfig databaseConfig,
-      REV2ProposerConfig proposerConfig,
-      boolean debugLogging,
-      boolean noFees,
-      ProtocolConfig protocolConfig,
-      StateTreeGcConfig stateTreeGcConfig) {
+  static REv2StateComputerConfig rev2() {
     return new REv2StateComputerConfig(
-        networkId,
-        genesis,
-        databaseConfig,
-        proposerConfig,
-        debugLogging,
-        stateTreeGcConfig,
-        LedgerProofsGcConfig.forTesting(),
-        LedgerSyncLimitsConfig.defaults(),
-        protocolConfig,
-        noFees);
-  }
-
-  static StateComputerConfig rev2(
-      int networkId,
-      GenesisData genesis,
-      DatabaseConfig databaseConfig,
-      REV2ProposerConfig proposerConfig) {
-    return new REv2StateComputerConfig(
-        networkId,
-        genesis,
-        databaseConfig,
-        proposerConfig,
+        Network.INTEGRATIONTESTNET.getId(),
+        GenesisData.testingDefaultEmpty(),
+        DatabaseConfig.forTesting(),
+        StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
         false,
         StateTreeGcConfig.forTesting(),
         LedgerProofsGcConfig.forTesting(),
@@ -198,33 +122,7 @@ public sealed interface StateComputerConfig {
         false);
   }
 
-  static StateComputerConfig rev2(
-      int networkId, GenesisData genesis, REV2ProposerConfig proposerConfig) {
-    return rev2(networkId, genesis, proposerConfig, ProtocolConfig.testingDefault());
-  }
-
-  static StateComputerConfig rev2(
-      int networkId,
-      GenesisData genesis,
-      REV2ProposerConfig proposerConfig,
-      ProtocolConfig protocolConfig) {
-    return new REv2StateComputerConfig(
-        networkId,
-        genesis,
-        new DatabaseConfig(true, false, false, false),
-        proposerConfig,
-        false,
-        StateTreeGcConfig.forTesting(),
-        LedgerProofsGcConfig.forTesting(),
-        LedgerSyncLimitsConfig.defaults(),
-        protocolConfig,
-        false);
-  }
-
   sealed interface MockedMempoolConfig {
-    static MockedMempoolConfig noMempool() {
-      return new NoMempool();
-    }
 
     record NoMempool() implements MockedMempoolConfig {}
 
@@ -235,6 +133,10 @@ public sealed interface StateComputerConfig {
 
   sealed interface MockedStateComputerConfig extends StateComputerConfig {
     MockedMempoolConfig mempoolConfig();
+
+    MockedStateComputerConfig withProposerElection(ProposerElectionMode mode);
+
+    MockedStateComputerConfig withMempool(MockedMempoolConfig config);
   }
 
   record MockedStateComputerConfigWithEpochs(
@@ -247,6 +149,22 @@ public sealed interface StateComputerConfig {
     @Override
     public MockedMempoolConfig mempoolConfig() {
       return mempoolType;
+    }
+
+    @Override
+    public MockedStateComputerConfig withProposerElection(ProposerElectionMode mode) {
+      return new MockedStateComputerConfigWithEpochs(
+          this.epochMaxRound, this.mapping, this.preGenesisLedgerHashes, this.mempoolType, mode);
+    }
+
+    @Override
+    public MockedStateComputerConfig withMempool(MockedMempoolConfig config) {
+      return new MockedStateComputerConfigWithEpochs(
+          this.epochMaxRound,
+          this.mapping,
+          this.preGenesisLedgerHashes,
+          config,
+          this.proposerElectionMode);
     }
   }
 
@@ -278,6 +196,17 @@ public sealed interface StateComputerConfig {
     public MockedMempoolConfig mempoolConfig() {
       return mempoolType;
     }
+
+    @Override
+    public MockedStateComputerConfig withProposerElection(ProposerElectionMode mode) {
+      return new MockedStateComputerConfigNoEpochs(this.numValidators, this.mempoolType, mode);
+    }
+
+    @Override
+    public MockedStateComputerConfig withMempool(MockedMempoolConfig config) {
+      return new MockedStateComputerConfigNoEpochs(
+          this.numValidators, config, this.proposerElectionMode);
+    }
   }
 
   record REv2StateComputerConfig(
@@ -291,7 +220,120 @@ public sealed interface StateComputerConfig {
       LedgerSyncLimitsConfig ledgerSyncLimitsConfig,
       ProtocolConfig protocolConfig,
       boolean noFees)
-      implements StateComputerConfig {}
+      implements StateComputerConfig {
+
+    public REv2StateComputerConfig withGenesis(GenesisData genesis) {
+      return new REv2StateComputerConfig(
+          this.networkId,
+          genesis,
+          this.databaseConfig,
+          this.proposerConfig,
+          this.debugLogging,
+          this.stateTreeGcConfig,
+          this.ledgerProofsGcConfig,
+          this.ledgerSyncLimitsConfig,
+          this.protocolConfig,
+          this.noFees);
+    }
+
+    public REv2StateComputerConfig withDatabaseConfig(DatabaseConfig databaseConfig) {
+      return new REv2StateComputerConfig(
+          this.networkId,
+          this.genesis,
+          databaseConfig,
+          this.proposerConfig,
+          this.debugLogging,
+          this.stateTreeGcConfig,
+          this.ledgerProofsGcConfig,
+          this.ledgerSyncLimitsConfig,
+          this.protocolConfig,
+          this.noFees);
+    }
+
+    public REv2StateComputerConfig withProposerConfig(REV2ProposerConfig proposerConfig) {
+      return new REv2StateComputerConfig(
+          this.networkId,
+          this.genesis,
+          this.databaseConfig,
+          proposerConfig,
+          this.debugLogging,
+          this.stateTreeGcConfig,
+          this.ledgerProofsGcConfig,
+          this.ledgerSyncLimitsConfig,
+          this.protocolConfig,
+          this.noFees);
+    }
+
+    public REv2StateComputerConfig withStateTreeGcConfig(StateTreeGcConfig stateTreeGc) {
+      return new REv2StateComputerConfig(
+          this.networkId,
+          this.genesis,
+          this.databaseConfig,
+          this.proposerConfig,
+          this.debugLogging,
+          stateTreeGc,
+          this.ledgerProofsGcConfig,
+          this.ledgerSyncLimitsConfig,
+          this.protocolConfig,
+          this.noFees);
+    }
+
+    public REv2StateComputerConfig withLedgerProofsGcConfig(LedgerProofsGcConfig ledgerProofsGc) {
+      return new REv2StateComputerConfig(
+          this.networkId,
+          this.genesis,
+          this.databaseConfig,
+          this.proposerConfig,
+          this.debugLogging,
+          this.stateTreeGcConfig,
+          ledgerProofsGc,
+          this.ledgerSyncLimitsConfig,
+          this.protocolConfig,
+          this.noFees);
+    }
+
+    public REv2StateComputerConfig withProtocolConfig(ProtocolConfig protocolConfig) {
+      return new REv2StateComputerConfig(
+          this.networkId,
+          this.genesis,
+          this.databaseConfig,
+          this.proposerConfig,
+          this.debugLogging,
+          this.stateTreeGcConfig,
+          this.ledgerProofsGcConfig,
+          this.ledgerSyncLimitsConfig,
+          protocolConfig,
+          this.noFees);
+    }
+
+    public REv2StateComputerConfig withLedgerSyncLimitsConfig(LedgerSyncLimitsConfig config) {
+      return new REv2StateComputerConfig(
+          this.networkId,
+          this.genesis,
+          this.databaseConfig,
+          this.proposerConfig,
+          this.debugLogging,
+          this.stateTreeGcConfig,
+          this.ledgerProofsGcConfig,
+          config,
+          this.protocolConfig,
+          this.noFees);
+    }
+
+    public REv2StateComputerConfig withNoFees(boolean noFees) {
+      return new REv2StateComputerConfig(
+          this.networkId,
+          this.genesis,
+          this.databaseConfig,
+          this.proposerConfig,
+          this.debugLogging,
+          this.stateTreeGcConfig,
+          this.ledgerProofsGcConfig,
+          this.ledgerSyncLimitsConfig,
+          this.protocolConfig,
+          noFees);
+    }
+  }
 
   sealed interface REV2ProposerConfig {
     static REV2ProposerConfig transactionGenerator(

--- a/core/src/test/java/com/radixdlt/api/DeterministicCoreApiTestBase.java
+++ b/core/src/test/java/com/radixdlt/api/DeterministicCoreApiTestBase.java
@@ -68,7 +68,6 @@ import static com.radixdlt.environment.deterministic.network.MessageSelector.fir
 import static org.assertj.core.api.Assertions.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.ClassPath;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.ProvidesIntoSet;
@@ -82,14 +81,11 @@ import com.radixdlt.environment.CoreApiServerFlags;
 import com.radixdlt.environment.StartProcessorOnRunner;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
-import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.harness.deterministic.DeterministicTest;
 import com.radixdlt.harness.deterministic.PhysicalNodeConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
-import com.radixdlt.protocol.ProtocolConfig;
 import com.radixdlt.rev2.*;
 import com.radixdlt.sync.SyncRelayConfig;
 import com.radixdlt.utils.FreePortFinder;
@@ -100,8 +96,6 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
 public abstract class DeterministicCoreApiTestBase {
-  private static final DatabaseConfig TEST_DATABASE_CONFIG =
-      new DatabaseConfig(true, false, false, false);
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
   public static NetworkDefinition networkDefinition = NetworkDefinition.INT_TEST_NET;
@@ -120,87 +114,14 @@ public abstract class DeterministicCoreApiTestBase {
     this.apiClient = buildApiClient();
   }
 
-  protected DeterministicTest buildRunningServerTest() {
-    return buildRunningServerTest(
-        1000000, TEST_DATABASE_CONFIG, GenesisData.NO_SCENARIOS, ProtocolConfig.testingDefault());
-  }
-
-  protected DeterministicTest buildRunningServerTestWithProtocolConfig(
-      int roundsPerEpoch, ProtocolConfig protocolConfig) {
-    return buildRunningServerTest(
-        roundsPerEpoch, TEST_DATABASE_CONFIG, GenesisData.NO_SCENARIOS, protocolConfig);
-  }
-
-  protected DeterministicTest buildRunningServerTestWithScenarios(ImmutableList<String> scenarios) {
-    return buildRunningServerTest(
-        1000000, TEST_DATABASE_CONFIG, scenarios, ProtocolConfig.testingDefault());
-  }
-
-  protected DeterministicTest buildRunningServerTest(DatabaseConfig databaseConfig) {
-    return buildRunningServerTest(
-        1000000, databaseConfig, GenesisData.NO_SCENARIOS, ProtocolConfig.testingDefault());
-  }
-
-  protected DeterministicTest buildRunningServerTest(
-      DatabaseConfig databaseConfig, StateTreeGcConfig stateTreeGcConfig) {
-    return buildRunningServerTest(
-        1000000,
-        databaseConfig,
-        GenesisData.NO_SCENARIOS,
-        ProtocolConfig.testingDefault(),
-        stateTreeGcConfig);
-  }
-
-  protected DeterministicTest buildRunningServerTest(int roundsPerEpoch) {
-    return buildRunningServerTest(
-        roundsPerEpoch,
-        TEST_DATABASE_CONFIG,
-        GenesisData.NO_SCENARIOS,
-        ProtocolConfig.testingDefault());
-  }
-
-  protected DeterministicTest buildRunningServerTest(
-      int roundsPerEpoch,
-      DatabaseConfig databaseConfig,
-      ImmutableList<String> scenariosToRun,
-      ProtocolConfig protocolConfig,
-      StateTreeGcConfig stateTreeGcConfig) {
-    return buildRunningServerTest(
-        StateComputerConfig.rev2(
-            Network.INTEGRATIONTESTNET.getId(),
+  protected StateComputerConfig.REv2StateComputerConfig defaultConfig() {
+    return StateComputerConfig.rev2()
+        .withGenesis(
             GenesisBuilder.createTestGenesisWithNumValidators(
                 1,
                 Decimal.ONE,
                 GenesisConsensusManagerConfig.Builder.testDefaults()
-                    .epochExactRoundCount(roundsPerEpoch),
-                scenariosToRun),
-            databaseConfig,
-            StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
-            false,
-            false,
-            protocolConfig,
-            stateTreeGcConfig));
-  }
-
-  protected DeterministicTest buildRunningServerTest(
-      int roundsPerEpoch,
-      DatabaseConfig databaseConfig,
-      ImmutableList<String> scenariosToRun,
-      ProtocolConfig protocolConfig) {
-    return buildRunningServerTest(
-        StateComputerConfig.rev2(
-            Network.INTEGRATIONTESTNET.getId(),
-            GenesisBuilder.createTestGenesisWithNumValidators(
-                1,
-                Decimal.ONE,
-                GenesisConsensusManagerConfig.Builder.testDefaults()
-                    .epochExactRoundCount(roundsPerEpoch),
-                scenariosToRun),
-            databaseConfig,
-            StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
-            false,
-            false,
-            protocolConfig));
+                    .epochExactRoundCount(1000000)));
   }
 
   protected DeterministicTest buildRunningServerTest(StateComputerConfig stateComputerConfig) {

--- a/core/src/test/java/com/radixdlt/api/DeterministicEngineStateApiTestBase.java
+++ b/core/src/test/java/com/radixdlt/api/DeterministicEngineStateApiTestBase.java
@@ -68,7 +68,6 @@ import static com.radixdlt.environment.deterministic.network.MessageSelector.fir
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.radixdlt.addressing.Addressing;
@@ -82,14 +81,11 @@ import com.radixdlt.environment.StartProcessorOnRunner;
 import com.radixdlt.environment.StateTreeGcConfig;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
-import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.harness.deterministic.DeterministicTest;
 import com.radixdlt.harness.deterministic.PhysicalNodeConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
-import com.radixdlt.protocol.ProtocolConfig;
 import com.radixdlt.rev2.*;
 import com.radixdlt.sync.SyncRelayConfig;
 import com.radixdlt.utils.FreePortFinder;
@@ -101,11 +97,6 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
 public abstract class DeterministicEngineStateApiTestBase {
-  private static final DatabaseConfig DEFAULT_DATABASE_CONFIG =
-      new DatabaseConfig(true, false, true, true);
-
-  private static final StateTreeGcConfig DEFAULT_JMT_GC_CONFIG =
-      new StateTreeGcConfig(UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(20));
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
   public static NetworkDefinition networkDefinition = NetworkDefinition.INT_TEST_NET;
@@ -124,26 +115,19 @@ public abstract class DeterministicEngineStateApiTestBase {
     this.apiClient = this.buildApiClient();
   }
 
-  protected DeterministicTest buildRunningServerTest() {
-    return buildRunningServerTest(
-        1000000, DEFAULT_DATABASE_CONFIG, DEFAULT_JMT_GC_CONFIG, GenesisData.NO_SCENARIOS);
+  protected StateComputerConfig.REv2StateComputerConfig defaultConfig() {
+    return StateComputerConfig.rev2()
+        .withGenesis(
+            GenesisBuilder.createTestGenesisWithNumValidators(
+                1,
+                Decimal.ONE,
+                GenesisConsensusManagerConfig.Builder.testDefaults().epochExactRoundCount(1000000)))
+        .withDatabaseConfig(new DatabaseConfig(true, false, true, true))
+        .withStateTreeGcConfig(
+            new StateTreeGcConfig(UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(20)));
   }
 
-  protected DeterministicTest buildRunningServerTestWithScenarios(String... scenarios) {
-    return buildRunningServerTest(
-        1000000, DEFAULT_DATABASE_CONFIG, DEFAULT_JMT_GC_CONFIG, ImmutableList.copyOf(scenarios));
-  }
-
-  protected DeterministicTest buildRunningServerTest(StateTreeGcConfig stateTreeGcConfig) {
-    return buildRunningServerTest(
-        1000000, DEFAULT_DATABASE_CONFIG, stateTreeGcConfig, GenesisData.NO_SCENARIOS);
-  }
-
-  protected DeterministicTest buildRunningServerTest(
-      int roundsPerEpoch,
-      DatabaseConfig databaseConfig,
-      StateTreeGcConfig stateTreeGcConfig,
-      ImmutableList<String> scenariosToRun) {
+  protected DeterministicTest buildRunningServerTest(StateComputerConfig config) {
     var test =
         DeterministicTest.builder()
             .addPhysicalNodes(PhysicalNodeConfig.createBatch(1, true))
@@ -173,21 +157,7 @@ public abstract class DeterministicEngineStateApiTestBase {
                     FunctionalRadixNodeModule.SafetyRecoveryConfig.MOCKED,
                     FunctionalRadixNodeModule.ConsensusConfig.of(1000),
                     FunctionalRadixNodeModule.LedgerConfig.stateComputerWithSyncRelay(
-                        StateComputerConfig.rev2(
-                            Network.INTEGRATIONTESTNET.getId(),
-                            GenesisBuilder.createTestGenesisWithNumValidators(
-                                1,
-                                Decimal.ONE,
-                                GenesisConsensusManagerConfig.Builder.testDefaults()
-                                    .epochExactRoundCount(roundsPerEpoch),
-                                scenariosToRun),
-                            databaseConfig,
-                            StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
-                            false,
-                            false,
-                            ProtocolConfig.testingDefault(),
-                            stateTreeGcConfig),
-                        SyncRelayConfig.of(200, 10, 2000))));
+                        config, SyncRelayConfig.of(200, 10, 2000))));
     try {
       test.startAllNodes();
     } catch (Exception ex) {

--- a/core/src/test/java/com/radixdlt/api/SystemApiTestBase.java
+++ b/core/src/test/java/com/radixdlt/api/SystemApiTestBase.java
@@ -77,7 +77,6 @@ import com.radixdlt.api.system.health.HealthInfoService;
 import com.radixdlt.api.system.health.HealthInfoServiceImpl;
 import com.radixdlt.consensus.bft.Self;
 import com.radixdlt.crypto.ECKeyPair;
-import com.radixdlt.environment.DatabaseConfig;
 import com.radixdlt.environment.deterministic.SingleNodeDeterministicRunner;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
@@ -132,14 +131,12 @@ public abstract class SystemApiTestBase {
                     SafetyRecoveryConfig.MOCKED,
                     ConsensusConfig.of(),
                     LedgerConfig.stateComputerWithSyncRelay(
-                        StateComputerConfig.rev2(
-                            Network.INTEGRATIONTESTNET.getId(),
-                            GenesisBuilder.createTestGenesisWithSingleValidator(
-                                TEST_KEY.getPublicKey(),
-                                Decimal.ONE,
-                                GenesisConsensusManagerConfig.Builder.testDefaults()),
-                            new DatabaseConfig(false, false, false, false),
-                            StateComputerConfig.REV2ProposerConfig.Mempool.defaults()),
+                        StateComputerConfig.rev2()
+                            .withGenesis(
+                                GenesisBuilder.createTestGenesisWithSingleValidator(
+                                    TEST_KEY.getPublicKey(),
+                                    Decimal.ONE,
+                                    GenesisConsensusManagerConfig.Builder.testDefaults())),
                         new SyncRelayConfig(500, 10, 3000, 10, Long.MAX_VALUE)))),
             new TestP2PModule.Builder().build(),
             new TestMessagingModule.Builder().build(),

--- a/core/src/test/java/com/radixdlt/api/core/AccountStateTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/AccountStateTest.java
@@ -83,7 +83,7 @@ import org.junit.Test;
 public final class AccountStateTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_core_api_can_retrieve_account_state() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // Prepare an account creation transaction

--- a/core/src/test/java/com/radixdlt/api/core/ComponentStateTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/ComponentStateTest.java
@@ -73,7 +73,7 @@ import org.junit.Test;
 public final class ComponentStateTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_core_api_can_retrieve_component_state() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses =

--- a/core/src/test/java/com/radixdlt/api/core/EpochManagerValidatorNonFungibleResourceAndDataStateTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/EpochManagerValidatorNonFungibleResourceAndDataStateTest.java
@@ -74,7 +74,7 @@ public final class EpochManagerValidatorNonFungibleResourceAndDataStateTest
     extends DeterministicCoreApiTestBase {
   @Test
   public void test_misc_state_endpoints() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // We test all these together because they can bootstrap each other to easily find real

--- a/core/src/test/java/com/radixdlt/api/core/LtsAccountDepositBehaviourTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/LtsAccountDepositBehaviourTest.java
@@ -83,7 +83,9 @@ public final class LtsAccountDepositBehaviourTest extends DeterministicCoreApiTe
 
   @Test
   public void account_with_default_config_allows_all_deposits() throws Exception {
-    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true, false, false))) {
+    final var config =
+        defaultConfig().withDatabaseConfig(new DatabaseConfig(true, true, false, false));
+    try (final var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       // Arrange: pretty empty state
@@ -157,7 +159,9 @@ public final class LtsAccountDepositBehaviourTest extends DeterministicCoreApiTe
 
   @Test
   public void account_with_reject_default_rule_disallows_all_deposits() throws Exception {
-    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true, false, false))) {
+    final var config =
+        defaultConfig().withDatabaseConfig(new DatabaseConfig(true, true, false, false));
+    try (final var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       // Arrange: create account and set its default deposit rule to `Reject`
@@ -211,7 +215,9 @@ public final class LtsAccountDepositBehaviourTest extends DeterministicCoreApiTe
 
   @Test
   public void configured_resource_preference_and_depositor_badge_is_returned() throws Exception {
-    try (final var test = buildRunningServerTest(new DatabaseConfig(true, true, false, false))) {
+    final var config =
+        defaultConfig().withDatabaseConfig(new DatabaseConfig(true, true, false, false));
+    try (final var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       // Arrange: create account with some resource preference and some authorized depositor badge

--- a/core/src/test/java/com/radixdlt/api/core/LtsAccountResourceBalanceTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/LtsAccountResourceBalanceTest.java
@@ -79,7 +79,9 @@ import org.junit.Test;
 public final class LtsAccountResourceBalanceTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_lts_account_xrd_balance() throws Exception {
-    try (var test = buildRunningServerTest(new DatabaseConfig(true, true, false, false))) {
+    final var config =
+        defaultConfig().withDatabaseConfig(new DatabaseConfig(true, true, false, false));
+    try (final var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       var accountKeyPair = ECKeyPair.generateNew();

--- a/core/src/test/java/com/radixdlt/api/core/LtsTransactionOutcomesTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/LtsTransactionOutcomesTest.java
@@ -71,6 +71,8 @@ import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
 import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.environment.DatabaseConfig;
+import com.radixdlt.genesis.GenesisBuilder;
+import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.identifiers.Address;
 import com.radixdlt.lang.Option;
@@ -84,7 +86,9 @@ import org.junit.Test;
 public class LtsTransactionOutcomesTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_non_fungible_entity_changes() throws Exception {
-    try (var test = buildRunningServerTest(new DatabaseConfig(true, true, false, false))) {
+    final var config =
+        defaultConfig().withDatabaseConfig(new DatabaseConfig(true, true, false, false));
+    try (final var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       var accountKeyPair = ECKeyPair.generateNew();
@@ -150,9 +154,16 @@ public class LtsTransactionOutcomesTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void test_resultant_account_balances() throws Exception {
-    // We run all scenarios for the case when RE decides to change invariants (i.e. no vault
-    // substate is deleted).
-    try (var test = buildRunningServerTestWithScenarios(GenesisData.ALL_SCENARIOS)) {
+    final var config =
+        defaultConfig()
+            .withGenesis(
+                GenesisBuilder.createTestGenesisWithNumValidators(
+                    1,
+                    Decimal.ONE,
+                    GenesisConsensusManagerConfig.Builder.testDefaults().epochExactRoundCount(100),
+                    // We run all scenarios for the case when RE decides to change invariants:
+                    GenesisData.ALL_SCENARIOS));
+    try (var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       var account1KeyPair = ECKeyPair.generateNew();
@@ -257,7 +268,9 @@ public class LtsTransactionOutcomesTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void test_multiple_transactions_have_correct_outcomes() throws Exception {
-    try (var test = buildRunningServerTest(new DatabaseConfig(true, true, false, false))) {
+    final var config =
+        defaultConfig().withDatabaseConfig(new DatabaseConfig(true, true, false, false));
+    try (final var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       var faucetAddressStr = ScryptoConstants.FAUCET_ADDRESS.encode(networkDefinition);

--- a/core/src/test/java/com/radixdlt/api/core/MempoolEndpointTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/MempoolEndpointTest.java
@@ -79,7 +79,7 @@ import org.junit.Test;
 public class MempoolEndpointTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_mempool_queries() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var transaction = TransactionBuilder.forTests().prepare();

--- a/core/src/test/java/com/radixdlt/api/core/NetworkConfigurationTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/NetworkConfigurationTest.java
@@ -75,7 +75,7 @@ import org.junit.Test;
 public class NetworkConfigurationTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_network_configuration() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var configurationResponse = getStatusApi().statusNetworkConfigurationPost();

--- a/core/src/test/java/com/radixdlt/api/core/NetworkScenariosTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/NetworkScenariosTest.java
@@ -72,6 +72,9 @@ import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
 import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
+import com.radixdlt.genesis.GenesisBuilder;
+import com.radixdlt.genesis.GenesisConsensusManagerConfig;
+import com.radixdlt.rev2.Decimal;
 import java.util.List;
 import java.util.stream.LongStream;
 import org.junit.Test;
@@ -79,9 +82,16 @@ import org.junit.Test;
 public class NetworkScenariosTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_network_scenarios() throws Exception {
-    // pick a custom subset/permutation (different than "all scenarios"):
-    final var names = ImmutableList.of("radiswap", "transfer_xrd");
-    try (var test = buildRunningServerTestWithScenarios(names)) {
+    final var config =
+        defaultConfig()
+            .withGenesis(
+                GenesisBuilder.createTestGenesisWithNumValidators(
+                    1,
+                    Decimal.ONE,
+                    GenesisConsensusManagerConfig.Builder.testDefaults().epochExactRoundCount(100),
+                    // pick a custom subset/permutation (different than "all scenarios"):
+                    ImmutableList.of("radiswap", "transfer_xrd")));
+    try (var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       // query all scenarios

--- a/core/src/test/java/com/radixdlt/api/core/NetworkStatusTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/NetworkStatusTest.java
@@ -74,7 +74,7 @@ public class NetworkStatusTest extends DeterministicCoreApiTestBase {
   @SuppressWarnings("DataFlowIssue")
   @Test
   public void test_core_api_status_response_at_startup() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
       final var response =
           getStatusApi()

--- a/core/src/test/java/com/radixdlt/api/core/NetworkSubmitTransactionTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/NetworkSubmitTransactionTest.java
@@ -71,6 +71,9 @@ import static org.assertj.core.api.Assertions.*;
 import com.google.common.collect.MoreCollectors;
 import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
+import com.radixdlt.genesis.GenesisBuilder;
+import com.radixdlt.genesis.GenesisConsensusManagerConfig;
+import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.Manifest;
 import com.radixdlt.rev2.TransactionBuilder;
 import org.junit.Test;
@@ -78,7 +81,7 @@ import org.junit.Test;
 public class NetworkSubmitTransactionTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_core_api_can_submit_and_commit_transaction() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var transaction = TransactionBuilder.forTests().prepare();
@@ -128,7 +131,7 @@ public class NetworkSubmitTransactionTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void test_transaction_rejected_when_same_payload_previously_committed() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var transaction = TransactionBuilder.forTests().prepare();
@@ -165,7 +168,7 @@ public class NetworkSubmitTransactionTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void test_transaction_rejected_when_same_intent_previously_committed() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var transaction1 = TransactionBuilder.forTests().nonce(1337).signatories(1).prepare();
@@ -204,7 +207,7 @@ public class NetworkSubmitTransactionTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void test_valid_but_rejected_transaction_should_be_rejected() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var transaction = TransactionBuilder.forTests().manifest(Manifest.validButReject()).prepare();
@@ -238,7 +241,15 @@ public class NetworkSubmitTransactionTest extends DeterministicCoreApiTestBase {
   public void
       test_valid_but_future_epoch_transaction_should_be_rejected_but_resubmittable_immediately_when_epoch_reached()
           throws Exception {
-    try (var test = buildRunningServerTest(100)) {
+    final var config =
+        defaultConfig()
+            .withGenesis(
+                GenesisBuilder.createTestGenesisWithNumValidators(
+                    1,
+                    Decimal.ONE,
+                    GenesisConsensusManagerConfig.Builder.testDefaults()
+                        .epochExactRoundCount(100)));
+    try (var test = buildRunningServerTest(config)) {
       var currentEpoch = 2; // Epoch after genesis is 2
       var validFromEpoch = 3; // Epoch after genesis is 2, so this needs to be after that
       var transaction = TransactionBuilder.forTests().fromEpoch(validFromEpoch).prepare();

--- a/core/src/test/java/com/radixdlt/api/core/NodeMetadataIndexTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/NodeMetadataIndexTest.java
@@ -81,7 +81,7 @@ public class NodeMetadataIndexTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void createdVaultHasItsAccountAsRootInDatabaseIndex() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
       // Set up an account and a vault
       var accountAddress = Address.virtualAccountAddress(ECKeyPair.generateNew().getPublicKey());

--- a/core/src/test/java/com/radixdlt/api/core/ProofStreamTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/ProofStreamTest.java
@@ -70,22 +70,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
+import com.radixdlt.genesis.GenesisBuilder;
+import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.protocol.ProtocolConfig;
 import com.radixdlt.protocol.ProtocolUpdateEnactmentCondition;
 import com.radixdlt.protocol.ProtocolUpdateTrigger;
+import com.radixdlt.rev2.Decimal;
 import org.junit.Test;
 
 public class ProofStreamTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_proof_stream() throws Exception {
-    final var protocolConfig =
-        new ProtocolConfig(
-            ImmutableList.of(
-                new ProtocolUpdateTrigger(
-                    ProtocolUpdateTrigger.ANEMONE,
-                    ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(3L))));
-
-    try (var test = buildRunningServerTestWithProtocolConfig(10, protocolConfig)) {
+    final var config =
+        defaultConfig()
+            .withProtocolConfig(
+                new ProtocolConfig(
+                    ImmutableList.of(
+                        new ProtocolUpdateTrigger(
+                            ProtocolUpdateTrigger.ANEMONE,
+                            ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(3L)))))
+            .withGenesis(
+                GenesisBuilder.createTestGenesisWithNumValidators(
+                    1,
+                    Decimal.ONE,
+                    GenesisConsensusManagerConfig.Builder.testDefaults()
+                        .epochExactRoundCount(100)));
+    try (var test = buildRunningServerTest(config)) {
       test.runUntilState(allAtOrOverEpoch(5L));
 
       // ==================

--- a/core/src/test/java/com/radixdlt/api/core/ResourceStateTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/ResourceStateTest.java
@@ -76,7 +76,7 @@ import org.junit.Test;
 public class ResourceStateTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_core_api_state_resource_response_for_xrd() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
       final var addressing = Addressing.ofNetwork(networkDefinition);
       final var response =

--- a/core/src/test/java/com/radixdlt/api/core/TransactionAccuTreeTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/TransactionAccuTreeTest.java
@@ -70,8 +70,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.hash.HashCode;
 import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.crypto.HashUtils;
+import com.radixdlt.genesis.GenesisBuilder;
+import com.radixdlt.genesis.GenesisConsensusManagerConfig;
+import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.harness.predicates.NodePredicate;
 import com.radixdlt.lang.Option;
+import com.radixdlt.rev2.Decimal;
 import com.radixdlt.statecomputer.commit.LedgerHeader;
 import com.radixdlt.testutil.TestStateReader;
 import com.radixdlt.transaction.ExecutedTransaction;
@@ -136,7 +140,17 @@ public class TransactionAccuTreeTest extends DeterministicCoreApiTestBase {
   }
 
   private CapturedEpoch captureEpoch(int epochNumber) {
-    try (var test = buildRunningServerTest(EPOCH_TRANSACTION_LENGTH)) {
+    final var config =
+        defaultConfig()
+            .withGenesis(
+                GenesisBuilder.createTestGenesisWithNumValidators(
+                    1,
+                    Decimal.ONE,
+                    GenesisConsensusManagerConfig.Builder.testDefaults()
+                        .epochExactRoundCount(EPOCH_TRANSACTION_LENGTH),
+                    // We run all scenarios for the case when RE decides to change invariants:
+                    GenesisData.ALL_SCENARIOS));
+    try (var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       // Run the setup until 2 epoch proofs are captured

--- a/core/src/test/java/com/radixdlt/api/core/TransactionParseTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/TransactionParseTest.java
@@ -79,7 +79,7 @@ import org.junit.Test;
 public class TransactionParseTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_parse_rejected_transaction() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var transaction = TransactionBuilder.forTests().manifest(Manifest.validButReject()).prepare();
@@ -105,7 +105,7 @@ public class TransactionParseTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void parsed_transaction_contains_its_message() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var created =

--- a/core/src/test/java/com/radixdlt/api/core/TransactionPreviewTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/TransactionPreviewTest.java
@@ -275,7 +275,7 @@ public class TransactionPreviewTest extends DeterministicCoreApiTestBase {
   @SuppressWarnings("DataFlowIssue") // Suppress invalid null reference warnings
   @Test
   public void transaction_previewed_with_message_consumes_more_cost_units() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // Prepare a base request (no message)
@@ -382,8 +382,10 @@ public class TransactionPreviewTest extends DeterministicCoreApiTestBase {
 
   private DeterministicTest buildTest(boolean stateHistoryEnabled, long historyLength) {
     return buildRunningServerTest(
-        new DatabaseConfig(true, false, stateHistoryEnabled, false),
-        new StateTreeGcConfig(
-            UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(historyLength)));
+        defaultConfig()
+            .withDatabaseConfig(new DatabaseConfig(true, false, stateHistoryEnabled, false))
+            .withStateTreeGcConfig(
+                new StateTreeGcConfig(
+                    UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(historyLength))));
   }
 }

--- a/core/src/test/java/com/radixdlt/api/core/TransactionReceiptTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/TransactionReceiptTest.java
@@ -86,7 +86,7 @@ import org.junit.Test;
 public final class TransactionReceiptTest extends DeterministicCoreApiTestBase {
   @Test
   public void core_api_returns_transaction_receipt_with_balance_changes() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // Prepare a transaction which deposits from faucet:

--- a/core/src/test/java/com/radixdlt/api/core/TransactionStreamTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/TransactionStreamTest.java
@@ -75,6 +75,8 @@ import com.radixdlt.api.DeterministicCoreApiTestBase;
 import com.radixdlt.api.core.generated.models.*;
 import com.radixdlt.crypto.EdDSAEd25519PublicKey;
 import com.radixdlt.crypto.PublicKey;
+import com.radixdlt.genesis.GenesisBuilder;
+import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.genesis.GenesisData;
 import com.radixdlt.harness.deterministic.TransactionExecutor;
 import com.radixdlt.message.CurveDecryptorSet;
@@ -84,6 +86,7 @@ import com.radixdlt.message.TransactionMessage;
 import com.radixdlt.protocol.ProtocolConfig;
 import com.radixdlt.protocol.ProtocolUpdateEnactmentCondition;
 import com.radixdlt.protocol.ProtocolUpdateTrigger;
+import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REv2TransactionsAndProofReader;
 import com.radixdlt.rev2.TransactionBuilder;
 import com.radixdlt.utils.Bytes;
@@ -96,9 +99,18 @@ public class TransactionStreamTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_core_api_can_submit_and_commit_transaction_after_running_all_scenarios()
       throws Exception {
-    // This test checks that the transaction stream doesn't return errors when mapping genesis and
-    // the scenarios
-    try (var test = buildRunningServerTestWithScenarios(GenesisData.ALL_SCENARIOS)) {
+    final var config =
+        defaultConfig()
+            .withGenesis(
+                GenesisBuilder.createTestGenesisWithNumValidators(
+                    1,
+                    Decimal.ONE,
+                    GenesisConsensusManagerConfig.Builder.testDefaults().epochExactRoundCount(100),
+                    // This test checks that the transaction stream doesn't return errors when
+                    // mapping
+                    // genesis and the scenarios:
+                    GenesisData.ALL_SCENARIOS));
+    try (var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
       var transaction = TransactionBuilder.forTests().prepare();
 
@@ -152,7 +164,7 @@ public class TransactionStreamTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void streamed_transactions_contain_their_message() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // Prepare 3 different flavors of messages in transaction:
@@ -237,7 +249,7 @@ public class TransactionStreamTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void requesting_state_version_out_of_bounds_returns_error() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // Arrange: commit any transaction
@@ -312,7 +324,7 @@ public class TransactionStreamTest extends DeterministicCoreApiTestBase {
 
   @Test
   public void test_previous_state_identifiers_and_proofs() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var firstPartTransactions =
@@ -406,13 +418,21 @@ public class TransactionStreamTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_core_api_can_return_vm_boot_substate_in_protocol_update_receipt()
       throws Exception {
-    final var protocolConfig =
-        new ProtocolConfig(
-            ImmutableList.of(
-                new ProtocolUpdateTrigger(
-                    ProtocolUpdateTrigger.ANEMONE,
-                    ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(4L))));
-    try (var test = buildRunningServerTestWithProtocolConfig(30, protocolConfig)) {
+    final var config =
+        defaultConfig()
+            .withProtocolConfig(
+                new ProtocolConfig(
+                    ImmutableList.of(
+                        new ProtocolUpdateTrigger(
+                            ProtocolUpdateTrigger.ANEMONE,
+                            ProtocolUpdateEnactmentCondition.unconditionallyAtEpoch(4L)))))
+            .withGenesis(
+                GenesisBuilder.createTestGenesisWithNumValidators(
+                    1,
+                    Decimal.ONE,
+                    GenesisConsensusManagerConfig.Builder.testDefaults()
+                        .epochExactRoundCount(100)));
+    try (var test = buildRunningServerTest(config)) {
       test.runUntilState(allAtOrOverEpoch(4L));
 
       final var protocolUpdateStateVersion =

--- a/core/src/test/java/com/radixdlt/api/core/regression/ImmediateMempoolRelayOnSubmitTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/regression/ImmediateMempoolRelayOnSubmitTest.java
@@ -79,7 +79,7 @@ import org.junit.Test;
 public class ImmediateMempoolRelayOnSubmitTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_immediate_relay_event_on_core_api_submit() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var validTransaction = TransactionBuilder.forNetwork(networkDefinition).prepare();

--- a/core/src/test/java/com/radixdlt/api/core/regression/NonFungibleActionsTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/regression/NonFungibleActionsTest.java
@@ -77,7 +77,7 @@ public class NonFungibleActionsTest extends DeterministicCoreApiTestBase {
   @Test
   public void test_can_mint_and_burn_in_same_transaction_against_previously_used_resource()
       throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var accountKeyPair = ECKeyPair.generateNew();
@@ -106,7 +106,7 @@ public class NonFungibleActionsTest extends DeterministicCoreApiTestBase {
   @Test
   public void minting_non_fungible_id_which_previously_existed_transiently_in_a_transaction_fails()
       throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var accountKeyPair = ECKeyPair.generateNew();
@@ -136,7 +136,7 @@ public class NonFungibleActionsTest extends DeterministicCoreApiTestBase {
   @Test
   public void minting_non_fungible_id_which_existed_persistently_and_then_got_burned_fails()
       throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       var accountKeyPair = ECKeyPair.generateNew();

--- a/core/src/test/java/com/radixdlt/api/core/regression/StateHistoryTest.java
+++ b/core/src/test/java/com/radixdlt/api/core/regression/StateHistoryTest.java
@@ -127,8 +127,10 @@ public class StateHistoryTest extends DeterministicCoreApiTestBase {
 
   private DeterministicTest buildTest(boolean stateHistoryEnabled, long historyLength) {
     return buildRunningServerTest(
-        new DatabaseConfig(true, false, stateHistoryEnabled, false),
-        new StateTreeGcConfig(
-            UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(historyLength)));
+        defaultConfig()
+            .withDatabaseConfig(new DatabaseConfig(true, false, stateHistoryEnabled, false))
+            .withStateTreeGcConfig(
+                new StateTreeGcConfig(
+                    UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(historyLength))));
   }
 }

--- a/core/src/test/java/com/radixdlt/api/engine_state/BlueprintInfoTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/BlueprintInfoTest.java
@@ -66,14 +66,15 @@ package com.radixdlt.api.engine_state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.MoreCollectors;
+import com.google.common.collect.*;
 import com.radixdlt.api.DeterministicEngineStateApiTestBase;
 import com.radixdlt.api.engine_state.generated.client.ApiException;
 import com.radixdlt.api.engine_state.generated.models.*;
+import com.radixdlt.genesis.GenesisBuilder;
+import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.harness.predicates.NodesPredicate;
+import com.radixdlt.modules.StateComputerConfig;
+import com.radixdlt.rev2.Decimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,7 +84,7 @@ public final class BlueprintInfoTest extends DeterministicEngineStateApiTestBase
 
   @Test
   public void engine_state_api_returns_blueprint_info() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();
 
@@ -179,7 +180,7 @@ public final class BlueprintInfoTest extends DeterministicEngineStateApiTestBase
 
   @Test
   public void engine_state_api_returns_blueprint_package_royalties() throws Exception {
-    try (var test = buildRunningServerTestWithScenarios("royalties")) {
+    try (var test = buildRunningServerTest(configWithScenarios("royalties"))) {
       test.suppressUnusedWarning();
 
       // Fetch the info of the blueprint created by the "royalties" Scenario:
@@ -202,7 +203,7 @@ public final class BlueprintInfoTest extends DeterministicEngineStateApiTestBase
 
   @Test
   public void engine_state_api_blueprint_info_supports_history() throws Exception {
-    try (var test = buildRunningServerTestWithScenarios("royalties")) {
+    try (var test = buildRunningServerTest(configWithScenarios("royalties"))) {
       test.suppressUnusedWarning();
 
       // Let's re-use the "royalties" Scenario's blueprint; first find out when it was created:
@@ -301,5 +302,15 @@ public final class BlueprintInfoTest extends DeterministicEngineStateApiTestBase
       }
     }
     throw new AssertionError("assumed package not found");
+  }
+
+  private StateComputerConfig.REv2StateComputerConfig configWithScenarios(String... scenarioNames) {
+    return defaultConfig()
+        .withGenesis(
+            GenesisBuilder.createTestGenesisWithNumValidators(
+                1,
+                Decimal.ONE,
+                GenesisConsensusManagerConfig.Builder.testDefaults().epochExactRoundCount(1000000),
+                ImmutableList.copyOf(scenarioNames)));
   }
 }

--- a/core/src/test/java/com/radixdlt/api/engine_state/EntityInfoTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/EntityInfoTest.java
@@ -80,7 +80,7 @@ public final class EntityInfoTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_returns_root_object_info() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();
@@ -137,7 +137,7 @@ public final class EntityInfoTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_object_info_returns_fields_respecting_conditions() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // fetch info of 2 well-known objects instantiating the same blueprint with different features
@@ -168,7 +168,7 @@ public final class EntityInfoTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_returns_kv_store_info() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // list entities and pick a random KV store
@@ -194,7 +194,7 @@ public final class EntityInfoTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_returns_uninstantiated_object_info() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var accountKeyPair = ECKeyPair.generateNew();
@@ -239,7 +239,7 @@ public final class EntityInfoTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_entity_info_supports_history() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // The Entity info is effectively immutable, but we can still experience "historical state"

--- a/core/src/test/java/com/radixdlt/api/engine_state/EntitySchemaEntryTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/EntitySchemaEntryTest.java
@@ -75,7 +75,7 @@ public final class EntitySchemaEntryTest extends DeterministicEngineStateApiTest
 
   @Test
   public void engine_state_api_returns_schema_contents() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();

--- a/core/src/test/java/com/radixdlt/api/engine_state/ExtraEntitySearchTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ExtraEntitySearchTest.java
@@ -93,7 +93,7 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
 
   @Test
   public void engine_state_api_extra_entity_search_pages_through_all_entities() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // first list all entities with a single request
@@ -145,7 +145,7 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
   @Parameters(method = "broadFilters")
   public void engine_state_api_extra_entity_search_pages_through_filtered_entities(
       EntitySearchFilter filter) throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var allResponse =
@@ -194,7 +194,7 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
 
   @Test
   public void engine_state_api_extra_entity_search_sorts_by_creation_asc() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var allResponse = getExtraApi().extraEntitySearchPost(new ExtraEntitySearchRequest());
@@ -211,7 +211,7 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
 
   @Test
   public void engine_state_api_extra_entity_search_filters_by_system_type() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var allResponse =
@@ -231,7 +231,7 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
 
   @Test
   public void engine_state_api_extra_entity_search_filters_by_entity_type() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var allResponse =
@@ -252,7 +252,7 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
 
   @Test
   public void engine_state_api_extra_entity_search_filters_by_blueprint() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();
@@ -279,7 +279,7 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
   @Test
   public void engine_state_api_extra_entity_search_requires_same_params_across_pages()
       throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var sameFilter = new EntityTypeFilter().entityType(EntityType.INTERNALKEYVALUESTORE);
@@ -336,7 +336,7 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
   @Parameters(method = "noneOrBroadFilters")
   public void engine_state_api_extra_entity_search_supports_history(
       @Nullable EntitySearchFilter filter) throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // Arrange: collect all entities (as of now) and index them by creation version:
@@ -386,7 +386,10 @@ public final class ExtraEntitySearchTest extends DeterministicEngineStateApiTest
   public void engine_state_api_extra_entity_search_at_state_version_requires_history_feature()
       throws Exception {
     final var tooShortHistory =
-        new StateTreeGcConfig(UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(10));
+        defaultConfig()
+            .withStateTreeGcConfig(
+                new StateTreeGcConfig(
+                    UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(10)));
     try (var test = buildRunningServerTest(tooShortHistory)) {
       test.suppressUnusedWarning();
 

--- a/core/src/test/java/com/radixdlt/api/engine_state/KeyValueStoreEntryTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/KeyValueStoreEntryTest.java
@@ -80,7 +80,7 @@ public final class KeyValueStoreEntryTest extends DeterministicEngineStateApiTes
 
   @Test
   public void engine_state_api_returns_kv_store_entry() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // execute a dummy transaction to create a known entry in the Faucet's KV-Store:
@@ -120,7 +120,7 @@ public final class KeyValueStoreEntryTest extends DeterministicEngineStateApiTes
 
   @Test
   public void engine_state_api_returns_not_found_for_unknown_key() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // execute a few dummy transactions (so that we test against non-empty KV-Store):

--- a/core/src/test/java/com/radixdlt/api/engine_state/KeyValueStoreIteratorTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/KeyValueStoreIteratorTest.java
@@ -88,7 +88,7 @@ public final class KeyValueStoreIteratorTest extends DeterministicEngineStateApi
 
   @Test
   public void engine_state_api_kv_store_iterator_pages_through_all_entries() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // execute a couple of dummy transactions (just to create multiple entries in the Faucet's
@@ -130,7 +130,7 @@ public final class KeyValueStoreIteratorTest extends DeterministicEngineStateApi
 
   @Test
   public void engine_state_api_kv_store_iterator_returns_actual_kv_store_keys() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // execute a dummy transaction to create a known entry in the Faucet's KV-Store:
@@ -162,7 +162,10 @@ public final class KeyValueStoreIteratorTest extends DeterministicEngineStateApi
   @Test
   public void engine_state_api_kv_store_iterator_supports_history() throws Exception {
     final var longHistory =
-        new StateTreeGcConfig(UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(100));
+        defaultConfig()
+            .withStateTreeGcConfig(
+                new StateTreeGcConfig(
+                    UInt32.fromNonNegativeInt(1), UInt64.fromNonNegativeLong(100)));
     try (var test = buildRunningServerTest(longHistory)) {
       test.suppressUnusedWarning();
 

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectCollectionEntryTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectCollectionEntryTest.java
@@ -76,7 +76,7 @@ public final class ObjectCollectionEntryTest extends DeterministicEngineStateApi
 
   @Test
   public void engine_state_api_returns_object_kv_collection_entry() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();
@@ -105,7 +105,7 @@ public final class ObjectCollectionEntryTest extends DeterministicEngineStateApi
 
   @Test
   public void engine_state_api_returns_object_sorted_collection_entry() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();
@@ -141,7 +141,7 @@ public final class ObjectCollectionEntryTest extends DeterministicEngineStateApi
 
   @Test
   public void engine_state_api_returns_not_found_for_unknown_key() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();
@@ -177,7 +177,7 @@ public final class ObjectCollectionEntryTest extends DeterministicEngineStateApi
     // Note: this is NOT the only endpoint in the Engine State API which is supposed to support
     // SBORs in different formats, but it is a convenient place to test it (both input and output).
 
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectCollectionIteratorTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectCollectionIteratorTest.java
@@ -79,7 +79,7 @@ public final class ObjectCollectionIteratorTest extends DeterministicEngineState
   @Test
   public void engine_state_api_object_collection_iterator_pages_through_all_entries()
       throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectFieldTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectFieldTest.java
@@ -88,7 +88,7 @@ public final class ObjectFieldTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_returns_object_field() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();
@@ -119,7 +119,7 @@ public final class ObjectFieldTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_returns_transient_object_field_default_value() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // Locate literally any fungible vault:
@@ -162,7 +162,7 @@ public final class ObjectFieldTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_object_field_supports_history() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // The easiest way to observe history is to look at the Consensus Manager's state field:
@@ -205,7 +205,7 @@ public final class ObjectFieldTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_returns_accurate_historical_state_summary() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       // We will query for some arbitrary field (that we know exists since very early versions):

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectMetadataEntryTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectMetadataEntryTest.java
@@ -74,7 +74,7 @@ public final class ObjectMetadataEntryTest extends DeterministicEngineStateApiTe
 
   @Test
   public void engine_state_api_return_object_metadata_entry() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectMetadataIteratorTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectMetadataIteratorTest.java
@@ -75,7 +75,7 @@ public final class ObjectMetadataIteratorTest extends DeterministicEngineStateAp
 
   @Test
   public void engine_state_api_object_metadata_iterator_returns_string_keys() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectRoleAssignmentTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectRoleAssignmentTest.java
@@ -76,7 +76,7 @@ public final class ObjectRoleAssignmentTest extends DeterministicEngineStateApiT
 
   @Test
   public void engine_state_api_returns_object_role_assignment() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       test.suppressUnusedWarning();
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectRoyaltyTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectRoyaltyTest.java
@@ -66,16 +66,29 @@ package com.radixdlt.api.engine_state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.radixdlt.api.DeterministicEngineStateApiTestBase;
 import com.radixdlt.api.engine_state.generated.client.ApiException;
 import com.radixdlt.api.engine_state.generated.models.*;
+import com.radixdlt.genesis.GenesisBuilder;
+import com.radixdlt.genesis.GenesisConsensusManagerConfig;
+import com.radixdlt.rev2.Decimal;
 import org.junit.Test;
 
 public final class ObjectRoyaltyTest extends DeterministicEngineStateApiTestBase {
 
   @Test
   public void engine_state_api_returns_object_royalty() throws Exception {
-    try (var test = buildRunningServerTestWithScenarios("royalties")) {
+    final var config =
+        defaultConfig()
+            .withGenesis(
+                GenesisBuilder.createTestGenesisWithNumValidators(
+                    1,
+                    Decimal.ONE,
+                    GenesisConsensusManagerConfig.Builder.testDefaults()
+                        .epochExactRoundCount(1000000),
+                    ImmutableList.of("royalties")));
+    try (var test = buildRunningServerTest(config)) {
       test.suppressUnusedWarning();
 
       // Find all the component instances created by the `royalties` Scenario:

--- a/core/src/test/java/com/radixdlt/benchmark/TxnCommitAndReadBenchmarkTest.java
+++ b/core/src/test/java/com/radixdlt/benchmark/TxnCommitAndReadBenchmarkTest.java
@@ -100,7 +100,7 @@ public final class TxnCommitAndReadBenchmarkTest extends DeterministicCoreApiTes
   @Test
   @Ignore("this test is meant to be run manually")
   public void test_txn_commit_and_read_time() throws Exception {
-    try (var test = buildRunningServerTest()) {
+    try (var test = buildRunningServerTest(defaultConfig())) {
       final var stateComputer = test.getInstance(0, RustStateComputer.class);
 
       final var commitStopwatch = Stopwatch.createStarted();

--- a/core/src/test/java/com/radixdlt/recovery/REv2ConsensusLedgerRecoveryTest.java
+++ b/core/src/test/java/com/radixdlt/recovery/REv2ConsensusLedgerRecoveryTest.java
@@ -81,7 +81,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.sync.SyncRelayConfig;
@@ -105,14 +104,15 @@ public final class REv2ConsensusLedgerRecoveryTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            2,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testInfiniteEpochs()),
-                        StateComputerConfig.REV2ProposerConfig.transactionGenerator(
-                            new REV2TransactionGenerator(), 1)),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                2,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testInfiniteEpochs()))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.transactionGenerator(
+                                new REV2TransactionGenerator(), 1)),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/test/java/com/radixdlt/recovery/REv2LedgerRecoveryTest.java
+++ b/core/src/test/java/com/radixdlt/recovery/REv2LedgerRecoveryTest.java
@@ -79,7 +79,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.rev2.Decimal;
 import com.radixdlt.rev2.REV2TransactionGenerator;
 import com.radixdlt.sync.TransactionsAndProofReader;
@@ -123,14 +122,15 @@ public final class REv2LedgerRecoveryTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testInfiniteEpochs()),
-                        StateComputerConfig.REV2ProposerConfig.transactionGenerator(
-                            new REV2TransactionGenerator(), 1)))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testInfiniteEpochs()))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.transactionGenerator(
+                                new REV2TransactionGenerator(), 1)))));
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/rev2/REv2GenesisTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2GenesisTest.java
@@ -82,7 +82,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.ConsensusConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.testutil.TestStateReader;
 import java.util.Map;
 import org.junit.Rule;
@@ -146,15 +145,16 @@ public final class REv2GenesisTest {
                 SafetyRecoveryConfig.MOCKED,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidatorsAndXrdBalances(
-                            1,
-                            INITIAL_STAKE,
-                            Map.of(XRD_ALLOC_ACCOUNT_PUB_KEY, XRD_ALLOC_AMOUNT),
-                            GenesisConsensusManagerConfig.Builder.testDefaults(),
-                            GenesisData.ALL_SCENARIOS),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.zero()))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidatorsAndXrdBalances(
+                                1,
+                                INITIAL_STAKE,
+                                Map.of(XRD_ALLOC_ACCOUNT_PUB_KEY, XRD_ALLOC_AMOUNT),
+                                GenesisConsensusManagerConfig.Builder.testDefaults(),
+                                GenesisData.ALL_SCENARIOS))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.Mempool.zero()))));
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/rev2/REv2IncreasingEpochTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2IncreasingEpochTest.java
@@ -76,7 +76,6 @@ import com.radixdlt.harness.deterministic.PhysicalNodeConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.testutil.TestStateReader;
 import org.junit.Rule;
 import org.junit.Test;
@@ -97,13 +96,14 @@ public class REv2IncreasingEpochTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                        StateComputerConfig.REV2ProposerConfig.noUserTransactions()))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.noUserTransactions()))));
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/rev2/REv2LargeTransactionTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2LargeTransactionTest.java
@@ -85,8 +85,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.sync.SyncRelayConfig;
 import com.radixdlt.transactions.PreparedNotarizedTransaction;
 import java.util.List;
@@ -110,13 +108,14 @@ public final class REv2LargeTransactionTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                        REV2ProposerConfig.Mempool.singleTransaction()),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.Mempool.singleTransaction()),
                     SyncRelayConfig.of(200, 10, 1000))));
   }
 

--- a/core/src/test/java/com/radixdlt/rev2/REv2MempoolToCommittedTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2MempoolToCommittedTest.java
@@ -79,7 +79,6 @@ import com.radixdlt.mempool.MempoolAdd;
 import com.radixdlt.modules.FunctionalRadixNodeModule;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.sync.SyncRelayConfig;
 import java.util.Collection;
 import java.util.List;
@@ -118,14 +117,15 @@ public class REv2MempoolToCommittedTest {
                 FunctionalRadixNodeModule.SafetyRecoveryConfig.MOCKED,
                 FunctionalRadixNodeModule.ConsensusConfig.of(1000),
                 FunctionalRadixNodeModule.LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
-                                this.roundsPerEpoch)),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.singleTransaction()),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    this.roundsPerEpoch)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.Mempool.singleTransaction()),
                     SyncRelayConfig.of(5000, 10, 3000L))));
   }
 

--- a/core/src/test/java/com/radixdlt/rev2/REv2RegisterValidatorTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2RegisterValidatorTest.java
@@ -90,7 +90,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.utils.PrivateKeys;
 import java.util.Collection;
 import java.util.List;
@@ -146,13 +145,13 @@ public final class REv2RegisterValidatorTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.defaults()))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    10))))));
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/rev2/REv2RejectMultipleIntentsTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2RejectMultipleIntentsTest.java
@@ -85,7 +85,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
 import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import java.util.List;
 import org.junit.Rule;
@@ -108,13 +107,14 @@ public final class REv2RejectMultipleIntentsTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)),
-                        REV2ProposerConfig.transactionGenerator(proposalGenerator)))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(10)))
+                        .withProposerConfig(
+                            REV2ProposerConfig.transactionGenerator(proposalGenerator)))));
   }
 
   private static RawNotarizedTransaction createValidTransactionWithSigs(int nonce, int sigsCount) {

--- a/core/src/test/java/com/radixdlt/rev2/REv2RejectedTransactionMempoolTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2RejectedTransactionMempoolTest.java
@@ -86,7 +86,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule;
 import com.radixdlt.modules.FunctionalRadixNodeModule.*;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.transactions.NotarizedTransactionHash;
 import com.radixdlt.transactions.PreparedNotarizedTransaction;
 import java.util.Collection;
@@ -126,15 +125,16 @@ public class REv2RejectedTransactionMempoolTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
-                                this.roundsPerEpoch)),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.singleTransaction()
-                            .withMempoolConfig(mempoolConfig)))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    this.roundsPerEpoch)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.Mempool.singleTransaction()
+                                .withMempoolConfig(mempoolConfig)))));
   }
 
   @Test

--- a/core/src/test/java/com/radixdlt/rev2/REv2RejectedTransactionTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2RejectedTransactionTest.java
@@ -84,7 +84,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
 import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.transactions.RawNotarizedTransaction;
 import java.util.Collection;
 import java.util.List;
@@ -123,14 +122,15 @@ public final class REv2RejectedTransactionTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
-                                roundsPerEpoch)),
-                        REV2ProposerConfig.transactionGenerator(proposalGenerator)))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    roundsPerEpoch)))
+                        .withProposerConfig(
+                            REV2ProposerConfig.transactionGenerator(proposalGenerator)))));
   }
 
   private static class ControlledProposerGenerator implements ProposalGenerator {

--- a/core/src/test/java/com/radixdlt/rev2/REv2SyncTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/REv2SyncTest.java
@@ -81,7 +81,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
 import com.radixdlt.modules.StateComputerConfig.REV2ProposerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.sync.SyncRelayConfig;
 import java.util.Collection;
 import java.util.List;
@@ -119,14 +118,16 @@ public class REv2SyncTest {
                 SafetyRecoveryConfig.MOCKED,
                 ConsensusConfig.of(1000),
                 LedgerConfig.stateComputerWithSyncRelay(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
-                                roundsPerEpoch)),
-                        REV2ProposerConfig.transactionGenerator(new REV2TransactionGenerator(), 1)),
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(
+                                    roundsPerEpoch)))
+                        .withProposerConfig(
+                            REV2ProposerConfig.transactionGenerator(
+                                new REV2TransactionGenerator(), 1)),
                     SyncRelayConfig.of(200, 10, 2000))));
   }
 

--- a/core/src/test/java/com/radixdlt/rev2/protocol/AnemoneProtocolUpdateTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/protocol/AnemoneProtocolUpdateTest.java
@@ -134,14 +134,15 @@ public final class AnemoneProtocolUpdateTest {
                 FunctionalRadixNodeModule.SafetyRecoveryConfig.BERKELEY_DB,
                 FunctionalRadixNodeModule.ConsensusConfig.of(1000),
                 FunctionalRadixNodeModule.LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            1,
-                            Decimal.ONE,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(5)),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.singleTransaction(),
-                        PROTOCOL_CONFIG))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                1,
+                                Decimal.ONE,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(5)))
+                        .withProposerConfig(
+                            StateComputerConfig.REV2ProposerConfig.Mempool.singleTransaction())
+                        .withProtocolConfig(PROTOCOL_CONFIG))));
   }
 
   private PreparedNotarizedTransaction createGetTimeCallTxn(boolean secondPrecision) {

--- a/core/src/test/java/com/radixdlt/rev2/protocol/ProtocolUpdateWithEpochBoundsTest.java
+++ b/core/src/test/java/com/radixdlt/rev2/protocol/ProtocolUpdateWithEpochBoundsTest.java
@@ -72,7 +72,6 @@ import static com.radixdlt.rev2.protocol.ProtocolUpdateWithEpochBoundsTest.TestE
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.radixdlt.environment.DatabaseConfig;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
 import com.radixdlt.harness.deterministic.DeterministicTest;
@@ -83,7 +82,6 @@ import com.radixdlt.modules.FunctionalRadixNodeModule.LedgerConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.NodeStorageConfig;
 import com.radixdlt.modules.FunctionalRadixNodeModule.SafetyRecoveryConfig;
 import com.radixdlt.modules.StateComputerConfig;
-import com.radixdlt.networks.Network;
 import com.radixdlt.protocol.*;
 import com.radixdlt.rev2.*;
 import com.radixdlt.utils.UInt192;
@@ -296,18 +294,15 @@ public final class ProtocolUpdateWithEpochBoundsTest {
                 SafetyRecoveryConfig.BERKELEY_DB,
                 ConsensusConfig.of(200),
                 LedgerConfig.stateComputerNoSync(
-                    StateComputerConfig.rev2(
-                        Network.INTEGRATIONTESTNET.getId(),
-                        GenesisBuilder.createTestGenesisWithNumValidators(
-                            scenario.numValidators(),
-                            STAKE_PER_VALIDATOR,
-                            GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(30)
-                                .totalEmissionXrdPerEpoch(Decimal.ZERO)),
-                        new DatabaseConfig(true, false, false, false),
-                        StateComputerConfig.REV2ProposerConfig.Mempool.defaults(),
-                        false,
-                        true,
-                        protocolConfig))));
+                    StateComputerConfig.rev2()
+                        .withGenesis(
+                            GenesisBuilder.createTestGenesisWithNumValidators(
+                                scenario.numValidators(),
+                                STAKE_PER_VALIDATOR,
+                                GenesisConsensusManagerConfig.Builder.testWithRoundsPerEpoch(30)
+                                    .totalEmissionXrdPerEpoch(Decimal.ZERO)))
+                        .withProtocolConfig(protocolConfig)
+                        .withNoFees(true))));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This addresses https://radixdlt.atlassian.net/browse/NODE-645.

## Details

The main config items now use a builder pattern, and the tests only customize the parts that they care about.
The customization of nested items is still a bit awkward, but it is a much rarer case (and TBH the new shape is good enough, especially within the testing realm).

## Testing

Only test code is affected.