### PR TITLE
Return uninstantiated Entity info from Engine via staged instantiation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ ENV VERSION_LAST_TAG=$VERSION_LAST_TAG
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     docker.io=20.10.24+dfsg1-1+b3 \
-    libssl-dev=3.0.11-1~deb12u2 \
+    libssl-dev=3.0.13-1~deb12u1 \
     pkg-config=1.8.1-1 \
     unzip=6.0-28 \
     wget=${WGET_VERSION} \
@@ -103,7 +103,7 @@ COPY --from=java-build-stage /radixdlt/core/build/distributions /
 # LAYER: library-build-stage-base
 # Creates the base image for building the rust library
 # =================================================================================================
-FROM debian:12.1-slim as library-build-stage-base
+FROM debian:12.1-slim AS library-build-stage-base
 WORKDIR /app
 
 
@@ -126,12 +126,12 @@ RUN apt-get update \
     ca-certificates \
     build-essential=12.9 \
     # https://security-tracker.debian.org/tracker/CVE-2023-38545
-    curl=7.88.1-10+deb12u5 \
+    curl=7.88.1-10+deb12u6 \
     g++-aarch64-linux-gnu \
     g++-x86-64-linux-gnu \
     libc6-dev-arm64-cross=2.36-8cross1 \
     libclang-dev=1:14.0-55.7~deb12u1 \
