### PR TITLE
Lenient parsing for commited failure's reason

### DIFF
--- a/core-rust/core-api-server/src/core_api/conversions/receipt.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/receipt.rs
@@ -23,7 +23,7 @@ pub fn to_api_receipt(
         DetailedTransactionOutcome::Failure(error) => (
             models::TransactionStatus::Failed,
             None,
-            Some(format!("{error:?}")),
+            Some(error.render()),
         ),
     };
 

--- a/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/lts/transaction_status.rs
@@ -84,11 +84,11 @@ pub(crate) async fn handle_lts_transaction_status(
                 "SUCCESS",
                 None,
             ),
-            DetailedTransactionOutcome::Failure(reason) => (
+            DetailedTransactionOutcome::Failure(error) => (
                 models::LtsTransactionIntentStatus::CommittedFailure,
                 models::LtsTransactionPayloadStatus::CommittedFailure,
                 "FAILURE",
-                Some(format!("{reason:?}")),
+                Some(error.render()),
             ),
         };
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_status.rs
@@ -84,11 +84,11 @@ pub(crate) async fn handle_transaction_status(
                 "SUCCESS",
                 None,
             ),
-            DetailedTransactionOutcome::Failure(reason) => (
+            DetailedTransactionOutcome::Failure(error) => (
                 models::TransactionIntentStatus::CommittedFailure,
                 models::TransactionPayloadStatus::CommittedFailure,
                 "FAILURE",
-                Some(format!("{reason:?}")),
+                Some(error.render()),
             ),
         };
 

--- a/core-rust/state-manager/src/jni/test_state_reader.rs
+++ b/core-rust/state-manager/src/jni/test_state_reader.rs
@@ -141,7 +141,7 @@ extern "system" fn Java_com_radixdlt_testutil_TestStateReader_getTransactionAtSt
                 },
                 error_message: match local_transaction_execution.outcome {
                     DetailedTransactionOutcome::Success(_) => None,
-                    DetailedTransactionOutcome::Failure(err) => Some(format!("{err:?}")),
+                    DetailedTransactionOutcome::Failure(error) => Some(error.render()),
                 },
                 consensus_receipt_bytes: scrypto_encode(
                     &committed_ledger_transaction_receipt.get_consensus_receipt(),

--- a/core-rust/state-manager/src/staging/result.rs
+++ b/core-rust/state-manager/src/staging/result.rs
@@ -250,13 +250,15 @@ impl ProcessedCommitResult {
         }
     }
 
-    pub fn expect_success(self, description: impl Display) -> Self {
+    pub fn expect_success(self, desc: impl Display) -> Self {
         if let DetailedTransactionOutcome::Failure(error) =
             &self.local_receipt.local_execution.outcome
         {
             panic!(
                 "{} (ledger hash: {}) failed: {:?}",
-                description, self.hash_structures_diff.ledger_hashes.transaction_root, error
+                desc,
+                self.hash_structures_diff.ledger_hashes.transaction_root,
+                error.render()
             );
         }
         self


### PR DESCRIPTION
## Summary

Historically stored `RuntimeError`s in the optional "local transaction execution" index can sometimes fail to decode on newer Node versions. Since we only want to render their type for information purposes, we can do it in a lenient way.

## Testing

Tested manually on a local Node with old enough ledger:
![image](https://github.com/radixdlt/babylon-node/assets/119413677/59abd010-844a-4161-a503-27c92849da8e)
