### PR TITLE
Bump Engine dep to `bottlenose-397a1bc0`

### DIFF
--- a/core-rust/Cargo.lock
+++ b/core-rust/Cargo.lock
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "radix-blueprint-schema-init"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "bitflags 1.3.2",
  "radix-common",
@@ -1665,7 +1665,7 @@ dependencies = [
 [[package]]
 name = "radix-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "bech32",
  "blake2",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "radix-common-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "bitflags 1.3.2",
  "colored",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "fixedstr",
 ]
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "radix-engine-profiling-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1774,7 +1774,7 @@ dependencies = [
 [[package]]
 name = "radix-native-sdk"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "radix-common",
  "radix-engine-interface",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "radix-rust"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "radix-sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-impls"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "hex",
  "itertools",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-interface"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "hex",
  "itertools",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "radix-substate-store-queries"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "hex",
  "itertools",
@@ -1847,7 +1847,7 @@ dependencies = [
 [[package]]
 name = "radix-transaction-scenarios"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "hex",
  "itertools",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "radix-transactions"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "annotate-snippets",
  "bech32",
@@ -2097,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "sbor"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "const-sha1",
  "hex",
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -2121,7 +2121,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive-common"
 version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-25601aac#25601aac582399386f5e7dd2bb7911ca8b5b429f"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=bottlenose-397a1bc0#397a1bc0bb67429f1c82fbe0a62b3ac2f89a6fad"
 dependencies = [
  "const-sha1",
  "itertools",

--- a/core-rust/Cargo.toml
+++ b/core-rust/Cargo.toml
@@ -23,17 +23,17 @@ resolver = "2"
 #   $ git push origin "release_name-BLAH"
 # * Then use tag="release_name-BLAH" in the below dependencies.
 # 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac", features = ["serde"] }
-radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac" }
-radix-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac" }
-radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac", features = ["serde"] }
-radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac" }
-radix-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac" }
-radix-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac" }
-radix-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac" }
-radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac", features = ["serde"] }
-radix-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-25601aac", features = ["serde"] }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0", features = ["serde"] }
+radix-transactions = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0" }
+radix-transaction-scenarios = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0" }
+radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0", features = ["serde"] }
+radix-engine-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0" }
+radix-substate-store-impls = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0" }
+radix-substate-store-interface = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0" }
+radix-substate-store-queries = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0" }
+radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0", features = ["serde"] }
+radix-blueprint-schema-init = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-397a1bc0", features = ["serde"] }
 
 itertools = { version = "=0.10.5" }
 jni = { version = "=0.19.0" }

--- a/core-rust/core-api-server/src/core_api/conversions/receipt.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/receipt.rs
@@ -698,7 +698,7 @@ pub fn to_api_fee_summary(
 pub fn to_api_costing_parameters(
     _context: &MappingContext,
     engine_costing_parameters: &CostingParameters,
-    transaction_costing_parameters: &TransactionCostingParameters,
+    transaction_costing_parameters: &TransactionCostingParametersReceipt,
 ) -> Result<models::CostingParameters, MappingError> {
     Ok(models::CostingParameters {
         execution_cost_unit_price: to_api_decimal(

--- a/core-rust/state-manager/src/receipt.rs
+++ b/core-rust/state-manager/src/receipt.rs
@@ -237,7 +237,7 @@ pub struct LocalTransactionExecutionV1 {
     pub fee_source: FeeSource,
     pub fee_destination: FeeDestination,
     pub engine_costing_parameters: CostingParameters,
-    pub transaction_costing_parameters: TransactionCostingParameters,
+    pub transaction_costing_parameters: TransactionCostingParametersReceipt,
     pub application_logs: Vec<(Level, String)>,
     pub state_update_summary: StateUpdateSummary,
     pub global_balance_summary: GlobalBalanceSummary,

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -114,7 +114,7 @@ pub struct HashUpdateContext<'s, S> {
 pub struct ExecutionFeeData {
     pub fee_summary: TransactionFeeSummary,
     pub engine_costing_parameters: CostingParameters,
-    pub transaction_costing_parameters: TransactionCostingParameters,
+    pub transaction_costing_parameters: TransactionCostingParametersReceipt,
 }
 
 impl ProcessedTransactionReceipt {

--- a/testnet-node/docker-compose.yml
+++ b/testnet-node/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   core:
     container_name: radixdlt-stokenet-node
     #### Chose to either uncomment "image" or "build" to either pull the image from dockerhub or build locally from source
-    image: radixdlt/babylon-node:v1.2.0.2
+    image: radixdlt/babylon-node:v1.2.0.3
     # build:
     #   context: ..
     #   dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

Pulling the latest `bottlenose-397a1bc0` Engine with a receipt versioning fix.

## Testing

No changes testable in Node's local tests.