-    libssl-dev=3.0.11-1~deb12u2 \
+    libssl-dev=3.0.13-1~deb12u1 \
     pkg-config=1.8.1-1 \
   && rm -rf /var/lib/apt/lists/*
 
@@ -152,7 +152,7 @@ ENV RUSTC_WRAPPER=/root/.cargo/bin/sccache
 # Specifically - the Rust isn't built as part of the image, instead the CMD of the image is to do the build.
 # It allows us to use volumes at runtime to cache the build dependencies and artifacts.
 # =================================================================================================
-FROM library-build-stage-base as library-builder-local
+FROM library-build-stage-base AS library-builder-local
 WORKDIR /app
 
 COPY docker/build_scripts/cargo_local_build.sh /opt/radixdlt/cargo_local_build.sh
@@ -166,7 +166,7 @@ CMD ["/opt/radixdlt/cargo_local_build.sh"]
 # LAYER: library-build-stage-cache-packages
 # This layer allows us to cache the compilation of all our rust dependencies in a Docker layer
 # =================================================================================================
-FROM library-build-stage-base as library-build-stage-cache-packages
+FROM library-build-stage-base AS library-build-stage-cache-packages
 
 WORKDIR /app
 
@@ -204,7 +204,7 @@ RUN --mount=type=cache,id=radixdlt-babylon-node-rust-cache,target=/root/.cache/s
 # LAYER: library-build-stage
 # The actual build of the library
 # =================================================================================================
-FROM library-build-stage-cache-packages as library-build-stage
+FROM library-build-stage-cache-packages AS library-build-stage
 
 # Tidy up from the previous layer
 RUN rm -rf core-api-server engine-state-api-server jni-export node-common state-manager
@@ -225,14 +225,14 @@ RUN --mount=type=cache,id=radixdlt-babylon-node-rust-cache,target=/root/.cache/s
 # LAYER: library-container
 # A layer containing just the built library at the root: /libcorerust.so
 # =================================================================================================
-FROM scratch as library-container
+FROM scratch AS library-container
 COPY --from=library-build-stage /libcorerust.so /
 
 # =================================================================================================
 # LAYER: app-container
 # The application container which will actually run the application
 # =================================================================================================
-FROM debian:12.1-slim as app-container
+FROM debian:12.1-slim AS app-container
 
 LABEL org.opencontainers.image.source="https://github.com/radixdlt/babylon-node"
 LABEL org.opencontainers.image.authors="devops@radixdlt.com"
@@ -258,7 +258,7 @@ RUN apt-get update -y \
   && apt-get -y --no-install-recommends install \
     openjdk-17-jre-headless=17.0.11+9-1~deb12u1 \
     # https://security-tracker.debian.org/tracker/CVE-2023-38545
-    curl=7.88.1-10+deb12u5 \
+    curl=7.88.1-10+deb12u6 \
     gettext-base=0.21-12 \
     daemontools=1:0.76-8.1 \
     # https://security-tracker.debian.org/tracker/CVE-2023-4911

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ENV VERSION_LAST_TAG=$VERSION_LAST_TAG
 # - https://packages.debian.org/bookworm/pkg-config
 # - https://packages.debian.org/bookworm/unzip
 # - https://packages.debian.org/bookworm/wget
-# - https://packages.debian.org/bookworm/software-properties-commo
+# - https://packages.debian.org/bookworm/software-properties-common
 # - https://packages.debian.org/bookworm/openjdk-17-jdk
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -54,7 +54,7 @@ RUN apt-get update \
     pkg-config=1.8.1-1 \
     unzip=6.0-28 \
     wget=${WGET_VERSION} \
-    software-properties-common=0.99.30-4 \
+    software-properties-common=0.99.30-4.1~deb12u1 \
   && apt-get install -y --no-install-recommends \
     openjdk-17-jdk=17.0.11+9-1~deb12u1 \
   && apt-get clean \
@@ -265,7 +265,7 @@ RUN apt-get update -y \
     # Fixes CVE-2023-4911 can be removed when we update the base OS image to include this fix
     # docker run -it debian:12.1-slim ldd --version
     # This fix can be removed as long as the version printed in the above command is 2.36-9+deb12u3 or above
-    libc6=2.36-9+deb12u4 \
+    libc6=2.36-9+deb12u7 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
+++ b/core-rust/core-api-server/src/core_api/handlers/transaction_callpreview.rs
@@ -75,9 +75,7 @@ pub(crate) async fn handle_transaction_callpreview(
     let result = state.state_manager.transaction_previewer.preview(
         PreviewRequest {
             manifest: TransactionManifestV1 {
-                instructions: vec![
-                    requested_call,
-                ],
+                instructions: vec![requested_call],
                 blobs: index_map_new(),
             },
             start_epoch_inclusive: None,

--- a/core-rust/engine-state-api-server/src/engine_state_api/readers.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/readers.rs
@@ -4,6 +4,13 @@ use crate::engine_prelude::*;
 
 use convert_case::{Case, Casing};
 use itertools::Itertools;
+use radix_engine::transaction::{
+    execute_and_commit_transaction, CommitResult, ExecutionConfig, StateUpdateSummary,
+    TransactionResult,
+};
+use radix_engine::vm::wasm::DefaultWasmEngine;
+use radix_engine::vm::{NoExtension, ScryptoVm, VmInit};
+use radix_substate_store_impls::substate_database_overlay::SubstateDatabaseOverlay;
 
 use state_manager::store::traits::indices::{
     CreationId, EntityBlueprintId, EntityBlueprintIdV1, EntityListingIndex,
@@ -28,6 +35,10 @@ pub struct EngineStateMetaLoader<'s, S: SubstateDatabase> {
     // same data multiple times, or avoid parsing large parts of SBOR). We can either extend the
     // Engine's reader, or implement required lower-level logic here.
     reader: SystemDatabaseReader<'s, S>,
+    // Note: we also need the direct reference to the `SubstateDatabase`, because it is required for
+    // a staged instantiation of "global virtual" entities (and the `SystemDatabaseReader` above
+    // does not expose it).
+    database: &'s S,
 }
 
 impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
@@ -35,6 +46,7 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
     pub fn new(database: &'s S) -> Self {
         Self {
             reader: SystemDatabaseReader::new(database),
+            database,
         }
     }
 
@@ -138,9 +150,7 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
             Err(error) => match error {
                 SystemReaderError::NodeIdDoesNotExist => {
                     if node_id.is_global_virtual() {
-                        return self.derive_uninstantiated_entity_meta(
-                            node_id.entity_type().expect("we just checked its type"),
-                        );
+                        return self.derive_uninstantiated_entity_meta(node_id);
                     }
                     return Err(EngineStateBrowsingError::RequestedItemNotFound(
                         ItemKind::Entity,
@@ -154,53 +164,17 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
                 }
             },
         };
-        match type_info {
-            TypeInfoSubstate::Object(object_info) => Ok(EntityMeta::Object(
-                self.load_object_meta(node_id, object_info)?,
-            )),
-            TypeInfoSubstate::KeyValueStore(kv_store_info) => Ok(EntityMeta::KeyValueStore(
-                self.load_kv_store_meta(node_id, kv_store_info)?,
-            )),
-            TypeInfoSubstate::GlobalAddressReservation(_)
-            | TypeInfoSubstate::GlobalAddressPhantom(_) => {
-                Err(EngineStateBrowsingError::RequestedItemInvalid(
-                    ItemKind::Entity,
-                    "entity neither an object nor a KV store".to_string(),
-                ))
-            }
-        }
+        EntityInfoLoader::new(&self.reader).load_instantiated_entity_meta(type_info, node_id)
     }
 
     /// Loads metadata on "state" (i.e. all fields and collections) of the given object's module.
     /// Does *not* support uninstantiated objects.
-    ///
-    /// API note: this is normally a part of the [`Self::load_entity_meta()`] result, but some
-    /// clients are interested only in specific module and can use this cheaper method.
     pub fn load_object_module_state_meta(
         &self,
         node_id: &NodeId,
         module_id: ModuleId,
     ) -> Result<ObjectModuleStateMeta, EngineStateBrowsingError> {
-        let type_target = self
-            .reader
-            .get_blueprint_type_target(node_id, module_id)
-            .map_err(|error| match error {
-                SystemReaderError::NodeIdDoesNotExist => {
-                    EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Entity)
-                }
-                SystemReaderError::ModuleDoesNotExist => {
-                    EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Module)
-                }
-                SystemReaderError::NotAnObject => EngineStateBrowsingError::RequestedItemInvalid(
-                    ItemKind::Entity,
-                    "not an object".to_string(),
-                ),
-                unexpected => EngineStateBrowsingError::UnexpectedEngineError(
-                    unexpected,
-                    "when getting type target".to_string(),
-                ),
-            })?;
-        self.load_blueprint_state_meta(&type_target)
+        EntityInfoLoader::new(&self.reader).load_object_module_state_meta(node_id, module_id)
     }
 
     /// Loads extra metadata on the given field (a part of [`Self::load_blueprint_meta()`]).
@@ -393,7 +367,7 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
         index: usize,
         schema: BlueprintCollectionSchema<BlueprintPayloadDef>,
     ) -> Result<BlueprintCollectionMeta, EngineStateBrowsingError> {
-        let (kind, collection_schema) = Self::destructure_collection_schema(schema);
+        let (kind, collection_schema) = destructure_collection_schema(schema);
         let BlueprintKeyValueSchema { key, value, .. } = collection_schema;
         let declared_key_type = self.load_blueprint_type_meta(node_id, key)?;
         let declared_value_type = self.load_blueprint_type_meta(node_id, value)?;
@@ -428,7 +402,7 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
     ) -> Result<BlueprintNamedTypeMeta, EngineStateBrowsingError> {
         Ok(BlueprintNamedTypeMeta {
             name,
-            resolved_type: self
+            resolved_type: SchemaLoader::new(&self.reader)
                 .augment_with_schema(ResolvedTypeReference::new(*node_id, scoped_type_id))?,
         })
     }
@@ -442,279 +416,40 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
     ) -> Result<BlueprintTypeMeta, EngineStateBrowsingError> {
         Ok(match payload_def {
             BlueprintPayloadDef::Static(scoped_type_id) => BlueprintTypeMeta::Static(
-                self.augment_with_schema(ResolvedTypeReference::new(*node_id, scoped_type_id))?,
+                SchemaLoader::new(&self.reader)
+                    .augment_with_schema(ResolvedTypeReference::new(*node_id, scoped_type_id))?,
             ),
             BlueprintPayloadDef::Generic(index) => BlueprintTypeMeta::Generic(index),
         })
     }
 
-    /// An implementation delegate of [`Self::load_entity_meta()`] for `Object`s.
-    fn load_object_meta(
-        &self,
-        node_id: &NodeId,
-        object_info: ObjectInfo,
-    ) -> Result<ObjectMeta, EngineStateBrowsingError> {
-        let ObjectInfo {
-            blueprint_info,
-            object_type,
-        } = object_info;
-        Ok(ObjectMeta {
-            is_instantiated: true,
-            main_module_state: self.load_object_module_state_meta(node_id, ModuleId::Main)?,
-            attached_module_states: match object_type {
-                ObjectType::Global { modules } => modules
-                    .into_keys() // deliberately ignored per-module blueprint versions
-                    .map(|module_id| {
-                        Ok((
-                            module_id,
-                            self.load_object_module_state_meta(node_id, module_id.into())?,
-                        ))
-                    })
-                    .collect::<Result<IndexMap<_, _>, _>>()?,
-                ObjectType::Owned => index_map_new(),
-            },
-            blueprint_reference: BlueprintReference {
-                id: blueprint_info.blueprint_id,
-                version: blueprint_info.blueprint_version,
-            },
-            instance_meta: ObjectInstanceMeta {
-                outer_object: match blueprint_info.outer_obj_info {
-                    OuterObjectInfo::Some { outer_object } => Some(outer_object),
-                    OuterObjectInfo::None => None,
-                },
-                enabled_features: Vec::from_iter(blueprint_info.features),
-                substituted_generic_types: blueprint_info
-                    .generic_substitutions
-                    .into_iter()
-                    .map(|substitution| {
-                        TypeReferenceResolver::new(&self.reader)
-                            .resolve_generic_substitution(Some(node_id), substitution)
-                            .and_then(|resolved_type| self.augment_with_schema(resolved_type))
-                    })
-                    .collect::<Result<Vec<_>, _>>()?,
-            },
-        })
-    }
-
     /// An implementation delegate of [`Self::load_entity_meta()`] for uninstantiated entities.
-    // TODO(after development in scrypto repo): The implementation here hardcodes the results for
-    // the only currently known uninstantiated entity types (accounts and identities). A more robust
-    // solution could be implemented on the Engine's side (e.g. staged instantiation).
     fn derive_uninstantiated_entity_meta(
         &self,
-        entity_type: EntityType,
-    ) -> Result<EntityMeta, EngineStateBrowsingError> {
-        let blueprint_id = match entity_type {
-            EntityType::GlobalVirtualSecp256k1Account | EntityType::GlobalVirtualEd25519Account => {
-                BlueprintId::new(&ACCOUNT_PACKAGE, ACCOUNT_BLUEPRINT)
-            }
-            EntityType::GlobalVirtualSecp256k1Identity
-            | EntityType::GlobalVirtualEd25519Identity => {
-                BlueprintId::new(&IDENTITY_PACKAGE, IDENTITY_BLUEPRINT)
-            }
-            _ => panic!("not an uninstantiated entity type"),
-        };
-        let blueprint_info = BlueprintInfo {
-            blueprint_id,
-            blueprint_version: BlueprintVersion::default(),
-            outer_obj_info: OuterObjectInfo::None,
-            features: index_set_new(),
-            generic_substitutions: vec![],
-        };
-        Ok(EntityMeta::Object(ObjectMeta {
-            is_instantiated: false,
-            main_module_state: self.load_blueprint_state_meta(&BlueprintTypeTarget {
-                blueprint_info: blueprint_info.clone(),
-                meta: SchemaValidationMeta::Blueprint,
-            })?,
-            attached_module_states: index_map_new(),
-            blueprint_reference: BlueprintReference {
-                id: blueprint_info.blueprint_id,
-                version: blueprint_info.blueprint_version,
-            },
-            instance_meta: ObjectInstanceMeta {
-                outer_object: None,
-                enabled_features: vec![],
-                substituted_generic_types: vec![],
-            },
-        }))
-    }
-
-    /// An implementation delegate of [`Self::load_entity_meta()`] for `KeyValueStore`s.
-    fn load_kv_store_meta(
-        &self,
         node_id: &NodeId,
-        kv_store_info: KeyValueStoreInfo,
-    ) -> Result<KeyValueStoreMeta, EngineStateBrowsingError> {
-        let KeyValueStoreGenericSubstitutions {
-            key_generic_substitution,
-            value_generic_substitution,
-            ..
-        } = kv_store_info.generic_substitutions;
-        let resolver = TypeReferenceResolver::new(&self.reader);
-        Ok(KeyValueStoreMeta {
-            resolved_key_type: resolver
-                .resolve_generic_substitution(Some(node_id), key_generic_substitution)
-                .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
-            resolved_value_type: resolver
-                .resolve_generic_substitution(Some(node_id), value_generic_substitution)
-                .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
-        })
-    }
+    ) -> Result<EntityMeta, EngineStateBrowsingError> {
+        let mut staged_database = SubstateDatabaseOverlay::new_unmergeable(self.database);
 
-    /// Loads metadata of all fields and collections within the blueprint referenced by the given
-    /// [`BlueprintTypeTarget`]. The "type target" will also be used while resolving all types (see
-    /// [`TypeReferenceResolver`]).
-    fn load_blueprint_state_meta(
-        &self,
-        type_target: &BlueprintTypeTarget,
-    ) -> Result<ObjectModuleStateMeta, EngineStateBrowsingError> {
-        let blueprint_info = &type_target.blueprint_info;
-        let blueprint_id = &blueprint_info.blueprint_id;
-        let blueprint_name = blueprint_id.blueprint_name.as_str();
-        let IndexedStateSchema {
-            fields,
-            collections,
-            ..
-        } = self
-            .reader
-            .get_blueprint_definition(blueprint_id)
-            .map_err(|error| {
-                EngineStateBrowsingError::UnexpectedEngineError(
-                    error,
-                    "when getting blueprint definition".to_string(),
-                )
-            })?
-            .interface
-            .state
-            .clone();
-
-        let type_resolver = TypeReferenceResolver::new(&self.reader);
-        let conditions_context = self.load_conditions_context(blueprint_info)?;
-
-        let fields = fields
-            .into_iter()
-            .flat_map(|(_partition_description, fields)| fields)
-            .enumerate()
-            .filter(|(_index, schema)| conditions_context.meets(&schema.condition))
-            .map(|(index, schema)| {
-                Ok(ObjectFieldMeta::new(
-                    index,
-                    blueprint_id.blueprint_name.as_str(),
-                    type_resolver
-                        .resolve_type_from_blueprint_data(type_target, schema.field)
-                        .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
-                    schema.transience,
-                ))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let collections = collections
-            .into_iter()
-            .enumerate()
-            .map(|(index, (_partition_description, schema))| {
-                let (kind, collection_schema) = Self::destructure_collection_schema(schema);
-                let BlueprintKeyValueSchema { key, value, .. } = collection_schema;
-                Ok(ObjectCollectionMeta::new(
-                    index,
-                    blueprint_name,
-                    kind,
-                    type_resolver
-                        .resolve_type_from_blueprint_data(type_target, key)
-                        .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
-                    type_resolver
-                        .resolve_type_from_blueprint_data(type_target, value)
-                        .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
-                ))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(ObjectModuleStateMeta {
-            fields,
-            collections,
-        })
-    }
-
-    /// Constructs an [`ObjectConditionsContext`] from the given object's blueprint-related info.
-    /// Note: the method belongs to the `load_*` family, since it may need to actually load the
-    /// outer object's enabled feature set (if it exists) from database.
-    fn load_conditions_context(
-        &self,
-        blueprint_info: &BlueprintInfo,
-    ) -> Result<ObjectConditionsContext, EngineStateBrowsingError> {
-        let object_features = blueprint_info.features.clone();
-        let outer_object_features = match &blueprint_info.outer_obj_info {
-            OuterObjectInfo::Some { outer_object } => {
-                self.reader
-                    .get_object_info(*outer_object.as_node_id())
-                    .map_err(|error| {
-                        EngineStateBrowsingError::UnexpectedEngineError(
-                            error,
-                            "when fetching outer object's info".to_string(),
-                        )
-                    })?
-                    .blueprint_info
-                    .features
-            }
-            OuterObjectInfo::None => index_set_new(),
+        let intent = create_intent_forcing_instantiation(node_id);
+        let receipt = execute_and_commit_transaction(
+            &mut staged_database,
+            VmInit::new(&ScryptoVm::<DefaultWasmEngine>::default(), NoExtension),
+            &ExecutionConfig::default(),
+            &intent.get_executable(),
+        );
+        let TransactionResult::Commit(commit) = receipt.result else {
+            panic!("failed to force instantiation: {:?}", receipt);
         };
-        Ok(ObjectConditionsContext {
-            object_features,
-            outer_object_features,
-        })
-    }
 
-    /// Wraps the given [`ResolvedTypeReference`] into a [`ResolvedTypeMeta`] by *eagerly* loading
-    /// the actual referenced schema.
-    /// Note: the schema seems irrelevant for many "get meta information" methods, but it is needed
-    /// to resolve human-readable type names (from which some field names are derived as well).
-    fn augment_with_schema(
-        &self,
-        type_reference: ResolvedTypeReference,
-    ) -> Result<ResolvedTypeMeta, EngineStateBrowsingError> {
-        Ok(ResolvedTypeMeta {
-            schema: match &type_reference {
-                ResolvedTypeReference::SchemaBased(schema_based) => {
-                    let SchemaReference {
-                        node_id,
-                        schema_hash,
-                    } = &schema_based.schema_reference;
-                    self.reader
-                        .get_schema(node_id, schema_hash)
-                        .map_err(|error| {
-                            EngineStateBrowsingError::UnexpectedEngineError(
-                                error,
-                                "when locating schema".to_string(),
-                            )
-                        })?
-                        .as_ref()
-                        .clone()
-                        .fully_update_and_into_latest_version()
-                    // .as_unique_version()
-                    // .clone()
-                }
-                ResolvedTypeReference::WellKnown(_) => SchemaV1::empty(),
-            },
-            type_reference,
-        })
-    }
-
-    /// Converts the given [`BlueprintCollectionSchema`] to a more direct representation.
-    fn destructure_collection_schema(
-        schema: BlueprintCollectionSchema<BlueprintPayloadDef>,
-    ) -> (
-        ObjectCollectionKind,
-        BlueprintKeyValueSchema<BlueprintPayloadDef>,
-    ) {
-        match schema {
-            BlueprintCollectionSchema::KeyValueStore(schema) => {
-                (ObjectCollectionKind::KeyValueStore, schema)
-            }
-            BlueprintCollectionSchema::Index(schema) => (ObjectCollectionKind::Index, schema),
-            BlueprintCollectionSchema::SortedIndex(schema) => {
-                (ObjectCollectionKind::SortedIndex, schema)
-            }
-        }
+        let staged_reader = SystemDatabaseReader::new(&staged_database);
+        let type_info = staged_reader.get_type_info(node_id).map_err(|_| {
+            EngineStateBrowsingError::EngineInvariantBroken(
+                "an entity remained uninstantiated after access".to_string(),
+            )
+        })?;
+        EntityInfoLoader::new(&staged_reader)
+            .with_staged_instantiations_from(&commit)
+            .load_instantiated_entity_meta(type_info, node_id)
     }
 }
 
@@ -1757,5 +1492,399 @@ impl From<EngineStateBrowsingError> for ResponseError {
                 format!("Invalid Engine state: {}", message),
             ),
         }
+    }
+}
+
+/// An internal implementation delegate for resolving information from an Entity's type info,
+/// aware of any "staged instantiation" of uninstantiated Entities.
+struct EntityInfoLoader<'s, S: SubstateDatabase> {
+    // Note: this will either be the direct reference to the caller's `reader`, or a temporary
+    // reader based on a staged database (when reading an uninstantiated Entity).
+    reader: &'s SystemDatabaseReader<'s, S>,
+    // Note: these are the Entities created via "staged instantiation" on the `reader`'s database;
+    // they can be read normally, but their `ObjectMeta.is_instantiated` will be `false`.
+    staged_node_ids: IndexSet<NodeId>,
+}
+
+impl<'s, S: SubstateDatabase> EntityInfoLoader<'s, S> {
+    /// Creates an instance sharing the given reader.
+    pub fn new(reader: &'s SystemDatabaseReader<'s, S>) -> Self {
+        Self {
+            reader,
+            staged_node_ids: index_set_new(),
+        }
+    }
+
+    /// Records the Entities instantiated by the given commit as "uninstantiated" (i.e. marks that
+    /// their [`ObjectMeta.is_instantiated`] should be `false` if read through this loader).
+    pub fn with_staged_instantiations_from(mut self, commit: &CommitResult) -> Self {
+        let StateUpdateSummary {
+            new_packages,
+            new_components,
+            new_resources,
+            new_vaults,
+            vault_balance_changes: _,
+        } = &commit.state_update_summary;
+        self.staged_node_ids
+            .extend(new_packages.iter().map(|addr| *addr.as_node_id()));
+        self.staged_node_ids
+            .extend(new_components.iter().map(|addr| *addr.as_node_id()));
+        self.staged_node_ids
+            .extend(new_resources.iter().map(|addr| *addr.as_node_id()));
+        self.staged_node_ids
+            .extend(new_vaults.iter().map(|addr| *addr.as_node_id()));
+        self
+    }
+
+    /// Loads metadata on the given entity, assuming that it is already instantiated (within the
+    /// [`Self.reader`]'s database) if needed.
+    /// The caller [`EngineStateMetaLoader::load_entity_meta()] shows how this is used to support
+    /// uninstantiated entities.
+    pub fn load_instantiated_entity_meta(
+        &self,
+        type_info: TypeInfoSubstate,
+        node_id: &NodeId,
+    ) -> Result<EntityMeta, EngineStateBrowsingError> {
+        match type_info {
+            TypeInfoSubstate::Object(object_info) => Ok(EntityMeta::Object(
+                self.load_object_meta(node_id, object_info)?,
+            )),
+            TypeInfoSubstate::KeyValueStore(kv_store_info) => Ok(EntityMeta::KeyValueStore(
+                self.load_kv_store_meta(node_id, kv_store_info)?,
+            )),
+            TypeInfoSubstate::GlobalAddressReservation(_)
+            | TypeInfoSubstate::GlobalAddressPhantom(_) => {
+                Err(EngineStateBrowsingError::RequestedItemInvalid(
+                    ItemKind::Entity,
+                    "entity neither an object nor a KV store".to_string(),
+                ))
+            }
+        }
+    }
+
+    /// Loads metadata on "state" (i.e. all fields and collections) of the given object's module.
+    /// Does *not* support uninstantiated objects.
+    ///
+    /// API note: this is normally a part of the [`Self::load_instantiated_entity_meta()`] result,
+    /// but some clients are interested only in specific module and can use this cheaper method.
+    pub fn load_object_module_state_meta(
+        &self,
+        node_id: &NodeId,
+        module_id: ModuleId,
+    ) -> Result<ObjectModuleStateMeta, EngineStateBrowsingError> {
+        let type_target = self
+            .reader
+            .get_blueprint_type_target(node_id, module_id)
+            .map_err(|error| match error {
+                SystemReaderError::NodeIdDoesNotExist => {
+                    EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Entity)
+                }
+                SystemReaderError::ModuleDoesNotExist => {
+                    EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Module)
+                }
+                SystemReaderError::NotAnObject => EngineStateBrowsingError::RequestedItemInvalid(
+                    ItemKind::Entity,
+                    "not an object".to_string(),
+                ),
+                unexpected => EngineStateBrowsingError::UnexpectedEngineError(
+                    unexpected,
+                    "when getting type target".to_string(),
+                ),
+            })?;
+        self.load_blueprint_state_meta(&type_target)
+    }
+
+    /// Loads metadata of all fields and collections within the blueprint referenced by the given
+    /// [`BlueprintTypeTarget`]. The "type target" will also be used while resolving all types (see
+    /// [`TypeReferenceResolver`]).
+    fn load_blueprint_state_meta(
+        &self,
+        type_target: &BlueprintTypeTarget,
+    ) -> Result<ObjectModuleStateMeta, EngineStateBrowsingError> {
+        let blueprint_info = &type_target.blueprint_info;
+        let blueprint_id = &blueprint_info.blueprint_id;
+        let blueprint_name = blueprint_id.blueprint_name.as_str();
+        let IndexedStateSchema {
+            fields,
+            collections,
+            ..
+        } = self
+            .reader
+            .get_blueprint_definition(blueprint_id)
+            .map_err(|error| {
+                EngineStateBrowsingError::UnexpectedEngineError(
+                    error,
+                    "when getting blueprint definition".to_string(),
+                )
+            })?
+            .interface
+            .state
+            .clone();
+
+        let type_resolver = TypeReferenceResolver::new(self.reader);
+        let schema_loader = SchemaLoader::new(self.reader);
+        let conditions_context = self.load_conditions_context(blueprint_info)?;
+
+        let fields = fields
+            .into_iter()
+            .flat_map(|(_partition_description, fields)| fields)
+            .enumerate()
+            .filter(|(_index, schema)| conditions_context.meets(&schema.condition))
+            .map(|(index, schema)| {
+                Ok(ObjectFieldMeta::new(
+                    index,
+                    blueprint_id.blueprint_name.as_str(),
+                    type_resolver
+                        .resolve_type_from_blueprint_data(type_target, schema.field)
+                        .and_then(|resolved_type| {
+                            schema_loader.augment_with_schema(resolved_type)
+                        })?,
+                    schema.transience,
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let collections = collections
+            .into_iter()
+            .enumerate()
+            .map(|(index, (_partition_description, schema))| {
+                let (kind, collection_schema) = destructure_collection_schema(schema);
+                let BlueprintKeyValueSchema { key, value, .. } = collection_schema;
+                Ok(ObjectCollectionMeta::new(
+                    index,
+                    blueprint_name,
+                    kind,
+                    type_resolver
+                        .resolve_type_from_blueprint_data(type_target, key)
+                        .and_then(|resolved_type| {
+                            schema_loader.augment_with_schema(resolved_type)
+                        })?,
+                    type_resolver
+                        .resolve_type_from_blueprint_data(type_target, value)
+                        .and_then(|resolved_type| {
+                            schema_loader.augment_with_schema(resolved_type)
+                        })?,
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(ObjectModuleStateMeta {
+            fields,
+            collections,
+        })
+    }
+
+    /// Constructs an [`ObjectConditionsContext`] from the given object's blueprint-related info.
+    /// Note: the method belongs to the `load_*` family, since it may need to actually load the
+    /// outer object's enabled feature set (if it exists) from database.
+    fn load_conditions_context(
+        &self,
+        blueprint_info: &BlueprintInfo,
+    ) -> Result<ObjectConditionsContext, EngineStateBrowsingError> {
+        let object_features = blueprint_info.features.clone();
+        let outer_object_features = match &blueprint_info.outer_obj_info {
+            OuterObjectInfo::Some { outer_object } => {
+                self.reader
+                    .get_object_info(*outer_object.as_node_id())
+                    .map_err(|error| {
+                        EngineStateBrowsingError::UnexpectedEngineError(
+                            error,
+                            "when fetching outer object's info".to_string(),
+                        )
+                    })?
+                    .blueprint_info
+                    .features
+            }
+            OuterObjectInfo::None => index_set_new(),
+        };
+        Ok(ObjectConditionsContext {
+            object_features,
+            outer_object_features,
+        })
+    }
+
+    /// An implementation delegate of [`Self::load_instantiated_entity_meta()`] for `Object`s.
+    fn load_object_meta(
+        &self,
+        node_id: &NodeId,
+        object_info: ObjectInfo,
+    ) -> Result<ObjectMeta, EngineStateBrowsingError> {
+        let ObjectInfo {
+            blueprint_info,
+            object_type,
+        } = object_info;
+        Ok(ObjectMeta {
+            is_instantiated: !self.staged_node_ids.contains(node_id),
+            main_module_state: self.load_object_module_state_meta(node_id, ModuleId::Main)?,
+            attached_module_states: match object_type {
+                ObjectType::Global { modules } => modules
+                    .into_keys() // deliberately ignored per-module blueprint versions
+                    .map(|module_id| {
+                        Ok((
+                            module_id,
+                            self.load_object_module_state_meta(node_id, module_id.into())?,
+                        ))
+                    })
+                    .collect::<Result<IndexMap<_, _>, _>>()?,
+                ObjectType::Owned => index_map_new(),
+            },
+            blueprint_reference: BlueprintReference {
+                id: blueprint_info.blueprint_id,
+                version: blueprint_info.blueprint_version,
+            },
+            instance_meta: ObjectInstanceMeta {
+                outer_object: match blueprint_info.outer_obj_info {
+                    OuterObjectInfo::Some { outer_object } => Some(outer_object),
+                    OuterObjectInfo::None => None,
+                },
+                enabled_features: Vec::from_iter(blueprint_info.features),
+                substituted_generic_types: blueprint_info
+                    .generic_substitutions
+                    .into_iter()
+                    .map(|substitution| {
+                        TypeReferenceResolver::new(self.reader)
+                            .resolve_generic_substitution(Some(node_id), substitution)
+                            .and_then(|resolved_type| {
+                                SchemaLoader::new(self.reader).augment_with_schema(resolved_type)
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            },
+        })
+    }
+
+    /// An implementation delegate of [`Self::load_instantiated_entity_meta()`] for `KeyValueStore`s.
+    fn load_kv_store_meta(
+        &self,
+        node_id: &NodeId,
+        kv_store_info: KeyValueStoreInfo,
+    ) -> Result<KeyValueStoreMeta, EngineStateBrowsingError> {
+        let KeyValueStoreGenericSubstitutions {
+            key_generic_substitution,
+            value_generic_substitution,
+            ..
+        } = kv_store_info.generic_substitutions;
+        let type_resolver = TypeReferenceResolver::new(self.reader);
+        let schema_loader = SchemaLoader::new(self.reader);
+        Ok(KeyValueStoreMeta {
+            resolved_key_type: type_resolver
+                .resolve_generic_substitution(Some(node_id), key_generic_substitution)
+                .and_then(|resolved_type| schema_loader.augment_with_schema(resolved_type))?,
+            resolved_value_type: type_resolver
+                .resolve_generic_substitution(Some(node_id), value_generic_substitution)
+                .and_then(|resolved_type| schema_loader.augment_with_schema(resolved_type))?,
+        })
+    }
+}
+
+/// An internal implementation delegate for augmenting type references with their schemas.
+struct SchemaLoader<'s, S: SubstateDatabase> {
+    reader: &'s SystemDatabaseReader<'s, S>,
+}
+
+impl<'s, S: SubstateDatabase> SchemaLoader<'s, S> {
+    /// Creates an instance sharing the given reader.
+    pub fn new(reader: &'s SystemDatabaseReader<'s, S>) -> Self {
+        Self { reader }
+    }
+
+    /// Wraps the given [`ResolvedTypeReference`] into a [`ResolvedTypeMeta`] by *eagerly* loading
+    /// the actual referenced schema.
+    /// Note: the schema seems irrelevant for many "get meta information" methods, but it is needed
+    /// to resolve human-readable type names (from which some field names are derived as well).
+    pub fn augment_with_schema(
+        &self,
+        type_reference: ResolvedTypeReference,
+    ) -> Result<ResolvedTypeMeta, EngineStateBrowsingError> {
+        Ok(ResolvedTypeMeta {
+            schema: match &type_reference {
+                ResolvedTypeReference::SchemaBased(schema_based) => {
+                    let SchemaReference {
+                        node_id,
+                        schema_hash,
+                    } = &schema_based.schema_reference;
+                    self.reader
+                        .get_schema(node_id, schema_hash)
+                        .map_err(|error| {
+                            EngineStateBrowsingError::UnexpectedEngineError(
+                                error,
+                                "when locating schema".to_string(),
+                            )
+                        })?
+                        .as_ref()
+                        .clone()
+                        .fully_update_and_into_latest_version()
+                }
+                ResolvedTypeReference::WellKnown(_) => SchemaV1::empty(),
+            },
+            type_reference,
+        })
+    }
+}
+
+/// Converts the given [`BlueprintCollectionSchema`] to a more direct representation.
+fn destructure_collection_schema(
+    schema: BlueprintCollectionSchema<BlueprintPayloadDef>,
+) -> (
+    ObjectCollectionKind,
+    BlueprintKeyValueSchema<BlueprintPayloadDef>,
+) {
+    match schema {
+        BlueprintCollectionSchema::KeyValueStore(schema) => {
+            (ObjectCollectionKind::KeyValueStore, schema)
+        }
+        BlueprintCollectionSchema::Index(schema) => (ObjectCollectionKind::Index, schema),
+        BlueprintCollectionSchema::SortedIndex(schema) => {
+            (ObjectCollectionKind::SortedIndex, schema)
+        }
+    }
+}
+
+/// Creates a minimal transaction intent which forces an instantiation of the given Entity.
+fn create_intent_forcing_instantiation(node_id: &NodeId) -> ValidatedPreviewIntent {
+    let address =
+        GlobalAddress::try_from(*node_id).expect("should only be reachable for global entities");
+    // Use dummy key, as for a regular preview:
+    let notary_public_key =
+        PublicKey::Secp256k1(Secp256k1PrivateKey::from_u64(1).unwrap().public_key());
+    let intent = IntentV1 {
+        header: TransactionHeaderV1 {
+            // Use dummy values, since we disable these checks anyway:
+            network_id: 0,
+            start_epoch_inclusive: Epoch::zero(),
+            end_epoch_exclusive: Epoch::zero(),
+            nonce: 0,
+            notary_public_key,
+            notary_is_signatory: true,
+            tip_percentage: 0,
+        },
+        instructions: InstructionsV1(vec![
+            // Call any basic, non-invasive method, which is enough to force instantiation:
+            // Note: the "get metadata" call below seems universal and future-proof enough, but
+            // a more elegant solution could be based on some hypothetical "ensure exists" method?
+            InstructionV1::CallMetadataMethod {
+                address: DynamicGlobalAddress::Static(address),
+                method_name: "get".to_string(),
+                args: ManifestValue::Tuple {
+                    fields: vec![ManifestValue::String {
+                        value: "dummy name".to_string(),
+                    }],
+                },
+            },
+        ]),
+        blobs: BlobsV1::default(),
+        message: MessageV1::None,
+    };
+
+    ValidatedPreviewIntent {
+        intent: intent.prepare().expect("hardcoded"),
+        encoded_instructions: manifest_encode(&intent.instructions.0).expect("hardcoded"),
+        signer_public_keys: vec![],
+        flags: PreviewFlags {
+            use_free_credit: true,
+            assume_all_signature_proofs: true,
+            skip_epoch_check: true,
+            disable_auth: true,
+        },
     }
 }

--- a/core-rust/engine-state-api-server/src/lib.rs
+++ b/core-rust/engine-state-api-server/src/lib.rs
@@ -77,8 +77,6 @@ pub(crate) mod engine_prelude {
 
     pub use radix_common::prelude::*;
 
-    pub use radix_engine_interface::blueprints::account::*;
-    pub use radix_engine_interface::blueprints::identity::*;
     pub use radix_engine_interface::prelude::*;
 
     pub use radix_transactions::model::*;

--- a/core-rust/state-manager/src/lib.rs
+++ b/core-rust/state-manager/src/lib.rs
@@ -99,7 +99,6 @@ pub use crate::types::*;
 pub mod engine_prelude {
     pub use radix_common::prelude::*;
 
-    pub use radix_engine::*;
     pub use radix_engine::errors::*;
     pub use radix_engine::system::bootstrap::*;
     #[cfg(feature = "db_checker")]
@@ -109,9 +108,10 @@ pub mod engine_prelude {
     pub use radix_engine::transaction::*;
     pub use radix_engine::updates::*;
     pub use radix_engine::vm::*;
+    pub use radix_engine::*;
 
-    pub use radix_engine_interface::blueprints::transaction_processor::*;
     pub use radix_engine_interface::blueprints::account::*;
+    pub use radix_engine_interface::blueprints::transaction_processor::*;
     pub use radix_engine_interface::prelude::*;
 
     pub use radix_substate_store_impls::state_tree::tree_store::*;

--- a/core/src/test/java/com/radixdlt/api/engine_state/EntityInfoTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/EntityInfoTest.java
@@ -224,7 +224,12 @@ public final class EntityInfoTest extends DeterministicEngineStateApiTestBase {
       assertThat(collectionsNames)
           .isEqualTo(List.of("resource_vault", "resource_preference", "authorized_depositor"));
 
-      assertThat(objectInfo.getAttachedModules()).isEmpty();
+      final var attachedModuleIds =
+          Lists.transform(
+              objectInfo.getAttachedModules(),
+              ObjectEntityInfoAllOfAttachedModules::getAttachedModuleId);
+      assertThat(attachedModuleIds)
+          .isEqualTo(List.of(AttachedModuleId.ROLEASSIGNMENT, AttachedModuleId.METADATA));
 
       final var wellKnownAddresses = getCoreApiHelper().getWellKnownAddresses();
       assertThat(objectInfo.getBlueprintReference())


### PR DESCRIPTION
## Summary

This one closes https://radixdlt.atlassian.net/browse/NODE-648 following the plan from https://radixdlt.atlassian.net/browse/NODE-648?focusedCommentId=20074 pretty closely.

## Details

This allows for returning more accurate and future-proof [uninstantiated] entity info (like "virtual account") from Engine State API.
In fact, this PR fixes one issue of the previously-hardcoded returns (see the in-line comments).

## Testing

Adjusted one existing test focused on uninstantiated entity infos.