### PR TITLE
Better separate protocol state vs current protocol version

### DIFF
--- a/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/ProtocolState.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/statecomputer/ProtocolState.java
@@ -67,15 +67,16 @@ package com.radixdlt.statecomputer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.radixdlt.lang.Tuple;
+import com.radixdlt.protocol.ProtocolConfig;
 import com.radixdlt.protocol.ProtocolUpdateEnactmentCondition;
 import com.radixdlt.protocol.ProtocolUpdateTrigger;
 import com.radixdlt.sbor.codec.CodecMap;
 import com.radixdlt.sbor.codec.EnumCodec;
 import com.radixdlt.sbor.codec.StructCodec;
 import com.radixdlt.utils.UInt64;
+import java.util.Map;
 
 public record ProtocolState(
-    String currentProtocolVersion,
     ImmutableMap<UInt64, String> enactedProtocolUpdates,
     ImmutableList<PendingProtocolUpdate> pendingProtocolUpdates) {
 
@@ -100,8 +101,15 @@ public record ProtocolState(
                 PendingProtocolUpdateState.SignalledReadinessThresholdState.class, codecs));
   }
 
+  public String currentProtocolVersion() {
+    return this.enactedProtocolUpdates().entrySet().stream()
+        .max(Map.Entry.comparingByKey())
+        .map(Map.Entry::getValue)
+        .orElse(ProtocolConfig.GENESIS_PROTOCOL_VERSION_NAME);
+  }
+
   public static ProtocolState testingEmpty() {
-    return new ProtocolState("babylon-genesis", ImmutableMap.of(), ImmutableList.of());
+    return new ProtocolState(ImmutableMap.of(), ImmutableList.of());
   }
 
   public record PendingProtocolUpdate(

--- a/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/status_network_status.rs
@@ -16,10 +16,10 @@ pub(crate) async fn handle_status_network_status(
 
     let database = state.state_manager.database.snapshot();
     let (current_state_version, current_ledger_hashes) = database.get_top_ledger_hashes();
-    let current_protocol_state = state
+    let current_protocol_version = state
         .state_manager
         .protocol_manager
-        .current_protocol_state();
+        .current_protocol_version();
     Ok(Json(models::NetworkStatusResponse {
         pre_genesis_state_identifier: Box::new(to_api_committed_state_identifiers(
             StateVersion::pre_genesis(),
@@ -78,7 +78,7 @@ pub(crate) async fn handle_status_network_status(
                 )?))
             })
             .transpose()?,
-        current_protocol_version: current_protocol_state.current_protocol_version.to_string(),
+        current_protocol_version: current_protocol_version.to_string(),
     }))
 }
 

--- a/core-rust/state-manager/src/committer.rs
+++ b/core-rust/state-manager/src/committer.rs
@@ -80,10 +80,10 @@ use crate::system_commits::*;
 
 use crate::accumulator_tree::storage::ReadableAccuTreeStore;
 
