### PR TITLE
Pass the openjdk version directly (remove the no-longer-needed docker arg)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ ENV DEBIAN_FRONTEND noninteractive
 CMD ["/bin/bash"]
 
 ARG WGET_VERSION="1.21.3-1+b2"
-ARG OPENJDK_17_VERSION="17.0.11+9-1~deb12u1"
 ARG VERSION_BRANCH=""
 ARG VERSION_COMMIT=""
 ARG VERSION_DISPLAY=""
@@ -57,7 +56,7 @@ RUN apt-get update \
     wget=${WGET_VERSION} \
     software-properties-common=0.99.30-4 \
   && apt-get install -y --no-install-recommends \
-    openjdk-17-jdk=${OPENJDK_17_VERSION} \
+    openjdk-17-jdk=17.0.11+9-1~deb12u1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -238,8 +237,6 @@ FROM debian:12.1-slim as app-container
 LABEL org.opencontainers.image.source="https://github.com/radixdlt/babylon-node"
 LABEL org.opencontainers.image.authors="devops@radixdlt.com"
 
-ARG OPENJDK_17_VERSION="17.0.11+9-1~deb12u1"
-
 # Install dependencies needed for building the image or running the application
 # - unzip is needed for unpacking the java build artifacts
 # - daemontools is needed at application runtime for async tasks
@@ -259,7 +256,7 @@ ARG OPENJDK_17_VERSION="17.0.11+9-1~deb12u1"
 # - https://packages.debian.org/bookworm/libc6
 RUN apt-get update -y \
   && apt-get -y --no-install-recommends install \
-    openjdk-17-jre-headless=${OPENJDK_17_VERSION} \
+    openjdk-17-jre-headless=17.0.11+9-1~deb12u1 \
     # https://security-tracker.debian.org/tracker/CVE-2023-38545
     curl=7.88.1-10+deb12u5 \
     gettext-base=0.21-12 \


### PR DESCRIPTION
## Summary

This partially addresses the https://radixdlt.atlassian.net/browse/NODE-635 - it only rollbacks a remaining part of the old, no longer needed hack.
The true scope of that issue (make a version arg conditional on `TARGETPLATFORM`) has no use-case at the moment.

## Testing

Only a mechanical change in dockerfile.