### PR TITLE
Tweak/improve core api substate version mapping

### DIFF
--- a/core-rust/core-api-server/src/core_api/conversions/substates/access_controller.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/access_controller.rs
@@ -7,7 +7,7 @@ pub fn to_api_access_controller_substate(
     context: &MappingContext,
     substate: &AccessControllerV2StateFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_multi_versioned!(
         substate,
         AccessControllerFieldState,
         AccessControllerV2Substate {

--- a/core-rust/core-api-server/src/core_api/conversions/substates/access_rules_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/access_rules_module.rs
@@ -7,7 +7,7 @@ pub fn to_api_owner_role_substate(
     context: &MappingContext,
     substate: &RoleAssignmentOwnerFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         RoleAssignmentModuleFieldOwnerRole,
         OwnerRoleSubstate { owner_role_entry },
@@ -35,7 +35,7 @@ pub fn to_api_access_rule_entry(
             ModuleRoleKey { module, key }
         ))
     );
-    Ok(key_value_store_optional_substate_versioned!(
+    Ok(key_value_store_optional_substate_single_versioned!(
         substate,
         RoleAssignmentModuleRuleEntry,
         models::ObjectRoleKey {

--- a/core-rust/core-api-server/src/core_api/conversions/substates/account.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/account.rs
@@ -7,7 +7,7 @@ pub fn to_api_account_state_substate(
     _context: &MappingContext,
     substate: &AccountDepositRuleFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         AccountFieldState,
         AccountSubstate {
@@ -36,7 +36,7 @@ pub fn to_api_account_vault_entry(
             })
         ))
     );
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         AccountVaultEntry,
         models::ResourceKey {
@@ -63,7 +63,7 @@ pub fn to_api_account_resource_preference_entry(
             )
         ))
     );
-    Ok(key_value_store_optional_substate_versioned!(
+    Ok(key_value_store_optional_substate_single_versioned!(
         substate,
         AccountResourcePreferenceEntry,
         models::ResourceKey {
@@ -93,7 +93,7 @@ pub fn to_api_account_authorized_depositor_entry(
             )
         ))
     );
-    Ok(key_value_store_optional_substate_versioned!(
+    Ok(key_value_store_optional_substate_single_versioned!(
         substate,
         AccountAuthorizedDepositorEntry,
         models::AuthorizedDepositorKey {

--- a/core-rust/core-api-server/src/core_api/conversions/substates/account_locker.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/account_locker.rs
@@ -18,7 +18,7 @@ pub fn to_api_account_locker_account_claim_entry(
             )
         ))
     );
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         AccountLockerAccountClaimsEntry,
         models::AccountAddressKey {

--- a/core-rust/core-api-server/src/core_api/conversions/substates/consensus_manager.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/consensus_manager.rs
@@ -18,7 +18,7 @@ pub fn to_api_registered_validators_by_stake_index_entry_substate(
         divided_stake,
         validator_address,
     } = key.clone().into_full_content();
-    Ok(index_substate_versioned!(
+    Ok(index_substate_single_versioned!(
         substate,
         ConsensusManagerRegisteredValidatorsByStakeIndexEntry,
         models::ActiveValidatorKey {
@@ -39,7 +39,7 @@ pub fn to_api_current_validator_set_substate(
     context: &MappingContext,
     substate: &ConsensusManagerCurrentValidatorSetFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ConsensusManagerFieldCurrentValidatorSet,
         CurrentValidatorSetSubstate { validator_set } => {
@@ -57,7 +57,7 @@ pub fn to_api_current_proposal_statistic_substate(
     _context: &MappingContext,
     substate: &ConsensusManagerCurrentProposalStatisticFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ConsensusManagerFieldCurrentProposalStatistic,
         CurrentProposalStatisticSubstate {
@@ -80,7 +80,7 @@ pub fn to_api_validator_rewards_substate(
     context: &MappingContext,
     substate: &ConsensusManagerValidatorRewardsFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ConsensusManagerFieldValidatorRewards,
         ValidatorRewardsSubstate {
@@ -129,7 +129,7 @@ pub fn to_api_validator_state_substate(
     context: &MappingContext,
     substate: &ValidatorStateFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ValidatorFieldState,
         ValidatorState {
@@ -210,7 +210,7 @@ pub fn to_api_validator_protocol_update_readiness_signal_substate(
     _context: &MappingContext,
     substate: &ValidatorProtocolUpdateReadinessSignalFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ValidatorFieldProtocolUpdateReadinessSignal,
         ValidatorProtocolUpdateReadinessSignalSubstate {
@@ -226,7 +226,7 @@ pub fn to_api_consensus_manager_state_substate(
     context: &MappingContext,
     substate: &ConsensusManagerStateFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ConsensusManagerFieldState,
         ConsensusManagerSubstate {
@@ -259,7 +259,7 @@ pub fn to_api_consensus_manager_config_substate(
     substate: &ConsensusManagerConfigurationFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
     let usd_price_in_xrd = Decimal::try_from(USD_PRICE_IN_XRD).unwrap();
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ConsensusManagerFieldConfig,
         ConsensusManagerConfigSubstate {
@@ -325,7 +325,7 @@ pub fn to_api_epoch_change_condition(
 pub fn to_api_current_time_substate(
     substate: &ConsensusManagerProposerMilliTimestampFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ConsensusManagerFieldCurrentTime,
         ProposerMilliTimestampSubstate { epoch_milli },
@@ -338,7 +338,7 @@ pub fn to_api_current_time_substate(
 pub fn to_api_current_time_rounded_to_minutes_substate(
     substate: &ConsensusManagerProposerMinuteTimestampFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         ConsensusManagerFieldCurrentTimeRoundedToMinutes,
         ProposerMinuteTimestampSubstate { epoch_minute },

--- a/core-rust/core-api-server/src/core_api/conversions/substates/metadata_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/metadata_module.rs
@@ -14,7 +14,7 @@ pub fn to_api_metadata_value_substate(
             entry_name
         ))
     );
-    Ok(key_value_store_optional_substate_versioned!(
+    Ok(key_value_store_optional_substate_single_versioned!(
         substate,
         MetadataModuleEntry,
         models::MetadataKey {

--- a/core-rust/core-api-server/src/core_api/conversions/substates/mod.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports, unused_macros)]
+
 mod access_controller;
 mod access_rules_module;
 mod account;
@@ -84,7 +86,7 @@ macro_rules! field_substate {
 }
 pub(crate) use field_substate;
 
-macro_rules! field_substate_versioned {
+macro_rules! field_substate_single_versioned {
     (
         $substate:ident,
         $substate_type:ident,
@@ -102,8 +104,7 @@ macro_rules! field_substate_versioned {
                 is_locked: matches!($substate.lock_status(), LockStatus::Locked),
                 value: {
                     // NB: We should use compiler to unpack to ensure we map all fields
-                    let $value_unpacking = &scrypto_clone($substate.payload())
-                        .fully_update_and_into_latest_version();
+                    let $value_unpacking = $substate.payload().as_unique_version();
                     $($($mapping)+)?;
                     Box::new(models::[<$substate_type Value>] $fields)
                 }
@@ -111,7 +112,36 @@ macro_rules! field_substate_versioned {
         }
     };
 }
-pub(crate) use field_substate_versioned;
+pub(crate) use field_substate_single_versioned;
+
+macro_rules! field_substate_multi_versioned {
+    (
+        $substate:ident,
+        $substate_type:ident,
+        $value_unpacking:pat $(=> {
+            $($mapping:stmt)+
+        })?,
+        Value $fields:tt$(,)?
+    ) => {
+        paste::paste! {
+            // The trailing semicolon after the $($($mapping)+)?; output is occasionally needed,
+            // eg if the mapping ends with a match statement. But otherwise it's reported as a
+            // redundant - so add this allow statement to allow us just to include it regardless.
+            #[allow(redundant_semicolons)]
+            models::Substate::[<$substate_type Substate>] {
+                is_locked: matches!($substate.lock_status(), LockStatus::Locked),
+                value: {
+                    let latest = create_latest_version_from_payload($substate.payload());
+                    // NB: We should use compiler to unpack to ensure we map all fields
+                    let $value_unpacking = latest.as_ref();
+                    $($($mapping)+)?;
+                    Box::new(models::[<$substate_type Value>] $fields)
+                }
+            }
+        }
+    };
+}
+pub(crate) use field_substate_multi_versioned;
 
 macro_rules! system_field_substate {
     (
@@ -164,7 +194,7 @@ macro_rules! key_value_store_optional_substate {
 }
 pub(crate) use key_value_store_optional_substate;
 
-macro_rules! key_value_store_optional_substate_versioned {
+macro_rules! key_value_store_optional_substate_single_versioned {
     (
         $substate:ident,
         $substate_type:ident,
@@ -179,8 +209,7 @@ macro_rules! key_value_store_optional_substate_versioned {
                     .get_optional_value()
                     .map(|opt| -> Result<_, MappingError> {
                         #[allow(clippy::let_unit_value)]
-                        let $value_unpacking = &scrypto_clone(opt)
-                            .fully_update_and_into_latest_version();
+                        let $value_unpacking = opt.as_unique_version();
                         Ok(Box::new(models::[<$substate_type Value>] $fields))
                     })
                     .transpose()?,
@@ -188,7 +217,34 @@ macro_rules! key_value_store_optional_substate_versioned {
         }
     };
 }
-pub(crate) use key_value_store_optional_substate_versioned;
+pub(crate) use key_value_store_optional_substate_single_versioned;
+
+macro_rules! key_value_store_optional_substate_multi_versioned {
+    (
+        $substate:ident,
+        $substate_type:ident,
+        $key:expr,
+        $value_unpacking:pat => $fields:tt$(,)?
+    ) => {
+        paste::paste! {
+            models::Substate::[<$substate_type Substate>] {
+                is_locked: matches!($substate.lock_status(), LockStatus::Locked),
+                key: Box::new($key),
+                value: $substate
+                    .get_optional_value()
+                    .map(|opt| -> Result<_, MappingError> {
+                        let latest = create_latest_version_from_payload(opt);
+                        #[allow(clippy::let_unit_value)]
+                        // NB: We should use compiler to unpack to ensure we map all fields
+                        let $value_unpacking = latest.as_ref();
+                        Ok(Box::new(models::[<$substate_type Value>] $fields))
+                    })
+                    .transpose()?,
+            }
+        }
+    };
+}
+pub(crate) use key_value_store_optional_substate_multi_versioned;
 
 macro_rules! key_value_store_mandatory_substate {
     (
@@ -199,6 +255,7 @@ macro_rules! key_value_store_mandatory_substate {
     ) => {
         paste::paste! {
             {
+                // NB: We should use compiler to unpack to ensure we map all fields
                 let $value_unpacking = $substate.get_definitely_present_value()?;
                 models::Substate::[<$substate_type Substate>] {
                     is_locked: matches!($substate.lock_status(), LockStatus::Locked),
@@ -211,7 +268,7 @@ macro_rules! key_value_store_mandatory_substate {
 }
 pub(crate) use key_value_store_mandatory_substate;
 
-macro_rules! key_value_store_mandatory_substate_versioned {
+macro_rules! key_value_store_mandatory_substate_single_versioned {
     (
         $substate:ident,
         $substate_type:ident,
@@ -220,8 +277,8 @@ macro_rules! key_value_store_mandatory_substate_versioned {
     ) => {
         paste::paste! {
             {
-                let $value_unpacking = &scrypto_clone($substate.get_definitely_present_value()?)
-                    .fully_update_and_into_latest_version();
+                // NB: We should use compiler to unpack to ensure we map all fields
+                let $value_unpacking = $substate.get_definitely_present_value()?.as_unique_version();
                 models::Substate::[<$substate_type Substate>] {
                     is_locked: matches!($substate.lock_status(), LockStatus::Locked),
                     key: Box::new($key),
@@ -231,7 +288,30 @@ macro_rules! key_value_store_mandatory_substate_versioned {
         }
     };
 }
-pub(crate) use key_value_store_mandatory_substate_versioned;
+pub(crate) use key_value_store_mandatory_substate_single_versioned;
+
+macro_rules! key_value_store_mandatory_substate_multi_versioned {
+    (
+        $substate:ident,
+        $substate_type:ident,
+        $key:expr,
+        $value_unpacking:pat => $fields:tt$(,)?
+    ) => {
+        paste::paste! {
+            {
+                let latest = create_latest_version_from_payload($substate.get_definitely_present_value()?);
+                // NB: We should use compiler to unpack to ensure we map all fields
+                let $value_unpacking = latest.as_ref();
+                models::Substate::[<$substate_type Substate>] {
+                    is_locked: matches!($substate.lock_status(), LockStatus::Locked),
+                    key: Box::new($key),
+                    value: Box::new(models::[<$substate_type Value>] $fields)
+                }
+            }
+        }
+    };
+}
+pub(crate) use key_value_store_mandatory_substate_multi_versioned;
 
 macro_rules! index_substate {
     (
@@ -251,7 +331,7 @@ macro_rules! index_substate {
 }
 pub(crate) use index_substate;
 
-macro_rules! index_substate_versioned {
+macro_rules! index_substate_single_versioned {
     (
         $substate:ident,
         $substate_type:ident,
@@ -260,8 +340,7 @@ macro_rules! index_substate_versioned {
     ) => {
         paste::paste! {
             {
-                let $value_unpacking = &scrypto_clone($substate.value())
-                    .fully_update_and_into_latest_version();
+                let $value_unpacking = $substate.value().as_unique_version();
                 models::Substate::[<$substate_type Substate>] {
                     is_locked: false,
                     key: Box::new($key),
@@ -271,7 +350,30 @@ macro_rules! index_substate_versioned {
         }
     };
 }
-pub(crate) use index_substate_versioned;
+pub(crate) use index_substate_single_versioned;
+
+macro_rules! index_substate_multi_versioned {
+    (
+        $substate:ident,
+        $substate_type:ident,
+        $key:expr,
+        $value_unpacking:pat => $fields:tt$(,)?
+    ) => {
+        paste::paste! {
+            {
+                let latest = create_latest_version_from_payload($substate.value());
+                // NB: We should use compiler to unpack to ensure we map all fields
+                let $value_unpacking = latest.as_ref();
+                models::Substate::[<$substate_type Substate>] {
+                    is_locked: false,
+                    key: Box::new($key),
+                    value: Box::new(models::[<$substate_type Value>] $fields)
+                }
+            }
+        }
+    };
+}
+pub(crate) use index_substate_multi_versioned;
 
 trait WrapperMethods<C> {
     fn get_definitely_present_value(&self) -> Result<&C, MappingError> {
@@ -289,12 +391,44 @@ impl<C> WrapperMethods<C> for KeyValueEntrySubstate<C> {
     }
 }
 
-/// "Clones" an SBOR-encodable value.
-/// Note: this hack is required since many of the Substate value structs do not support [`Clone`],
-/// and the convenient "into latest" method (which we need in order to output the value according to
-/// the "current" Core API schema) needs an owned instance. A true fix should involve either cloning
-/// or some other way of "get latest from reference" on the Engine's side.
-fn scrypto_clone<T: ScryptoSbor>(value: &T) -> T {
-    let bytes = scrypto_encode(value).expect("cannot encode");
-    scrypto_decode(&bytes).expect("cannot decode")
+/// Returns either a reference to the latest version if the payload is already at the latest version,
+/// or does a more expensive clone, and then updates the payload.
+///
+/// To avoid this overhead, if you know a payload is single versioned, you can just use `as_unique_version`
+/// which only exists on single-versioned items.
+fn create_latest_version_from_payload<'a, P, T>(payload: &'a P) -> SimpleCow<'a, T::LatestVersion>
+where
+    P: core::ops::Deref<Target = T>, // Note - the payload itself isn't Versioned, but Derefs to the content which is Versioned.
+    T: ScryptoSbor + Versioned + 'a,
+{
+    let versioned_content = payload.deref();
+    if let Some(latest) = versioned_content.as_latest_version() {
+        // Save on an expensive clone if we're already the latest version
+        SimpleCow::Borrowed(latest)
+    } else {
+        // Otherwise, we need to clone the value, but the type isn't necessarily Clone.
+        // So instead, we implement "clone" via SBOR-encoding value.
+        // Note: this hack is required since many of the Substate value structs do not support [`Clone`],
+        // and the convenient "into latest" method (which we need in order to output the value according to
+        // the "current" Core API schema) needs an owned instance. A true fix should involve either cloning
+        // or some other way of "get latest from reference" on the Engine's side.
+        let bytes = scrypto_encode(versioned_content).expect("cannot encode");
+        let cloned = scrypto_decode::<T>(&bytes).expect("cannot decode");
+        SimpleCow::Owned(cloned.fully_update_and_into_latest_version())
+    }
+}
+
+// Unlike Cow, this doesn't require that B implements ToOwned / Clone.
+pub enum SimpleCow<'a, B: 'a> {
+    Borrowed(&'a B),
+    Owned(B),
+}
+
+impl<'a, B: 'a> AsRef<B> for SimpleCow<'a, B> {
+    fn as_ref(&self) -> &B {
+        match self {
+            SimpleCow::Borrowed(b) => b,
+            SimpleCow::Owned(b) => b,
+        }
+    }
 }

--- a/core-rust/core-api-server/src/core_api/conversions/substates/package.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/package.rs
@@ -7,7 +7,7 @@ pub fn to_api_package_royalty_accumulator_substate(
     context: &MappingContext,
     substate: &PackageRoyaltyAccumulatorFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         PackageFieldRoyaltyAccumulator,
         PackageRoyaltyAccumulator { royalty_vault },
@@ -34,7 +34,7 @@ pub fn to_api_package_code_vm_type_entry_substate(
         ))
     );
 
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         PackageCodeVmTypeEntry,
         models::PackageCodeKey {
@@ -63,7 +63,7 @@ pub fn to_api_package_code_original_code_entry_substate(
         ))
     );
 
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         PackageCodeOriginalCodeEntry,
         models::PackageCodeKey {
@@ -89,7 +89,7 @@ pub fn to_api_package_code_instrumented_code_entry_substate(
         ))
     );
 
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         PackageCodeInstrumentedCodeEntry,
         models::PackageCodeKey {
@@ -111,7 +111,7 @@ pub fn to_api_schema_entry_substate(
         TypedSubstateKey::Schema(TypedSchemaSubstateKey::SchemaKey(hash))
     );
 
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         SchemaEntry,
         models::SchemaKey {
@@ -139,7 +139,7 @@ pub fn to_api_package_blueprint_definition_entry(
         ))
     );
 
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         PackageBlueprintDefinitionEntry,
         to_api_blueprint_version_key(context, blueprint_version_key)?,
@@ -165,7 +165,7 @@ pub fn to_api_package_blueprint_dependencies_entry(
         ))
     );
 
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         PackageBlueprintDependenciesEntry,
         to_api_blueprint_version_key(context, blueprint_version_key)?,
@@ -191,7 +191,7 @@ pub fn to_api_package_blueprint_royalty_entry(
         ))
     );
 
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         PackageBlueprintRoyaltyEntry,
         to_api_blueprint_version_key(context, blueprint_version_key)?,
@@ -239,7 +239,7 @@ pub fn to_api_package_auth_template_entry(
             )
         ))
     );
-    Ok(key_value_store_mandatory_substate_versioned!(
+    Ok(key_value_store_mandatory_substate_single_versioned!(
         substate,
         PackageBlueprintAuthTemplateEntry,
         to_api_blueprint_version_key(context, blueprint_version_key)?,

--- a/core-rust/core-api-server/src/core_api/conversions/substates/pools.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/pools.rs
@@ -7,7 +7,7 @@ pub fn to_api_one_resource_pool_substate(
     context: &MappingContext,
     substate: &OneResourcePoolStateFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         OneResourcePoolFieldState,
         OneResourcePoolState {
@@ -28,7 +28,7 @@ pub fn to_api_two_resource_pool_substate(
     context: &MappingContext,
     substate: &TwoResourcePoolStateFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         TwoResourcePoolFieldState,
         TwoResourcePoolState {
@@ -56,7 +56,7 @@ pub fn to_api_multi_resource_pool_substate(
     context: &MappingContext,
     substate: &MultiResourcePoolStateFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         MultiResourcePoolFieldState,
         MultiResourcePoolState {

--- a/core-rust/core-api-server/src/core_api/conversions/substates/resource.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/resource.rs
@@ -7,7 +7,7 @@ pub fn to_api_fungible_vault_balance_substate(
     _context: &MappingContext,
     substate: &FungibleVaultBalanceFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         FungibleVaultFieldBalance,
         balance,
@@ -21,7 +21,7 @@ pub fn to_api_fungible_vault_frozen_status_substate(
     _context: &MappingContext,
     substate: &FungibleVaultFreezeStatusFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         FungibleVaultFieldFrozenStatus,
         VaultFrozenFlag { frozen },
@@ -46,7 +46,7 @@ pub fn to_api_non_fungible_vault_balance_substate(
     _context: &MappingContext,
     substate: &NonFungibleVaultBalanceFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         NonFungibleVaultFieldBalance,
         NonFungibleVaultBalance { amount },
@@ -60,7 +60,7 @@ pub fn to_api_non_fungible_vault_frozen_status_substate(
     _context: &MappingContext,
     substate: &NonFungibleVaultFreezeStatusFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         FungibleVaultFieldFrozenStatus,
         VaultFrozenFlag { frozen },
@@ -100,7 +100,7 @@ pub fn to_api_non_fungible_vault_contents_entry_substate(
 pub fn to_api_fungible_resource_manager_divisibility_substate(
     substate: &FungibleResourceManagerDivisibilityFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         FungibleResourceManagerFieldDivisibility,
         divisibility,
@@ -113,7 +113,7 @@ pub fn to_api_fungible_resource_manager_divisibility_substate(
 pub fn to_api_fungible_resource_manager_total_supply_substate(
     substate: &FungibleResourceManagerTotalSupplyFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         FungibleResourceManagerFieldTotalSupply,
         total_supply,
@@ -126,7 +126,7 @@ pub fn to_api_fungible_resource_manager_total_supply_substate(
 pub fn to_api_non_fungible_resource_manager_id_type_substate(
     substate: &NonFungibleResourceManagerIdTypeFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         NonFungibleResourceManagerFieldIdType,
         non_fungible_id_type,
@@ -139,7 +139,7 @@ pub fn to_api_non_fungible_resource_manager_id_type_substate(
 pub fn to_api_non_fungible_resource_manager_total_supply_substate(
     substate: &NonFungibleResourceManagerTotalSupplyFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         NonFungibleResourceManagerFieldTotalSupply,
         total_supply,
@@ -153,7 +153,7 @@ pub fn to_api_non_fungible_resource_manager_mutable_fields_substate(
     context: &MappingContext,
     substate: &NonFungibleResourceManagerMutableFieldsFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         NonFungibleResourceManagerFieldMutableFields,
         NonFungibleResourceManagerMutableFields {

--- a/core-rust/core-api-server/src/core_api/conversions/substates/royalty_module.rs
+++ b/core-rust/core-api-server/src/core_api/conversions/substates/royalty_module.rs
@@ -7,7 +7,7 @@ pub fn to_api_component_royalty_substate(
     context: &MappingContext,
     substate: &ComponentRoyaltyAccumulatorFieldSubstate,
 ) -> Result<models::Substate, MappingError> {
-    Ok(field_substate_versioned!(
+    Ok(field_substate_single_versioned!(
         substate,
         RoyaltyModuleFieldState,
         ComponentRoyaltySubstate { royalty_vault },
@@ -32,7 +32,7 @@ pub fn to_api_component_method_royalty_substate(
             TypedRoyaltyModuleSubstateKey::RoyaltyMethodRoyaltyEntryKey(method_name)
         )
     );
-    Ok(key_value_store_optional_substate_versioned!(
+    Ok(key_value_store_optional_substate_single_versioned!(
         substate,
         RoyaltyModuleMethodRoyaltyEntry,
         models::MainMethodKey {

--- a/core-rust/state-manager/src/lib.rs
+++ b/core-rust/state-manager/src/lib.rs
@@ -99,7 +99,6 @@ pub use crate::types::*;
 pub mod engine_prelude {
     pub use radix_common::prelude::*;
 
-    pub use radix_engine::*;
     pub use radix_engine::errors::*;
     pub use radix_engine::system::bootstrap::*;
     #[cfg(feature = "db_checker")]
@@ -109,9 +108,10 @@ pub mod engine_prelude {
     pub use radix_engine::transaction::*;
     pub use radix_engine::updates::*;
     pub use radix_engine::vm::*;
+    pub use radix_engine::*;
 
-    pub use radix_engine_interface::blueprints::transaction_processor::*;
     pub use radix_engine_interface::blueprints::account::*;
+    pub use radix_engine_interface::blueprints::transaction_processor::*;
     pub use radix_engine_interface::prelude::*;
 
     pub use radix_substate_store_impls::state_tree::tree_store::*;
@@ -125,12 +125,12 @@ pub mod engine_prelude {
     pub use radix_transaction_scenarios::scenario::*;
 
     pub use radix_transactions::builder::*;
+    pub use radix_transactions::define_raw_transaction_payload;
     pub use radix_transactions::errors::*;
     pub use radix_transactions::manifest::*;
     pub use radix_transactions::model::*;
     pub use radix_transactions::prelude::*;
     pub use radix_transactions::validation::*;
-    pub use radix_transactions::*;
 
     // Note: plain `pub use radix_engine::track::*` would clash with the top-level `utils::prelude`
     // (because it contains a private module of the same name)


### PR DESCRIPTION
## Summary

Small improvements to https://github.com/radixdlt/babylon-node/pull/946

## Details

* The as-performant-as-before version macro `_single_versioned!` now makes use of the `.as_unique_version()` method for single-versioned types which is _only available on substates with a single version_ - else it gives a compiler error.
* If you have a multi-versioned substate, you can use an alternative `..._multi_versioned!` macro. This only updates to the latest if the substate isn't already the latest, as a little perf optimisation.

## Testing

Automated tests still pass. Clippy via `./gradlew spotlessApply` now passes without warnings.