### PR TITLE
Change how RATE_LIMIT is reported in logs

### DIFF
--- a/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
+++ b/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
@@ -448,8 +448,10 @@ public final class BFTSync implements BFTSyncer {
   private String outboundRateLimitLogMessage(
       String reason, Round round, NodeId author, GetVerticesRequest request) {
     return String.format(
-        "RATE_LIMIT: Outbound BFT Sync request %s for round %s due to %s to %s was not sent"
-            + " because we're over our %s/second rate limit on sync requests.",
+        """
+			RATE_LIMIT: Outbound BFT Sync request %s for round %s due to %s to %s was not sent\
+			 because we're over our %s/second rate limit on sync requests.
+			This can happen if a node has a temporarily flaky internet connection.""",
         request, round, reason, author, this.syncRequestRateLimiter.getRate());
   }
 

--- a/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
+++ b/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
@@ -433,9 +433,9 @@ public final class BFTSync implements BFTSyncer {
       } else {
         // Report issue. Once per second as info-level message, rest as debug
         if (loggingRateLimiter.tryAcquire() && log.isInfoEnabled()) {
-          log.info(buildMessage(reason, round, authors, request));
+          log.info(outboundRateLimitLogMessage(reason, round, authors, request));
         } else if (log.isDebugEnabled()) {
-          log.debug(buildMessage(reason, round, authors, request));
+          log.debug(outboundRateLimitLogMessage(reason, round, authors, request));
         }
       }
       this.bftSyncing.put(request, syncRequestState);
@@ -443,7 +443,7 @@ public final class BFTSync implements BFTSyncer {
     syncRequestState.syncIds.add(syncId);
   }
 
-  private String buildMessage(
+  private String outboundRateLimitLogMessage(
       String reason, Round round, ImmutableList<NodeId> authors, GetVerticesRequest request) {
     return String.format(
         "RATE_LIMIT: Outbound BFT Sync request %s for round %s due to %s to %s was not sent"

--- a/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
+++ b/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
@@ -92,6 +92,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 
 /** Manages keeping the VertexStore and pacemaker in sync for consensus */
 public final class BFTSync implements BFTSyncer {
@@ -173,6 +174,7 @@ public final class BFTSync implements BFTSyncer {
 
   // FIXME: Remove this once sync is fixed
   private final RateLimiter syncRequestRateLimiter;
+  private final RateLimiter loggingRateLimiter = RateLimiter.create(1.0); // 1 per second
 
   public BFTSync(
       BFTValidatorId self,
@@ -244,7 +246,7 @@ public final class BFTSync implements BFTSyncer {
     }
 
     return switch (vertexStore.insertQc(qc)) {
-      case VertexStore.InsertQcResult.Inserted inserted -> {
+      case VertexStore.InsertQcResult.Inserted ignored -> {
         // QC was inserted, try TC too (as it can be higher), and then process a new highQC
         highQC.highestTC().map(vertexStore::insertTimeoutCertificate);
         this.pacemakerReducer.processQC(
@@ -260,7 +262,7 @@ public final class BFTSync implements BFTSyncer {
         }
         yield SyncResult.SYNCED;
       }
-      case VertexStore.InsertQcResult.VertexIsMissing vertexIsMissing -> {
+      case VertexStore.InsertQcResult.VertexIsMissing ignored -> {
         // QC is missing some vertices, sync up
         // TC (if present) is put aside for now (and reconsidered later, once QC is synced)
         log.trace("SYNC_TO_QC: Need sync: {}", highQC);
@@ -427,19 +429,27 @@ public final class BFTSync implements BFTSyncer {
 
     if (syncRequestState.syncIds.isEmpty()) {
       if (this.syncRequestRateLimiter.tryAcquire()) {
-        VertexRequestTimeout scheduledTimeout = new VertexRequestTimeout(request);
-        this.timeoutDispatcher.dispatch(scheduledTimeout, bftSyncPatienceMillis);
+        this.timeoutDispatcher.dispatch(new VertexRequestTimeout(request), bftSyncPatienceMillis);
         this.requestSender.dispatch(authors.get(0), request);
       } else {
-        log.warn(
-            String.format(
-                "RATE_LIMIT: Outbound BFT Sync request %s for round %s due to %s to %s was not sent"
-                    + " because we're over our %s/second rate limit on sync requests",
-                request, round, reason, authors.get(0), this.syncRequestRateLimiter.getRate()));
+        // Report issue. Once per second as info-level message, rest as debug
+        if (loggingRateLimiter.tryAcquire() && log.isInfoEnabled()) {
+          log.info(buildMessage(reason, round, authors, request));
+        } else if (log.isDebugEnabled()) {
+          log.debug(buildMessage(reason, round, authors, request));
+        }
       }
       this.bftSyncing.put(request, syncRequestState);
     }
     syncRequestState.syncIds.add(syncId);
+  }
+
+  private @NotNull String buildMessage(
+      String reason, Round round, ImmutableList<NodeId> authors, GetVerticesRequest request) {
+    return String.format(
+        "RATE_LIMIT: Outbound BFT Sync request %s for round %s due to %s to %s was not sent"
+            + " because we're over our %s/second rate limit on sync requests.",
+        request, round, reason, authors.get(0), this.syncRequestRateLimiter.getRate());
   }
 
   private void rebuildAndSyncQC(SyncState syncState) {
@@ -523,7 +533,7 @@ public final class BFTSync implements BFTSyncer {
           localSyncRequestEventDispatcher.dispatch(
               new LocalSyncRequest(ofConensusQc.ledgerProof(), nodeIds));
         }
-        case ProcessedQcCommit.OfInitialEpochQc ofInitialEpochQc -> {
+        case ProcessedQcCommit.OfInitialEpochQc ignored -> {
           // BFTSync somehow decided it needs to ledger-sync
           // to a header that should already be committed (epoch initial).
           // This should never happen, but if by any chance it does,

--- a/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
+++ b/core/src/main/java/com/radixdlt/consensus/sync/BFTSync.java
@@ -92,7 +92,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 /** Manages keeping the VertexStore and pacemaker in sync for consensus */
 public final class BFTSync implements BFTSyncer {
@@ -444,7 +443,7 @@ public final class BFTSync implements BFTSyncer {
     syncRequestState.syncIds.add(syncId);
   }
 
-  private @NotNull String buildMessage(
+  private String buildMessage(
       String reason, Round round, ImmutableList<NodeId> authors, GetVerticesRequest request) {
     return String.format(
         "RATE_LIMIT: Outbound BFT Sync request %s for round %s due to %s to %s was not sent"


### PR DESCRIPTION
Small change, which reduces the frequency of the RATE_LIMIT message and shifts it to INFO level. Remaining messages logged at DEBUG level.