+use crate::rocks_db::ActualStateManagerDatabase;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::SystemTime;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 pub struct Committer {
     database: Arc<DbLock<ActualStateManagerDatabase>>,
@@ -198,7 +198,7 @@ impl Committer {
             .unwrap_or_else(|| {
                 Self::calculate_transaction_root(
                     database.deref(),
-                    series_executor.epoch_identifiers(),
+                    &series_executor.epoch_identifiers(),
                     series_executor.latest_state_version(),
                     &prepared_transactions,
                 )

--- a/core-rust/state-manager/src/jni/node_rust_environment.rs
+++ b/core-rust/state-manager/src/jni/node_rust_environment.rs
@@ -85,14 +85,11 @@ use crate::priority_mempool::PriorityMempool;
 
 use super::fatal_panic_handler::FatalPanicHandler;
 
-use crate::rocks_db::ActualStateManagerDatabase;
-use crate::{StateManager, StateManagerConfig};
 use crate::protocol::ProtocolManager;
+use crate::rocks_db::ActualStateManagerDatabase;
 use crate::transaction::Preparator;
-use crate::{
-    Committer, LedgerMetrics,
-    SystemExecutor,
-};
+use crate::{Committer, LedgerMetrics, SystemExecutor};
+use crate::{StateManager, StateManagerConfig};
 
 const POINTER_JNI_FIELD_NAME: &str = "rustNodeRustEnvironmentPointer";
 

--- a/core-rust/state-manager/src/protocol/protocol_state.rs
+++ b/core-rust/state-manager/src/protocol/protocol_state.rs
@@ -10,12 +10,12 @@ use tracing::info;
 use crate::protocol::*;
 use crate::traits::{IterableProofStore, QueryableProofStore, QueryableTransactionStore};
 
+use crate::rocks_db::ActualStateManagerDatabase;
 use crate::{
-    LocalTransactionReceipt, ProtocolMetrics, ScenariosExecutionConfig,
-    StateVersion, SystemExecutor,
+    LocalTransactionReceipt, ProtocolMetrics, ScenariosExecutionConfig, StateVersion,
+    SystemExecutor,
 };
 use ProtocolUpdateEnactmentCondition::*;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 // This file contains types and utilities for managing the (dynamic) protocol state of a running
 // node.
@@ -111,6 +111,7 @@ impl ProtocolUpdateExecutor {
 
 pub struct ProtocolManager {
     protocol_metrics: ProtocolMetrics,
+    current_protocol_version: RwLock<ProtocolVersionName>,
     protocol_state: RwLock<ProtocolState>,
     newest_protocol_version: ProtocolVersionName,
 }
@@ -123,13 +124,18 @@ impl ProtocolManager {
         lock_factory: &LockFactory,
         metric_registry: &Registry,
     ) -> Self {
-        let initial_protocol_state = ProtocolState::compute_initial(
-            database,
-            &genesis_protocol_version,
-            &protocol_update_triggers,
-        );
+        let initial_protocol_state =
+            ProtocolState::compute_initial(database, &protocol_update_triggers);
         Self {
             protocol_metrics: ProtocolMetrics::new(metric_registry, &initial_protocol_state),
+            current_protocol_version: lock_factory.named("current_version").new_rwlock(
+                initial_protocol_state
+                    .enacted_protocol_updates
+                    .last_key_value()
+                    .map(|(_, protocol_version)| protocol_version)
+                    .unwrap_or(&genesis_protocol_version)
+                    .clone(),
+            ),
             protocol_state: lock_factory
                 .named("state")
                 .new_rwlock(initial_protocol_state),
@@ -140,8 +146,22 @@ impl ProtocolManager {
         }
     }
 
+    pub fn protocol_state_at_version(&self, _state_version: StateVersion) -> ProtocolState {
+        // TODO(strict correctness): At the moment, the protocol state is only relevant when
+        // executing an epoch change (i.e. as part of a round update, during `prepare()`). In these
+        // cases, we actually always need only the current protocol state. In future though, this
+        // method could be called e.g. by historical transaction preview logic, or historical state
+        // serving API (even if only for informational purposes), and we can cheaply avoid confusion
+        // by resolving this from an in-memory map (which we almost have at `compute_initial()`).
+        self.current_protocol_state()
+    }
+
     pub fn current_protocol_state(&self) -> ProtocolState {
         self.protocol_state.read().deref().clone()
+    }
+
+    pub fn current_protocol_version(&self) -> ProtocolVersionName {
+        self.current_protocol_version.read().deref().clone()
     }
 
     pub fn update_protocol_state_and_metrics(
@@ -161,14 +181,12 @@ impl ProtocolManager {
     }
 
     pub fn set_current_protocol_version(&self, protocol_version: &ProtocolVersionName) {
-        self.protocol_state.write().current_protocol_version = protocol_version.clone()
+        *self.current_protocol_version.write() = protocol_version.clone()
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, ScryptoCategorize, ScryptoEncode, ScryptoDecode)]
 pub struct ProtocolState {
-    /// A protocol version currently in use. The latest enacted version or the genesis version.
-    pub current_protocol_version: ProtocolVersionName,
     /// A list of all protocol updates that have been enacted.
     pub enacted_protocol_updates: BTreeMap<StateVersion, ProtocolVersionName>,
     /// A list of protocol updates that haven't yet been enacted, but still can be in the future.
@@ -333,7 +351,6 @@ impl ProtocolState {
         S: QueryableProofStore + IterableProofStore + QueryableTransactionStore,
     >(
         store: &S,
-        genesis_protocol_version: &ProtocolVersionName,
         protocol_update_triggers: &[ProtocolUpdateTrigger],
     ) -> ProtocolState {
         // For each configured allowed protocol update we calculate its expected status against
@@ -396,12 +413,6 @@ impl ProtocolState {
             );
         }
 
-        let current_protocol_version = enacted_protocol_updates
-            .last_key_value()
-            .map(|(_, protocol_version)| protocol_version)
-            .unwrap_or(genesis_protocol_version)
-            .clone();
-
         let pending_protocol_updates = initial_statuses
             .into_iter()
             .flat_map(|(protocol_update, status)| match status {
@@ -415,7 +426,6 @@ impl ProtocolState {
             .collect();
 
         ProtocolState {
-            current_protocol_version,
             enacted_protocol_updates,
             pending_protocol_updates,
         }

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/anemone_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/anemone_definition.rs
@@ -1,8 +1,8 @@
 use crate::engine_prelude::*;
 use crate::protocol::*;
+use crate::rocks_db::ActualStateManagerDatabase;
 use node_common::locks::DbLock;
 use std::sync::Arc;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 pub struct AnemoneProtocolUpdateDefinition;
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/bottlenose_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/bottlenose_definition.rs
@@ -1,8 +1,8 @@
 use crate::engine_prelude::*;
 use crate::protocol::*;
+use crate::rocks_db::ActualStateManagerDatabase;
 use node_common::locks::DbLock;
 use std::sync::Arc;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 pub struct BottlenoseProtocolUpdateDefinition;
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/custom_definition.rs
@@ -1,8 +1,8 @@
 use crate::engine_prelude::*;
 use crate::protocol::*;
+use crate::rocks_db::ActualStateManagerDatabase;
 use node_common::locks::DbLock;
 use std::sync::Arc;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 /// Any protocol update beginning `custom-` can have content injected via config.
 pub struct CustomProtocolUpdateDefinition;

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/default_definition.rs
@@ -1,8 +1,8 @@
 use crate::engine_prelude::*;
 use crate::protocol::*;
+use crate::rocks_db::ActualStateManagerDatabase;
 use node_common::locks::DbLock;
 use std::sync::Arc;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 pub struct NoOpProtocolDefinition;
 

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/mod.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/mod.rs
@@ -12,11 +12,11 @@ pub use test_definition::*;
 
 use crate::engine_prelude::*;
 use crate::protocol::*;
+use crate::rocks_db::ActualStateManagerDatabase;
 use crate::transaction::*;
 use node_common::locks::DbLock;
 use std::ops::Deref;
 use std::sync::Arc;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 /// A [`ProtocolUpdateNodeBatchGenerator`] implementation for the actual Engine's protocol updates.
 pub struct EngineBatchGenerator<G> {

--- a/core-rust/state-manager/src/protocol/protocol_updates/definitions/test_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/definitions/test_definition.rs
@@ -1,8 +1,8 @@
 use crate::engine_prelude::*;
+use crate::rocks_db::ActualStateManagerDatabase;
 use crate::{protocol::*, transaction::FlashTransactionV1};
 use node_common::locks::DbLock;
 use std::sync::Arc;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 /// Any protocol update beginning `test-` just injects a single transaction.
 pub struct TestProtocolUpdateDefinition {

--- a/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_definition.rs
+++ b/core-rust/state-manager/src/protocol/protocol_updates/protocol_update_definition.rs
@@ -2,9 +2,9 @@
 
 use crate::engine_prelude::*;
 use crate::protocol::*;
+use crate::rocks_db::ActualStateManagerDatabase;
 use node_common::locks::DbLock;
 use std::sync::Arc;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 /// A protocol update definition.
 ///

--- a/core-rust/state-manager/src/staging/cache.rs
+++ b/core-rust/state-manager/src/staging/cache.rs
@@ -81,17 +81,16 @@ use crate::transaction::{
     HasLedgerTransactionHash, LedgerTransactionHash, PreparedLedgerTransaction, TransactionLogic,
 };
 use crate::{
-    EpochTransactionIdentifiers, LedgerHashes, ReceiptTreeHash,
-    StateVersion, TransactionTreeHash,
+    EpochTransactionIdentifiers, LedgerHashes, ReceiptTreeHash, StateVersion, TransactionTreeHash,
 };
 use im::hashmap::HashMap as ImmutableHashMap;
 use itertools::Itertools;
 
+use crate::rocks_db::ActualStateManagerDatabase;
 use crate::store::traits::{SubstateNodeAncestryRecord, SubstateNodeAncestryStore};
 use crate::traits::{ConfigurableDatabase, QueryableProofStore};
 use node_common::locks::{DbLock, LockFactory, Mutex};
 use slotmap::SecondaryMap;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 pub struct ExecutionCacheManager {
     database: Arc<DbLock<ActualStateManagerDatabase>>,

--- a/core-rust/state-manager/src/state_manager.rs
+++ b/core-rust/state-manager/src/state_manager.rs
@@ -69,10 +69,10 @@ use std::time::Duration;
 
 use crate::engine_prelude::*;
 use crate::jni::LedgerSyncLimitsConfig;
-use crate::rocks_db::{ActualStateManagerDatabase, StateManagerDatabase};
 use crate::protocol::{
     ProtocolConfig, ProtocolManager, ProtocolUpdateExecutor, ProtocolVersionName,
 };
+use crate::rocks_db::{ActualStateManagerDatabase, StateManagerDatabase};
 use crate::store::jmt_gc::StateTreeGcConfig;
 use crate::store::proofs_gc::{LedgerProofsGc, LedgerProofsGcConfig};
 use crate::store::traits::proofs::QueryableProofStore;
@@ -86,8 +86,8 @@ use crate::{
     priority_mempool::PriorityMempool,
     store::{jmt_gc::StateTreeGc, DatabaseBackendConfig, DatabaseConfig, RawDbMetricsCollector},
     transaction::{CachedCommittabilityValidator, CommittabilityValidator, TransactionPreviewer},
-    Committer, ExecutionCacheManager, LedgerMetrics,
-    PendingTransactionResultCache, ProtocolUpdateResult, SystemExecutor,
+    Committer, ExecutionCacheManager, LedgerMetrics, PendingTransactionResultCache,
+    ProtocolUpdateResult, SystemExecutor,
 };
 use node_common::java::{JavaError, JavaResult, StructFromJava};
 use node_common::scheduler::{Metrics, Scheduler, Spawner, Tracker};

--- a/core-rust/state-manager/src/store/rocks_db.rs
+++ b/core-rust/state-manager/src/store/rocks_db.rs
@@ -832,7 +832,7 @@ impl StateManagerDatabase<DirectRocks> {
             column_families,
             false,
         )
-            .unwrap();
+        .unwrap();
 
         StateManagerDatabase {
             config: DatabaseConfig {

--- a/core-rust/state-manager/src/system_executor.rs
+++ b/core-rust/state-manager/src/system_executor.rs
@@ -81,11 +81,11 @@ use crate::store::traits::scenario::{
 use crate::system_commits::*;
 
 use crate::protocol::{ProtocolUpdateNodeBatch, ProtocolVersionName};
+use crate::rocks_db::ActualStateManagerDatabase;
 use crate::traits::scenario::ExecutedScenarioV1;
 use radix_transaction_scenarios::scenarios::ALL_SCENARIOS;
 use std::sync::Arc;
 use std::time::Instant;
-use crate::rocks_db::ActualStateManagerDatabase;
 
 pub struct SystemExecutor {
     network: NetworkDefinition,

--- a/core-rust/state-manager/src/transaction/preparation.rs
+++ b/core-rust/state-manager/src/transaction/preparation.rs
@@ -72,8 +72,8 @@ use tracing::{debug, info};
 
 use crate::engine_prelude::*;
 use crate::limits::*;
-use crate::*;
 use crate::rocks_db::ActualStateManagerDatabase;
+use crate::*;
 
 use crate::system_commits::*;
 


### PR DESCRIPTION
## Summary

When working on "staged instantiation" (needed for https://radixdlt.atlassian.net/browse/NODE-648) I noticed a refactoring opportunity: the "current protocol version" wasn't really updated by `TransactionTracker`, and it was a bit confusing that it is a part of `ProtocolState`. Now it is a separate piece of `ProtocolManager`'s state, clearly updated only as the last step of a protocol update execution process.

## Details

Please see one `TODO` that I added after noticing a theoretical deficiency of the today's `TransactionSeriesExecutor`. I really believe we should address it soon, if we don't want to be surprised.

## Testing

No behavior changes, only regression tests need to pass.
