### PR TITLE
Add CI for rust code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           RADIXDLT_LOG_LEVEL: error
         run: ./gradlew clean check jacocoTestReport --stacktrace --refresh-dependencies
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: RDXWorks-actions/install-action@cargo-llvm-cov
       - name: DistZip
         run: cd ./core-rust && cargo llvm-cov --html && cd target && zip -9r ../../core/build/distributions/core-rust-coverage.zip ./llvm-cov/* && cd ../.. && ./gradlew distZip
       - name: Publish Java distZip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,9 @@ jobs:
         env:
           RADIXDLT_LOG_LEVEL: error
         run: ./gradlew clean check jacocoTestReport --stacktrace --refresh-dependencies
-      - name: DistZip
+      - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: DistZip
         run: cd ./core-rust && cargo llvm-cov --html && cd target && zip -9r ../../core/build/distributions/core-rust-coverage.zip ./llvm-cov/* && cd ../.. && ./gradlew distZip
       - name: Publish Java distZip
         uses: RDXWorks-actions/upload-artifact@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,18 @@ jobs:
         run: ./gradlew clean check jacocoTestReport --stacktrace --refresh-dependencies
       - name: Install cargo-llvm-cov
         uses: RDXWorks-actions/install-action@cargo-llvm-cov
+      - name: Generate Code Coverage
+        run: cd core-rust && cargo llvm-cov --lcov --output-path lcov.info && cd ..
+      - name: Upload to CodeCov.io
+        uses: RDXWorks-actions/codecov-action@main
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          file: ./core-rust/lcov.info
+          name: codecov-rust
+          flags: rust
       - name: DistZip
-        run: mkdir -p ./core/build/distributions && cd ./core-rust && cargo llvm-cov --html && cd target && zip -9r ../../core/build/distributions/core-rust-coverage.zip ./llvm-cov/* && cd ../.. && ./gradlew distZip
+        run: ./gradlew distZip
       - name: Publish Java distZip
         uses: RDXWorks-actions/upload-artifact@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,19 @@ jobs:
         run: ./gradlew clean check jacocoTestReport --stacktrace --refresh-dependencies
       - name: Install cargo-llvm-cov
         uses: RDXWorks-actions/install-action@cargo-llvm-cov
+      - uses: radixdlt/public-iac-resuable-artifacts/fetch-secrets@main
+        with:
+          role_name: ${{ secrets.COMMON_SECRETS_ROLE_ARN }}
+          app_name: "babylon-node"
+          step_name: "codecoverage"
+          secret_prefix: "CODECOV"
+          secret_name: ${{ secrets.AWS_SECRET_NAME_CODECOV }}
+          parse_json: true
       - name: Generate Code Coverage
         run: cd core-rust && cargo llvm-cov --lcov --output-path lcov.info && cd ..
-      - name: Upload to CodeCov.io
+      - name: Upload to codecov.io
         uses: RDXWorks-actions/codecov-action@main
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           file: ./core-rust/lcov.info
           name: codecov-rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: RDXWorks-actions/install-action@cargo-llvm-cov
       - name: DistZip
-        run: cd ./core-rust && cargo llvm-cov --html && cd target && zip -9r ../../core/build/distributions/core-rust-coverage.zip ./llvm-cov/* && cd ../.. && ./gradlew distZip
+        run: mkdir -p ./core/build/distributions && cd ./core-rust && cargo llvm-cov --html && cd target && zip -9r ../../core/build/distributions/core-rust-coverage.zip ./llvm-cov/* && cd ../.. && ./gradlew distZip
       - name: Publish Java distZip
         uses: RDXWorks-actions/upload-artifact@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,9 @@ jobs:
         env:
           RADIXDLT_LOG_LEVEL: error
         run: ./gradlew clean check jacocoTestReport --stacktrace --refresh-dependencies
-      - uses: taiki-e/install-action@cargo-llvm-cov
-        run: cd ./core-rust && cargo llvm-cov --html && cd target && zip -9r ../../core/build/distributions/core-rust-coverage.zip ./llvm-cov/* && cd ../..
       - name: DistZip
-        run: ./gradlew distZip
+        uses: taiki-e/install-action@cargo-llvm-cov
+        run: cd ./core-rust && cargo llvm-cov --html && cd target && zip -9r ../../core/build/distributions/core-rust-coverage.zip ./llvm-cov/* && cd ../.. && ./gradlew distZip
       - name: Publish Java distZip
         uses: RDXWorks-actions/upload-artifact@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
         env:
           RADIXDLT_LOG_LEVEL: error
         run: ./gradlew clean check jacocoTestReport --stacktrace --refresh-dependencies
+      - uses: taiki-e/install-action@cargo-llvm-cov
+        run: cd ./core-rust && cargo llvm-cov --html && cd target && zip -9r ../../core/build/distributions/core-rust-coverage.zip ./llvm-cov/* && cd ../..
       - name: DistZip
         run: ./gradlew distZip
       - name: Publish Java distZip

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ node_modules/
 # auto-generated doc
 **/resources/documentation/*.html
 **/resources/markdown
+
+# code coverage info
+**/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Radix Babylon Node
 
+
+| Rust                                                                                                                                      | 
+|:------------------------------------------------------------------------------------------------------------------------------------------|
+| [![codecov](https://codecov.io/gh/radixdlt/babylon-node/graph/badge.svg?token=CUJDJI1IKB)](https://codecov.io/gh/radixdlt/babylon-node)   |
+
 This is the repository for the RadixDLT node, for the Babylon release and beyond.
 
 ## Integrators

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  notify:
+    wait_for_ci: true
+  max_report_age: off
+  require_ci_to_pass: true
+comment:
+  behavior: default
+  layout: "reach, diff, flags, files"
+  show_carryforward_flags: false
+coverage:
+  precision: 1
+  range: 97...98 # red -> yellow (the inside range) -> green
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 80%
+        base: auto
+        only_pulls: true
+flag_management:
+  default_rules:
+    carryforward: true

--- a/core-rust/code-coverage.sh
+++ b/core-rust/code-coverage.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# The command below requires cargo-llvm-cov to be installed.
+# See details here: https://lib.rs/crates/cargo-llvm-cov
+
+cargo llvm-cov --html


### PR DESCRIPTION
Generate code coverage for Rust part. Code coverage results are uploaded along with binaries for further review and analysys.