### PR TITLE
Support uninstantiated entities in a unified way across ES API endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
       - name: Update clang version to 17
         run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 17 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-17 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-17 /usr/bin/clang++ && sudo apt-get install -y libclang-dev llvm llvm-dev
       - name: Install cargo-xwin
-        run: cargo install cargo-xwin --version 0.17.1
+        run: cargo install cargo-xwin --version 0.17.1 --locked
       - name: cross compile to windows
         run: pushd core-rust; cargo xwin build --release --target x86_64-pc-windows-msvc
       - name: Publish corerust.dll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
       - name: Update clang version to 17
         run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 17 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-17 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-17 /usr/bin/clang++ && sudo apt-get install -y libclang-dev llvm llvm-dev
       - name: Install cargo-xwin
-        run: cargo install cargo-xwin
+        run: cargo install cargo-xwin --version 0.17.1
       - name: cross compile to windows
         run: pushd core-rust; cargo xwin build --release --target x86_64-pc-windows-msvc
       - name: Publish corerust.dll

--- a/core-rust-bridge/src/main/java/com/radixdlt/identifiers/Address.java
+++ b/core-rust-bridge/src/main/java/com/radixdlt/identifiers/Address.java
@@ -80,8 +80,16 @@ public final class Address {
     return virtualAccountAddress(publicKey.getBytes());
   }
 
+  public static ComponentAddress virtualIdentityAddress(ECDSASecp256k1PublicKey publicKey) {
+    return virtualIdentityAddress(publicKey.getBytes());
+  }
+
   public static ComponentAddress virtualAccountAddress(byte[] publicKeyBytes) {
     return virtualAccountAddressFunc.call(publicKeyBytes);
+  }
+
+  public static ComponentAddress virtualIdentityAddress(byte[] publicKeyBytes) {
+    return virtualIdentityAddressFunc.call(publicKeyBytes);
   }
 
   public static ResourceAddress globalFungible(byte[] addressBytesWithoutEntityId) {
@@ -92,6 +100,11 @@ public final class Address {
       Natives.builder(Address::nativeVirtualAccountAddress).build(new TypeToken<>() {});
 
   private static native byte[] nativeVirtualAccountAddress(byte[] requestPayload);
+
+  private static final Natives.Call1<byte[], ComponentAddress> virtualIdentityAddressFunc =
+      Natives.builder(Address::nativeVirtualIdentityAddress).build(new TypeToken<>() {});
+
+  private static native byte[] nativeVirtualIdentityAddress(byte[] requestPayload);
 
   private static final Natives.Call1<byte[], ResourceAddress> globalFungibleFunc =
       Natives.builder(Address::nativeGlobalFungible).build(new TypeToken<>() {});

--- a/core-rust/engine-state-api-server/src/engine_state_api/attached_modules.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/attached_modules.rs
@@ -25,19 +25,11 @@ lazy_static::lazy_static! {
 /// abstraction layer higher than the rest of the Engine State API (i.e. it interprets the data that
 /// can be read using other, lower-level means).
 pub struct ObjectRoyaltyLoader<'s, S: SubstateDatabase> {
-    meta_loader: EngineStateMetaLoader<'s, S>,
-    data_loader: EngineStateDataLoader<'s, S>,
+    pub meta_loader: EngineStateMetaLoader<'s, S>,
+    pub data_loader: EngineStateDataLoader<'s, S>,
 }
 
 impl<'s, S: SubstateDatabase> ObjectRoyaltyLoader<'s, S> {
-    /// Creates an instance reading from the given database.
-    pub fn new(database: &'s S) -> Self {
-        Self {
-            meta_loader: EngineStateMetaLoader::new(database),
-            data_loader: EngineStateDataLoader::new(database),
-        }
-    }
-
     /// Returns Package and Component royalty amounts for all methods of the given object.
     pub fn load_method_amounts(
         &self,
@@ -66,6 +58,7 @@ impl<'s, S: SubstateDatabase> ObjectRoyaltyLoader<'s, S> {
                 })
                 .collect::<Result<NonIterMap<_, _>, _>>()?
         } else {
+            // It is ok for an object to NOT have Royalty module (and it means free methods):
             NonIterMap::new()
         };
 
@@ -98,19 +91,11 @@ pub struct MethodRoyaltyAmount {
 /// abstraction layer higher than the rest of the Engine State API (i.e. it interprets the data that
 /// can be read using other, lower-level means).
 pub struct ObjectRoleAssignmentLoader<'s, S: SubstateDatabase> {
-    meta_loader: EngineStateMetaLoader<'s, S>,
-    data_loader: EngineStateDataLoader<'s, S>,
+    pub meta_loader: EngineStateMetaLoader<'s, S>,
+    pub data_loader: EngineStateDataLoader<'s, S>,
 }
 
 impl<'s, S: SubstateDatabase> ObjectRoleAssignmentLoader<'s, S> {
-    /// Creates an instance reading from the given database.
-    pub fn new(database: &'s S) -> Self {
-        Self {
-            meta_loader: EngineStateMetaLoader::new(database),
-            data_loader: EngineStateDataLoader::new(database),
-        }
-    }
-
     /// Loads full information from the [`ModuleId::RoleAssignment`] module:
     /// - the Owner rule and updater,
     /// - the role-to-rule assignment for all roles defined by the object and its attached modules.
@@ -259,17 +244,10 @@ pub enum Assignment {
 /// abstraction layer higher than the rest of the Engine State API (i.e. it interprets the data that
 /// can be read using other, lower-level means).
 pub struct ObjectMetadataLoader<'s, S: SubstateDatabase> {
-    loader: EngineStateDataLoader<'s, S>,
+    pub loader: EngineStateDataLoader<'s, S>,
 }
 
 impl<'s, S: SubstateDatabase> ObjectMetadataLoader<'s, S> {
-    /// Creates an instance reading from the given database.
-    pub fn new(database: &'s S) -> Self {
-        Self {
-            loader: EngineStateDataLoader::new(database),
-        }
-    }
-
     /// Returns an iterator of keys within the Metadata module attached to the given object,
     /// starting at the given key.
     pub fn iter_keys(

--- a/core-rust/engine-state-api-server/src/engine_state_api/extras.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/extras.rs
@@ -1,0 +1,74 @@
+use crate::engine_prelude::*;
+
+use itertools::Itertools;
+
+use state_manager::store::traits::indices::{
+    CreationId, EntityBlueprintId, EntityBlueprintIdV1, EntityListingIndex,
+};
+
+use super::*;
+
+/// A lister of entities.
+pub struct EngineEntityLister<'s, S> {
+    database: &'s S,
+}
+
+/// Basic information about an entity (i.e. read from a DB index, for listing purposes).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntitySummary {
+    pub node_id: NodeId,
+    pub creation_id: CreationId,
+    pub blueprint_id: Option<BlueprintId>, // only present for Object entities
+}
+
+impl<'s, S: EntityListingIndex> EngineEntityLister<'s, S> {
+    /// Creates an instance reading from the given database.
+    pub fn new(database: &'s S) -> Self {
+        Self { database }
+    }
+
+    /// Returns an iterator of entities having one of the given [`EntityType`]s, starting from the
+    /// given [`CreationId`] (or its successor, if it does not exist), in the [`CreationId`]'s
+    /// natural order (ascending).
+    pub fn iter_created_entities(
+        &self,
+        entity_types: impl Iterator<Item = EntityType>,
+        from_creation_id: Option<&CreationId>,
+    ) -> Result<impl Iterator<Item = EntitySummary> + 's, EngineStateBrowsingError> {
+        Ok(entity_types
+            .map(|entity_type| {
+                self.database
+                    .get_created_entity_iter(entity_type, from_creation_id)
+            })
+            .kmerge_by(|(a_creation_id, _), (b_creation_id, _)| a_creation_id < b_creation_id)
+            .map(Self::to_entity_summary))
+    }
+
+    /// Returns an iterator of entities having the given [`BlueprintId`], starting from the given
+    /// [`CreationId`] (or its successor, if it does not exist), in the [`CreationId`]'s natural
+    /// order (ascending).
+    pub fn iter_blueprint_entities(
+        &self,
+        blueprint_id: &BlueprintId,
+        from_creation_id: Option<&CreationId>,
+    ) -> Result<impl Iterator<Item = EntitySummary> + 's, EngineStateBrowsingError> {
+        Ok(self
+            .database
+            .get_blueprint_entity_iter(blueprint_id, from_creation_id)
+            .map(Self::to_entity_summary))
+    }
+
+    /// Converts a database index entry into an [`EntitySummary`].
+    fn to_entity_summary(db_entry: (CreationId, EntityBlueprintId)) -> EntitySummary {
+        let (creation_id, entity_blueprint_id) = db_entry;
+        let EntityBlueprintIdV1 {
+            node_id,
+            blueprint_id,
+        } = entity_blueprint_id;
+        EntitySummary {
+            node_id,
+            creation_id,
+            blueprint_id,
+        }
+    }
+}

--- a/core-rust/engine-state-api-server/src/engine_state_api/factories.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/factories.rs
@@ -1,0 +1,210 @@
+use crate::engine_prelude::*;
+
+use radix_engine::transaction::{
+    execute_and_commit_transaction, CommitResult, ExecutionConfig, StateUpdateSummary,
+    TransactionResult,
+};
+use radix_engine::vm::wasm::DefaultWasmEngine;
+use radix_engine::vm::{NoExtension, ScryptoVm, VmInit};
+use radix_substate_store_impls::substate_database_overlay::{
+    SubstateDatabaseOverlay, UnmergeableSubstateDatabaseOverlay,
+};
+
+use super::*;
+
+/// A factory of various "loaders" used by Engine State API.
+///
+/// Instantiating a loader is sometimes not trivial, since it may require e.g. a "staged
+/// instantiation" of an uninstantiated entity - hence most endpoint handlers should interact with
+/// this factory.
+pub struct EngineStateLoaderFactory<'s, S> {
+    database: UnmergeableSubstateDatabaseOverlay<'s, S>,
+    staged_node_ids: IndexSet<NodeId>,
+}
+
+impl<'s, S: SubstateDatabase> EngineStateLoaderFactory<'s, S> {
+    /// Creates a factory using the given database.
+    pub fn new(database: &'s S) -> Self {
+        Self {
+            database: SubstateDatabaseOverlay::new_unmergeable(database),
+            staged_node_ids: index_set_new(),
+        }
+    }
+
+    /// Performs a "staged instantiation" of the given entity, if required.
+    ///
+    /// The uninstantiated instance will be "forced" into being by executing a simple transaction
+    /// that uses it (see [`create_intent_forcing_instantiation()`]). The newly-written nodes will
+    /// of course live only in a staged [`SubstateDatabaseOverlay`] (passed to all loaders created
+    /// by this factory).
+    pub fn ensure_instantiated(mut self, node_id: &NodeId) -> Self {
+        if !self.requires_instantiation(node_id) {
+            return self;
+        }
+        let commit = self.instantiate(node_id);
+        // In theory, precisely the input `node_id` should be created. However, the code below is
+        // ready to fail-fast on downstream bugs (e.g. the entity not getting instantiated) and to
+        // handle possible future behaviors (e.g. some extra related entities being created):
+        let instantiated_node_ids = collect_instantiated_node_ids(commit);
+        if !instantiated_node_ids.contains(node_id) {
+            panic!(
+                "forced instantiation succeeded but did not create {:?}",
+                node_id
+            );
+        }
+        self.staged_node_ids.extend(instantiated_node_ids);
+        self
+    }
+
+    /// Creates a loader of an entity's type info.
+    pub fn create_meta_loader(
+        &'s self,
+    ) -> EngineStateMetaLoader<'s, UnmergeableSubstateDatabaseOverlay<'s, S>> {
+        EngineStateMetaLoader {
+            reader: SystemDatabaseReader::new(&self.database),
+            non_instantiated_node_ids: self.staged_node_ids.clone(),
+        }
+    }
+
+    /// Creates a loader of raw data living in an object's Main module.
+    pub fn create_data_loader(
+        &'s self,
+    ) -> EngineStateDataLoader<'s, UnmergeableSubstateDatabaseOverlay<'s, S>> {
+        EngineStateDataLoader {
+            reader: SystemDatabaseReader::new(&self.database),
+        }
+    }
+
+    /// Creates a higher-level loader of data living in an object's Role Assignment module.
+    pub fn create_object_role_assignment_loader(
+        &'s self,
+    ) -> ObjectRoleAssignmentLoader<'s, UnmergeableSubstateDatabaseOverlay<'s, S>> {
+        ObjectRoleAssignmentLoader {
+            meta_loader: self.create_meta_loader(),
+            data_loader: self.create_data_loader(),
+        }
+    }
+
+    /// Creates a higher-level loader of data living in an object's Royalty module.
+    pub fn create_object_royalty_loader(
+        &'s self,
+    ) -> ObjectRoyaltyLoader<'s, UnmergeableSubstateDatabaseOverlay<'s, S>> {
+        ObjectRoyaltyLoader {
+            meta_loader: self.create_meta_loader(),
+            data_loader: self.create_data_loader(),
+        }
+    }
+
+    /// Creates a higher-level loader of data living in an object's Metadata module.
+    pub fn create_object_metadata_loader(
+        &'s self,
+    ) -> ObjectMetadataLoader<'s, UnmergeableSubstateDatabaseOverlay<'s, S>> {
+        ObjectMetadataLoader {
+            loader: self.create_data_loader(),
+        }
+    }
+
+    /// Checks whether the given entity should be automatically instantiated on access, given the
+    /// current database state.
+    fn requires_instantiation(&self, node_id: &NodeId) -> bool {
+        if !node_id.is_global_virtual() {
+            // No matter if it exists or not, we shouldn't instantiate:
+            return false;
+        }
+        // We check whether it is missing by trying to load the `TypeInfo`:
+        return SystemDatabaseReader::new(&self.database)
+            .get_type_info(node_id)
+            .is_err();
+    }
+
+    /// Triggers automatic instantiation of the given entity, using a handcrafted transaction on the
+    /// internally-staged database.
+    fn instantiate(&mut self, node_id: &NodeId) -> CommitResult {
+        let intent = create_intent_forcing_instantiation(node_id);
+
+        // Note: here, we initialize a new `ScryptoVm` instance every time - however, this is
+        // currently a very lightweight operation. At the same time, we would NOT be able to feel
+        // the benefits of caching an instance (since we do not use any WASM here). If these
+        // assumptions change in future, then it will make most sense to turn the `Self` into a
+        // long-lived service holding a `ScryptoVm` as its dependency.
+        let scrypto_vm = ScryptoVm::<DefaultWasmEngine>::default();
+
+        let receipt = execute_and_commit_transaction(
+            &mut self.database,
+            VmInit::new(&scrypto_vm, NoExtension),
+            &ExecutionConfig::default(),
+            &intent.get_executable(),
+        );
+        let TransactionResult::Commit(commit) = receipt.result else {
+            panic!("failed to force instantiation: {:?}", receipt);
+        };
+
+        commit
+    }
+}
+
+/// Traverses the state updates in order to discover all actually instantiated [`NodeId`]s.
+fn collect_instantiated_node_ids(commit: CommitResult) -> IndexSet<NodeId> {
+    let mut staged_node_ids = index_set_new();
+    let StateUpdateSummary {
+        new_packages,
+        new_components,
+        new_resources,
+        new_vaults,
+        vault_balance_changes: _,
+    } = &commit.state_update_summary;
+    staged_node_ids.extend(new_packages.iter().map(|addr| *addr.as_node_id()));
+    staged_node_ids.extend(new_components.iter().map(|addr| *addr.as_node_id()));
+    staged_node_ids.extend(new_resources.iter().map(|addr| *addr.as_node_id()));
+    staged_node_ids.extend(new_vaults.iter().map(|addr| *addr.as_node_id()));
+    staged_node_ids
+}
+
+/// Creates a minimal transaction intent which forces an instantiation of the given Entity.
+fn create_intent_forcing_instantiation(node_id: &NodeId) -> ValidatedPreviewIntent {
+    let address =
+        GlobalAddress::try_from(*node_id).expect("should only be reachable for global entities");
+    // Use dummy key, as for a regular preview:
+    let notary_public_key =
+        PublicKey::Secp256k1(Secp256k1PrivateKey::from_u64(1).unwrap().public_key());
+    let intent = IntentV1 {
+        header: TransactionHeaderV1 {
+            // Use dummy values, since we disable these checks anyway:
+            network_id: 0,
+            start_epoch_inclusive: Epoch::zero(),
+            end_epoch_exclusive: Epoch::zero(),
+            nonce: 0,
+            notary_public_key,
+            notary_is_signatory: true,
+            tip_percentage: 0,
+        },
+        instructions: InstructionsV1(vec![
+            // Call any basic, non-invasive method, which is enough to force instantiation:
+            // Note: the "get metadata" call below seems universal and future-proof enough, but
+            // a more elegant solution could be based on some hypothetical "ensure exists" method?
+            InstructionV1::CallMetadataMethod {
+                address: DynamicGlobalAddress::Static(address),
+                method_name: "get".to_string(),
+                args: ManifestValue::Tuple {
+                    fields: vec![ManifestValue::String {
+                        value: "dummy name".to_string(),
+                    }],
+                },
+            },
+        ]),
+        blobs: BlobsV1::default(),
+        message: MessageV1::None,
+    };
+
+    ValidatedPreviewIntent {
+        intent: intent.prepare().expect("hardcoded"),
+        encoded_instructions: manifest_encode(&intent.instructions.0).expect("hardcoded"),
+        signer_public_keys: vec![],
+        flags: PreviewFlags {
+            use_free_credit: true,
+            assume_all_signature_proofs: true,
+            skip_epoch_check: true,
+            disable_auth: true,
+        },
+    }
+}

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/blueprint_info.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/blueprint_info.rs
@@ -1,6 +1,7 @@
 use crate::engine_prelude::*;
 use crate::engine_state_api::*;
 
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use state_manager::historical_state::VersionScopingSupport;
 
 pub(crate) async fn handle_blueprint_info(
@@ -33,9 +34,11 @@ pub(crate) async fn handle_blueprint_info(
         .database
         .snapshot()
         .scoped_at(requested_state_version)?;
+    let loader_factory = EngineStateLoaderFactory::new(&database);
 
-    let meta_loader = EngineStateMetaLoader::new(&database);
-    let blueprint_meta = meta_loader.load_blueprint_meta(&blueprint_reference)?;
+    let blueprint_meta = loader_factory
+        .create_meta_loader()
+        .load_blueprint_meta(&blueprint_reference)?;
 
     let ledger_state = database.at_ledger_state();
 

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/entity_info.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/entity_info.rs
@@ -1,4 +1,5 @@
 use crate::engine_prelude::*;
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use crate::engine_state_api::*;
 use state_manager::historical_state::VersionScopingSupport;
 use state_manager::store::traits::{SubstateNodeAncestryRecord, SubstateNodeAncestryStore};
@@ -21,9 +22,11 @@ pub(crate) async fn handle_entity_info(
         .database
         .snapshot()
         .scoped_at(requested_state_version)?;
+    let loader_factory = EngineStateLoaderFactory::new(&database).ensure_instantiated(&node_id);
 
-    let meta_loader = EngineStateMetaLoader::new(&database);
-    let entity_meta = meta_loader.load_entity_meta(&node_id)?;
+    let entity_meta = loader_factory
+        .create_meta_loader()
+        .load_entity_meta(&node_id)?;
 
     // Technically, the ancestry information could be interpreted as part of "meta" and included in
     // the `EntityMeta` above. However, we plan to move `EngineStateMetaLoader` (among others) into

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/entity_schema_entry.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/entity_schema_entry.rs
@@ -2,6 +2,7 @@ use crate::engine_state_api::*;
 
 use crate::engine_prelude::*;
 
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use state_manager::historical_state::VersionScopingSupport;
 
 pub(crate) async fn handle_entity_schema_entry(
@@ -26,7 +27,9 @@ pub(crate) async fn handle_entity_schema_entry(
         .snapshot()
         .scoped_at(requested_state_version)?;
 
-    let data_loader = EngineStateDataLoader::new(&database);
+    let loader_factory = EngineStateLoaderFactory::new(&database).ensure_instantiated(&node_id);
+    let data_loader = loader_factory.create_data_loader();
+
     let versioned_schema_data = data_loader.load_schema(&SchemaReference {
         node_id,
         schema_hash,

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/extra_entity_search.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/extra_entity_search.rs
@@ -6,6 +6,7 @@ use state_manager::historical_state::VersionScopingSupport;
 use state_manager::store::traits::indices::CreationId;
 use state_manager::store::traits::ConfigurableDatabase;
 
+use crate::engine_state_api::extras::{EngineEntityLister, EntitySummary};
 use state_manager::StateVersion;
 use std::ops::Deref;
 

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/kv_store_entry.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/kv_store_entry.rs
@@ -2,6 +2,7 @@ use crate::engine_state_api::*;
 
 use crate::engine_prelude::*;
 
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use state_manager::historical_state::VersionScopingSupport;
 
 pub(crate) async fn handle_kv_store_entry(
@@ -26,7 +27,9 @@ pub(crate) async fn handle_kv_store_entry(
         .snapshot()
         .scoped_at(requested_state_version)?;
 
-    let meta_loader = EngineStateMetaLoader::new(&database);
+    let loader_factory = EngineStateLoaderFactory::new(&database).ensure_instantiated(&node_id);
+
+    let meta_loader = loader_factory.create_meta_loader();
     let EntityMeta::KeyValueStore(kv_store_meta) = meta_loader.load_entity_meta(&node_id)? else {
         return Err(ResponseError::new(
             StatusCode::BAD_REQUEST,
@@ -37,7 +40,7 @@ pub(crate) async fn handle_kv_store_entry(
         }));
     };
 
-    let data_loader = EngineStateDataLoader::new(&database);
+    let data_loader = loader_factory.create_data_loader();
     let entry_data = data_loader.load_kv_store_entry(&node_id, &kv_store_meta, &key)?;
 
     let ledger_state = database.at_ledger_state();

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_collection_entry.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_collection_entry.rs
@@ -2,6 +2,7 @@ use crate::engine_state_api::*;
 
 use crate::engine_prelude::*;
 
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use state_manager::historical_state::VersionScopingSupport;
 
 pub(crate) async fn handle_object_collection_entry(
@@ -37,15 +38,16 @@ pub(crate) async fn handle_object_collection_entry(
         .snapshot()
         .scoped_at(requested_state_version)?;
 
-    let meta_loader = EngineStateMetaLoader::new(&database);
+    let loader_factory = EngineStateLoaderFactory::new(&database).ensure_instantiated(&node_id);
+
+    let meta_loader = loader_factory.create_meta_loader();
     let module_state_meta = meta_loader.load_object_module_state_meta(&node_id, module_id)?;
     let collection_meta = match collection_input {
         RichIndexInput::Name(name) => module_state_meta.collection_by_name(name),
         RichIndexInput::Index(index) => module_state_meta.collection_by_index(index),
     }?;
 
-    let data_loader = EngineStateDataLoader::new(&database);
-
+    let data_loader = loader_factory.create_data_loader();
     let entry_data =
         data_loader.load_collection_entry(&node_id, module_id, collection_meta, &key)?;
 

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_metadata_entry.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_metadata_entry.rs
@@ -2,6 +2,7 @@ use crate::engine_state_api::*;
 
 use crate::engine_prelude::*;
 
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use state_manager::historical_state::VersionScopingSupport;
 
 pub(crate) async fn handle_object_metadata_entry(
@@ -24,8 +25,11 @@ pub(crate) async fn handle_object_metadata_entry(
         .snapshot()
         .scoped_at(requested_state_version)?;
 
-    let loader = ObjectMetadataLoader::new(&database);
-    let metadata_value = loader.load_entry(&node_id, &MetadataKey::from(request.key))?;
+    let loader_factory = EngineStateLoaderFactory::new(&database).ensure_instantiated(&node_id);
+
+    let metadata_value = loader_factory
+        .create_object_metadata_loader()
+        .load_entry(&node_id, &MetadataKey::from(request.key))?;
 
     let ledger_state = database.at_ledger_state();
 

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_metadata_iterator.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_metadata_iterator.rs
@@ -4,6 +4,7 @@ use crate::engine_prelude::*;
 
 use crate::engine_state_api::handlers::HandlerPagingSupport;
 
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use state_manager::historical_state::VersionScopingSupport;
 
 pub(crate) async fn handle_object_metadata_iterator(
@@ -28,7 +29,9 @@ pub(crate) async fn handle_object_metadata_iterator(
         .snapshot()
         .scoped_at(requested_state_version)?;
 
-    let loader = ObjectMetadataLoader::new(&database);
+    let loader_factory = EngineStateLoaderFactory::new(&database).ensure_instantiated(&node_id);
+
+    let loader = loader_factory.create_object_metadata_loader();
     let page = paging_support.get_page(|from| loader.iter_keys(&node_id, from))?;
 
     let ledger_state = database.at_ledger_state();

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_role_assignment.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_role_assignment.rs
@@ -2,6 +2,7 @@ use crate::engine_state_api::*;
 
 use crate::engine_prelude::*;
 
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use state_manager::historical_state::VersionScopingSupport;
 
 pub(crate) async fn handle_object_role_assignment(
@@ -24,12 +25,15 @@ pub(crate) async fn handle_object_role_assignment(
         .snapshot()
         .scoped_at(requested_state_version)?;
 
-    let loader = ObjectRoleAssignmentLoader::new(&database);
+    let loader_factory = EngineStateLoaderFactory::new(&database).ensure_instantiated(&node_id);
+
     let ObjectRoleAssignment {
         owner_role_entry,
         main_module_roles,
         attached_modules,
-    } = loader.load_role_assignment(&node_id)?;
+    } = loader_factory
+        .create_object_role_assignment_loader()
+        .load_role_assignment(&node_id)?;
 
     let ledger_state = database.at_ledger_state();
 

--- a/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_royalty.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/handlers/object_royalty.rs
@@ -2,6 +2,7 @@ use crate::engine_state_api::*;
 
 use crate::engine_prelude::*;
 
+use crate::engine_state_api::factories::EngineStateLoaderFactory;
 use state_manager::historical_state::VersionScopingSupport;
 
 pub(crate) async fn handle_object_royalty(
@@ -24,8 +25,11 @@ pub(crate) async fn handle_object_royalty(
         .snapshot()
         .scoped_at(requested_state_version)?;
 
-    let loader = ObjectRoyaltyLoader::new(&database);
-    let method_amounts = loader.load_method_amounts(&node_id)?;
+    let loader_factory = EngineStateLoaderFactory::new(&database).ensure_instantiated(&node_id);
+
+    let method_amounts = loader_factory
+        .create_object_royalty_loader()
+        .load_method_amounts(&node_id)?;
 
     let ledger_state = database.at_ledger_state();
 

--- a/core-rust/engine-state-api-server/src/engine_state_api/mod.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/mod.rs
@@ -66,6 +66,8 @@ mod attached_modules;
 mod conversions;
 mod errors;
 mod extractors;
+mod extras;
+mod factories;
 mod handlers;
 mod metrics;
 mod metrics_layer;

--- a/core-rust/engine-state-api-server/src/engine_state_api/readers.rs
+++ b/core-rust/engine-state-api-server/src/engine_state_api/readers.rs
@@ -3,18 +3,6 @@ use std::ops::Deref;
 use crate::engine_prelude::*;
 
 use convert_case::{Case, Casing};
-use itertools::Itertools;
-use radix_engine::transaction::{
-    execute_and_commit_transaction, CommitResult, ExecutionConfig, StateUpdateSummary,
-    TransactionResult,
-};
-use radix_engine::vm::wasm::DefaultWasmEngine;
-use radix_engine::vm::{NoExtension, ScryptoVm, VmInit};
-use radix_substate_store_impls::substate_database_overlay::SubstateDatabaseOverlay;
-
-use state_manager::store::traits::indices::{
-    CreationId, EntityBlueprintId, EntityBlueprintIdV1, EntityListingIndex,
-};
 
 use super::*;
 
@@ -34,22 +22,13 @@ pub struct EngineStateMetaLoader<'s, S: SubstateDatabase> {
     // Engine, but many parts could be achieved in a more performant way (e.g. avoid loading the
     // same data multiple times, or avoid parsing large parts of SBOR). We can either extend the
     // Engine's reader, or implement required lower-level logic here.
-    reader: SystemDatabaseReader<'s, S>,
-    // Note: we also need the direct reference to the `SubstateDatabase`, because it is required for
-    // a staged instantiation of "global virtual" entities (and the `SystemDatabaseReader` above
-    // does not expose it).
-    database: &'s S,
+    pub reader: SystemDatabaseReader<'s, S>,
+    // The IDs of entities that should be returned as `is_instantiated: false`; they were captured
+    // during "staged instantiation" by this loader's factory.
+    pub non_instantiated_node_ids: IndexSet<NodeId>,
 }
 
 impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
-    /// Creates an instance reading from the given database.
-    pub fn new(database: &'s S) -> Self {
-        Self {
-            reader: SystemDatabaseReader::new(database),
-            database,
-        }
-    }
-
     /// Loads metadata on the given blueprint.
     pub fn load_blueprint_meta(
         &self,
@@ -147,34 +126,64 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
     ) -> Result<EntityMeta, EngineStateBrowsingError> {
         let type_info = match self.reader.get_type_info(node_id) {
             Ok(type_info) => type_info,
-            Err(error) => match error {
-                SystemReaderError::NodeIdDoesNotExist => {
-                    if node_id.is_global_virtual() {
-                        return self.derive_uninstantiated_entity_meta(node_id);
+            Err(error) => {
+                return Err(match error {
+                    SystemReaderError::NodeIdDoesNotExist => {
+                        EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Entity)
                     }
-                    return Err(EngineStateBrowsingError::RequestedItemNotFound(
-                        ItemKind::Entity,
-                    ));
-                }
-                unexpected => {
-                    return Err(EngineStateBrowsingError::UnexpectedEngineError(
+                    unexpected => EngineStateBrowsingError::UnexpectedEngineError(
                         unexpected,
                         "when getting type info".to_string(),
-                    ))
-                }
-            },
+                    ),
+                })
+            }
         };
-        EntityInfoLoader::new(&self.reader).load_instantiated_entity_meta(type_info, node_id)
+        match type_info {
+            TypeInfoSubstate::Object(object_info) => Ok(EntityMeta::Object(
+                self.load_object_meta(node_id, object_info)?,
+            )),
+            TypeInfoSubstate::KeyValueStore(kv_store_info) => Ok(EntityMeta::KeyValueStore(
+                self.load_kv_store_meta(node_id, kv_store_info)?,
+            )),
+            TypeInfoSubstate::GlobalAddressReservation(_)
+            | TypeInfoSubstate::GlobalAddressPhantom(_) => {
+                Err(EngineStateBrowsingError::RequestedItemInvalid(
+                    ItemKind::Entity,
+                    "entity neither an object nor a KV store".to_string(),
+                ))
+            }
+        }
     }
 
     /// Loads metadata on "state" (i.e. all fields and collections) of the given object's module.
-    /// Does *not* support uninstantiated objects.
+    ///
+    /// API note: this is normally a part of the [`Self::load_entity_meta()`] result, but some
+    /// clients are interested only in specific module and can use this cheaper method.
     pub fn load_object_module_state_meta(
         &self,
         node_id: &NodeId,
         module_id: ModuleId,
     ) -> Result<ObjectModuleStateMeta, EngineStateBrowsingError> {
-        EntityInfoLoader::new(&self.reader).load_object_module_state_meta(node_id, module_id)
+        let type_target = self
+            .reader
+            .get_blueprint_type_target(node_id, module_id)
+            .map_err(|error| match error {
+                SystemReaderError::NodeIdDoesNotExist => {
+                    EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Entity)
+                }
+                SystemReaderError::ModuleDoesNotExist => {
+                    EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Module)
+                }
+                SystemReaderError::NotAnObject => EngineStateBrowsingError::RequestedItemInvalid(
+                    ItemKind::Entity,
+                    "not an object".to_string(),
+                ),
+                unexpected => EngineStateBrowsingError::UnexpectedEngineError(
+                    unexpected,
+                    "when getting type target".to_string(),
+                ),
+            })?;
+        self.load_blueprint_state_meta(&type_target)
     }
 
     /// Loads extra metadata on the given field (a part of [`Self::load_blueprint_meta()`]).
@@ -402,7 +411,7 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
     ) -> Result<BlueprintNamedTypeMeta, EngineStateBrowsingError> {
         Ok(BlueprintNamedTypeMeta {
             name,
-            resolved_type: SchemaLoader::new(&self.reader)
+            resolved_type: self
                 .augment_with_schema(ResolvedTypeReference::new(*node_id, scoped_type_id))?,
         })
     }
@@ -416,48 +425,215 @@ impl<'s, S: SubstateDatabase> EngineStateMetaLoader<'s, S> {
     ) -> Result<BlueprintTypeMeta, EngineStateBrowsingError> {
         Ok(match payload_def {
             BlueprintPayloadDef::Static(scoped_type_id) => BlueprintTypeMeta::Static(
-                SchemaLoader::new(&self.reader)
-                    .augment_with_schema(ResolvedTypeReference::new(*node_id, scoped_type_id))?,
+                self.augment_with_schema(ResolvedTypeReference::new(*node_id, scoped_type_id))?,
             ),
             BlueprintPayloadDef::Generic(index) => BlueprintTypeMeta::Generic(index),
         })
     }
 
-    /// An implementation delegate of [`Self::load_entity_meta()`] for uninstantiated entities.
-    fn derive_uninstantiated_entity_meta(
+    /// An implementation delegate of [`Self::load_entity_meta()`] for `Object`s.
+    fn load_object_meta(
         &self,
         node_id: &NodeId,
-    ) -> Result<EntityMeta, EngineStateBrowsingError> {
-        let mut staged_database = SubstateDatabaseOverlay::new_unmergeable(self.database);
+        object_info: ObjectInfo,
+    ) -> Result<ObjectMeta, EngineStateBrowsingError> {
+        let ObjectInfo {
+            blueprint_info,
+            object_type,
+        } = object_info;
+        Ok(ObjectMeta {
+            is_instantiated: !self.non_instantiated_node_ids.contains(node_id),
+            main_module_state: self.load_object_module_state_meta(node_id, ModuleId::Main)?,
+            attached_module_states: match object_type {
+                ObjectType::Global { modules } => modules
+                    .into_keys() // deliberately ignored per-module blueprint versions
+                    .map(|module_id| {
+                        Ok((
+                            module_id,
+                            self.load_object_module_state_meta(node_id, module_id.into())?,
+                        ))
+                    })
+                    .collect::<Result<IndexMap<_, _>, _>>()?,
+                ObjectType::Owned => index_map_new(),
+            },
+            blueprint_reference: BlueprintReference {
+                id: blueprint_info.blueprint_id,
+                version: blueprint_info.blueprint_version,
+            },
+            instance_meta: ObjectInstanceMeta {
+                outer_object: match blueprint_info.outer_obj_info {
+                    OuterObjectInfo::Some { outer_object } => Some(outer_object),
+                    OuterObjectInfo::None => None,
+                },
+                enabled_features: Vec::from_iter(blueprint_info.features),
+                substituted_generic_types: blueprint_info
+                    .generic_substitutions
+                    .into_iter()
+                    .map(|substitution| {
+                        TypeReferenceResolver::new(&self.reader)
+                            .resolve_generic_substitution(Some(node_id), substitution)
+                            .and_then(|resolved_type| self.augment_with_schema(resolved_type))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+            },
+        })
+    }
 
-        let intent = create_intent_forcing_instantiation(node_id);
+    /// An implementation delegate of [`Self::load_entity_meta()`] for `KeyValueStore`s.
+    fn load_kv_store_meta(
+        &self,
+        node_id: &NodeId,
+        kv_store_info: KeyValueStoreInfo,
+    ) -> Result<KeyValueStoreMeta, EngineStateBrowsingError> {
+        let KeyValueStoreGenericSubstitutions {
+            key_generic_substitution,
+            value_generic_substitution,
+            ..
+        } = kv_store_info.generic_substitutions;
+        let resolver = TypeReferenceResolver::new(&self.reader);
+        Ok(KeyValueStoreMeta {
+            resolved_key_type: resolver
+                .resolve_generic_substitution(Some(node_id), key_generic_substitution)
+                .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
+            resolved_value_type: resolver
+                .resolve_generic_substitution(Some(node_id), value_generic_substitution)
+                .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
+        })
+    }
 
-        // Note: here, we initialize a new `ScryptoVm` instance every time - however, this is
-        // currently a very lightweight operation. At the same time, we would NOT be able to feel
-        // the benefits of caching an instance (since we do not use any WASM here). If these
-        // assumptions change in future, then it will make most sense to turn the `Self` into a
-        // long-lived service holding a `ScryptoVm` as its dependency.
-        let scrypto_vm = ScryptoVm::<DefaultWasmEngine>::default();
+    /// Loads metadata of all fields and collections within the blueprint referenced by the given
+    /// [`BlueprintTypeTarget`]. The "type target" will also be used while resolving all types (see
+    /// [`TypeReferenceResolver`]).
+    fn load_blueprint_state_meta(
+        &self,
+        type_target: &BlueprintTypeTarget,
+    ) -> Result<ObjectModuleStateMeta, EngineStateBrowsingError> {
+        let blueprint_info = &type_target.blueprint_info;
+        let blueprint_id = &blueprint_info.blueprint_id;
+        let blueprint_name = blueprint_id.blueprint_name.as_str();
+        let IndexedStateSchema {
+            fields,
+            collections,
+            ..
+        } = self
+            .reader
+            .get_blueprint_definition(blueprint_id)
+            .map_err(|error| {
+                EngineStateBrowsingError::UnexpectedEngineError(
+                    error,
+                    "when getting blueprint definition".to_string(),
+                )
+            })?
+            .interface
+            .state
+            .clone();
 
-        let receipt = execute_and_commit_transaction(
-            &mut staged_database,
-            VmInit::new(&scrypto_vm, NoExtension),
-            &ExecutionConfig::default(),
-            &intent.get_executable(),
-        );
-        let TransactionResult::Commit(commit) = receipt.result else {
-            panic!("failed to force instantiation: {:?}", receipt);
+        let type_resolver = TypeReferenceResolver::new(&self.reader);
+        let conditions_context = self.load_conditions_context(blueprint_info)?;
+
+        let fields = fields
+            .into_iter()
+            .flat_map(|(_partition_description, fields)| fields)
+            .enumerate()
+            .filter(|(_index, schema)| conditions_context.meets(&schema.condition))
+            .map(|(index, schema)| {
+                Ok(ObjectFieldMeta::new(
+                    index,
+                    blueprint_id.blueprint_name.as_str(),
+                    type_resolver
+                        .resolve_type_from_blueprint_data(type_target, schema.field)
+                        .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
+                    schema.transience,
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let collections = collections
+            .into_iter()
+            .enumerate()
+            .map(|(index, (_partition_description, schema))| {
+                let (kind, collection_schema) = destructure_collection_schema(schema);
+                let BlueprintKeyValueSchema { key, value, .. } = collection_schema;
+                Ok(ObjectCollectionMeta::new(
+                    index,
+                    blueprint_name,
+                    kind,
+                    type_resolver
+                        .resolve_type_from_blueprint_data(type_target, key)
+                        .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
+                    type_resolver
+                        .resolve_type_from_blueprint_data(type_target, value)
+                        .and_then(|resolved_type| self.augment_with_schema(resolved_type))?,
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(ObjectModuleStateMeta {
+            fields,
+            collections,
+        })
+    }
+
+    /// Constructs an [`ObjectConditionsContext`] from the given object's blueprint-related info.
+    /// Note: the method belongs to the `load_*` family, since it may need to actually load the
+    /// outer object's enabled feature set (if it exists) from database.
+    fn load_conditions_context(
+        &self,
+        blueprint_info: &BlueprintInfo,
+    ) -> Result<ObjectConditionsContext, EngineStateBrowsingError> {
+        let object_features = blueprint_info.features.clone();
+        let outer_object_features = match &blueprint_info.outer_obj_info {
+            OuterObjectInfo::Some { outer_object } => {
+                self.reader
+                    .get_object_info(*outer_object.as_node_id())
+                    .map_err(|error| {
+                        EngineStateBrowsingError::UnexpectedEngineError(
+                            error,
+                            "when fetching outer object's info".to_string(),
+                        )
+                    })?
+                    .blueprint_info
+                    .features
+            }
+            OuterObjectInfo::None => index_set_new(),
         };
+        Ok(ObjectConditionsContext {
+            object_features,
+            outer_object_features,
+        })
+    }
 
-        let staged_reader = SystemDatabaseReader::new(&staged_database);
-        let type_info = staged_reader.get_type_info(node_id).map_err(|_| {
-            EngineStateBrowsingError::EngineInvariantBroken(
-                "an entity remained uninstantiated after access".to_string(),
-            )
-        })?;
-        EntityInfoLoader::new(&staged_reader)
-            .with_staged_instantiations_from(&commit)
-            .load_instantiated_entity_meta(type_info, node_id)
+    /// Wraps the given [`ResolvedTypeReference`] into a [`ResolvedTypeMeta`] by *eagerly* loading
+    /// the actual referenced schema.
+    /// Note: the schema seems irrelevant for many "get meta information" methods, but it is needed
+    /// to resolve human-readable type names (from which some field names are derived as well).
+    fn augment_with_schema(
+        &self,
+        type_reference: ResolvedTypeReference,
+    ) -> Result<ResolvedTypeMeta, EngineStateBrowsingError> {
+        Ok(ResolvedTypeMeta {
+            schema: match &type_reference {
+                ResolvedTypeReference::SchemaBased(schema_based) => {
+                    let SchemaReference {
+                        node_id,
+                        schema_hash,
+                    } = &schema_based.schema_reference;
+                    self.reader
+                        .get_schema(node_id, schema_hash)
+                        .map_err(|error| {
+                            EngineStateBrowsingError::UnexpectedEngineError(
+                                error,
+                                "when locating schema".to_string(),
+                            )
+                        })?
+                        .as_ref()
+                        .clone()
+                        .fully_update_and_into_latest_version()
+                }
+                ResolvedTypeReference::WellKnown(_) => SchemaV1::empty(),
+            },
+            type_reference,
+        })
     }
 }
 
@@ -933,84 +1109,12 @@ struct AuthorizedCallablesMeta {
     roles: BlueprintRolesDefinition,
 }
 
-/// A lister of entities.
-pub struct EngineEntityLister<'s, S> {
-    database: &'s S,
-}
-
-/// Basic information about an entity (i.e. read from a DB index, for listing purposes).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EntitySummary {
-    pub node_id: NodeId,
-    pub creation_id: CreationId,
-    pub blueprint_id: Option<BlueprintId>, // only present for Object entities
-}
-
-impl<'s, S: EntityListingIndex> EngineEntityLister<'s, S> {
-    /// Creates an instance reading from the given database.
-    pub fn new(database: &'s S) -> Self {
-        Self { database }
-    }
-
-    /// Returns an iterator of entities having one of the given [`EntityType`]s, starting from the
-    /// given [`CreationId`] (or its successor, if it does not exist), in the [`CreationId`]'s
-    /// natural order (ascending).
-    pub fn iter_created_entities(
-        &self,
-        entity_types: impl Iterator<Item = EntityType>,
-        from_creation_id: Option<&CreationId>,
-    ) -> Result<impl Iterator<Item = EntitySummary> + 's, EngineStateBrowsingError> {
-        Ok(entity_types
-            .map(|entity_type| {
-                self.database
-                    .get_created_entity_iter(entity_type, from_creation_id)
-            })
-            .kmerge_by(|(a_creation_id, _), (b_creation_id, _)| a_creation_id < b_creation_id)
-            .map(Self::to_entity_summary))
-    }
-
-    /// Returns an iterator of entities having the given [`BlueprintId`], starting from the given
-    /// [`CreationId`] (or its successor, if it does not exist), in the [`CreationId`]'s natural
-    /// order (ascending).
-    pub fn iter_blueprint_entities(
-        &self,
-        blueprint_id: &BlueprintId,
-        from_creation_id: Option<&CreationId>,
-    ) -> Result<impl Iterator<Item = EntitySummary> + 's, EngineStateBrowsingError> {
-        Ok(self
-            .database
-            .get_blueprint_entity_iter(blueprint_id, from_creation_id)
-            .map(Self::to_entity_summary))
-    }
-
-    /// Converts a database index entry into an [`EntitySummary`].
-    fn to_entity_summary(db_entry: (CreationId, EntityBlueprintId)) -> EntitySummary {
-        let (creation_id, entity_blueprint_id) = db_entry;
-        let EntityBlueprintIdV1 {
-            node_id,
-            blueprint_id,
-        } = entity_blueprint_id;
-        EntitySummary {
-            node_id,
-            creation_id,
-            blueprint_id,
-        }
-    }
-}
-
 /// A loader of Engine State's data (i.e. values) required by the Engine State API.
 pub struct EngineStateDataLoader<'s, S: SubstateDatabase> {
-    reader: SystemDatabaseReader<'s, S>,
+    pub reader: SystemDatabaseReader<'s, S>,
 }
 
 impl<'s, S: SubstateDatabase> EngineStateDataLoader<'s, S> {
-    /// Creates an instance reading from the given database.
-    pub fn new(database: &'s S) -> Self {
-        Self {
-            reader: SystemDatabaseReader::new(database),
-        }
-    }
-
     /// Loads an SBOR-encoded value of the given field.
     /// Note: technically, loading an SBOR does not need the fully-resolved field metadata (just its
     /// index); however, the object we return is schema-aware, so that it can render itself
@@ -1503,333 +1607,6 @@ impl From<EngineStateBrowsingError> for ResponseError {
     }
 }
 
-/// An internal implementation delegate for resolving information from an Entity's type info,
-/// aware of any "staged instantiation" of uninstantiated Entities.
-struct EntityInfoLoader<'s, S: SubstateDatabase> {
-    // Note: this will either be the direct reference to the caller's `reader`, or a temporary
-    // reader based on a staged database (when reading an uninstantiated Entity).
-    reader: &'s SystemDatabaseReader<'s, S>,
-    // Note: these are the Entities created via "staged instantiation" on the `reader`'s database;
-    // they can be read normally, but their `ObjectMeta.is_instantiated` will be `false`.
-    staged_node_ids: IndexSet<NodeId>,
-}
-
-impl<'s, S: SubstateDatabase> EntityInfoLoader<'s, S> {
-    /// Creates an instance sharing the given reader.
-    pub fn new(reader: &'s SystemDatabaseReader<'s, S>) -> Self {
-        Self {
-            reader,
-            staged_node_ids: index_set_new(),
-        }
-    }
-
-    /// Records the Entities instantiated by the given commit as "uninstantiated" (i.e. marks that
-    /// their [`ObjectMeta.is_instantiated`] should be `false` if read through this loader).
-    pub fn with_staged_instantiations_from(mut self, commit: &CommitResult) -> Self {
-        let StateUpdateSummary {
-            new_packages,
-            new_components,
-            new_resources,
-            new_vaults,
-            vault_balance_changes: _,
-        } = &commit.state_update_summary;
-        self.staged_node_ids
-            .extend(new_packages.iter().map(|addr| *addr.as_node_id()));
-        self.staged_node_ids
-            .extend(new_components.iter().map(|addr| *addr.as_node_id()));
-        self.staged_node_ids
-            .extend(new_resources.iter().map(|addr| *addr.as_node_id()));
-        self.staged_node_ids
-            .extend(new_vaults.iter().map(|addr| *addr.as_node_id()));
-        self
-    }
-
-    /// Loads metadata on the given entity, assuming that it is already instantiated (within the
-    /// [`Self.reader`]'s database) if needed.
-    /// The caller [`EngineStateMetaLoader::load_entity_meta()] shows how this is used to support
-    /// uninstantiated entities.
-    pub fn load_instantiated_entity_meta(
-        &self,
-        type_info: TypeInfoSubstate,
-        node_id: &NodeId,
-    ) -> Result<EntityMeta, EngineStateBrowsingError> {
-        match type_info {
-            TypeInfoSubstate::Object(object_info) => Ok(EntityMeta::Object(
-                self.load_object_meta(node_id, object_info)?,
-            )),
-            TypeInfoSubstate::KeyValueStore(kv_store_info) => Ok(EntityMeta::KeyValueStore(
-                self.load_kv_store_meta(node_id, kv_store_info)?,
-            )),
-            TypeInfoSubstate::GlobalAddressReservation(_)
-            | TypeInfoSubstate::GlobalAddressPhantom(_) => {
-                Err(EngineStateBrowsingError::RequestedItemInvalid(
-                    ItemKind::Entity,
-                    "entity neither an object nor a KV store".to_string(),
-                ))
-            }
-        }
-    }
-
-    /// Loads metadata on "state" (i.e. all fields and collections) of the given object's module.
-    /// Does *not* support uninstantiated objects.
-    ///
-    /// API note: this is normally a part of the [`Self::load_instantiated_entity_meta()`] result,
-    /// but some clients are interested only in specific module and can use this cheaper method.
-    pub fn load_object_module_state_meta(
-        &self,
-        node_id: &NodeId,
-        module_id: ModuleId,
-    ) -> Result<ObjectModuleStateMeta, EngineStateBrowsingError> {
-        let type_target = self
-            .reader
-            .get_blueprint_type_target(node_id, module_id)
-            .map_err(|error| match error {
-                SystemReaderError::NodeIdDoesNotExist => {
-                    EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Entity)
-                }
-                SystemReaderError::ModuleDoesNotExist => {
-                    EngineStateBrowsingError::RequestedItemNotFound(ItemKind::Module)
-                }
-                SystemReaderError::NotAnObject => EngineStateBrowsingError::RequestedItemInvalid(
-                    ItemKind::Entity,
-                    "not an object".to_string(),
-                ),
-                unexpected => EngineStateBrowsingError::UnexpectedEngineError(
-                    unexpected,
-                    "when getting type target".to_string(),
-                ),
-            })?;
-        self.load_blueprint_state_meta(&type_target)
-    }
-
-    /// Loads metadata of all fields and collections within the blueprint referenced by the given
-    /// [`BlueprintTypeTarget`]. The "type target" will also be used while resolving all types (see
-    /// [`TypeReferenceResolver`]).
-    fn load_blueprint_state_meta(
-        &self,
-        type_target: &BlueprintTypeTarget,
-    ) -> Result<ObjectModuleStateMeta, EngineStateBrowsingError> {
-        let blueprint_info = &type_target.blueprint_info;
-        let blueprint_id = &blueprint_info.blueprint_id;
-        let blueprint_name = blueprint_id.blueprint_name.as_str();
-        let IndexedStateSchema {
-            fields,
-            collections,
-            ..
-        } = self
-            .reader
-            .get_blueprint_definition(blueprint_id)
-            .map_err(|error| {
-                EngineStateBrowsingError::UnexpectedEngineError(
-                    error,
-                    "when getting blueprint definition".to_string(),
-                )
-            })?
-            .interface
-            .state
-            .clone();
-
-        let type_resolver = TypeReferenceResolver::new(self.reader);
-        let schema_loader = SchemaLoader::new(self.reader);
-        let conditions_context = self.load_conditions_context(blueprint_info)?;
-
-        let fields = fields
-            .into_iter()
-            .flat_map(|(_partition_description, fields)| fields)
-            .enumerate()
-            .filter(|(_index, schema)| conditions_context.meets(&schema.condition))
-            .map(|(index, schema)| {
-                Ok(ObjectFieldMeta::new(
-                    index,
-                    blueprint_id.blueprint_name.as_str(),
-                    type_resolver
-                        .resolve_type_from_blueprint_data(type_target, schema.field)
-                        .and_then(|resolved_type| {
-                            schema_loader.augment_with_schema(resolved_type)
-                        })?,
-                    schema.transience,
-                ))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let collections = collections
-            .into_iter()
-            .enumerate()
-            .map(|(index, (_partition_description, schema))| {
-                let (kind, collection_schema) = destructure_collection_schema(schema);
-                let BlueprintKeyValueSchema { key, value, .. } = collection_schema;
-                Ok(ObjectCollectionMeta::new(
-                    index,
-                    blueprint_name,
-                    kind,
-                    type_resolver
-                        .resolve_type_from_blueprint_data(type_target, key)
-                        .and_then(|resolved_type| {
-                            schema_loader.augment_with_schema(resolved_type)
-                        })?,
-                    type_resolver
-                        .resolve_type_from_blueprint_data(type_target, value)
-                        .and_then(|resolved_type| {
-                            schema_loader.augment_with_schema(resolved_type)
-                        })?,
-                ))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(ObjectModuleStateMeta {
-            fields,
-            collections,
-        })
-    }
-
-    /// Constructs an [`ObjectConditionsContext`] from the given object's blueprint-related info.
-    /// Note: the method belongs to the `load_*` family, since it may need to actually load the
-    /// outer object's enabled feature set (if it exists) from database.
-    fn load_conditions_context(
-        &self,
-        blueprint_info: &BlueprintInfo,
-    ) -> Result<ObjectConditionsContext, EngineStateBrowsingError> {
-        let object_features = blueprint_info.features.clone();
-        let outer_object_features = match &blueprint_info.outer_obj_info {
-            OuterObjectInfo::Some { outer_object } => {
-                self.reader
-                    .get_object_info(*outer_object.as_node_id())
-                    .map_err(|error| {
-                        EngineStateBrowsingError::UnexpectedEngineError(
-                            error,
-                            "when fetching outer object's info".to_string(),
-                        )
-                    })?
-                    .blueprint_info
-                    .features
-            }
-            OuterObjectInfo::None => index_set_new(),
-        };
-        Ok(ObjectConditionsContext {
-            object_features,
-            outer_object_features,
-        })
-    }
-
-    /// An implementation delegate of [`Self::load_instantiated_entity_meta()`] for `Object`s.
-    fn load_object_meta(
-        &self,
-        node_id: &NodeId,
-        object_info: ObjectInfo,
-    ) -> Result<ObjectMeta, EngineStateBrowsingError> {
-        let ObjectInfo {
-            blueprint_info,
-            object_type,
-        } = object_info;
-        Ok(ObjectMeta {
-            is_instantiated: !self.staged_node_ids.contains(node_id),
-            main_module_state: self.load_object_module_state_meta(node_id, ModuleId::Main)?,
-            attached_module_states: match object_type {
-                ObjectType::Global { modules } => modules
-                    .into_keys() // deliberately ignored per-module blueprint versions
-                    .map(|module_id| {
-                        Ok((
-                            module_id,
-                            self.load_object_module_state_meta(node_id, module_id.into())?,
-                        ))
-                    })
-                    .collect::<Result<IndexMap<_, _>, _>>()?,
-                ObjectType::Owned => index_map_new(),
-            },
-            blueprint_reference: BlueprintReference {
-                id: blueprint_info.blueprint_id,
-                version: blueprint_info.blueprint_version,
-            },
-            instance_meta: ObjectInstanceMeta {
-                outer_object: match blueprint_info.outer_obj_info {
-                    OuterObjectInfo::Some { outer_object } => Some(outer_object),
-                    OuterObjectInfo::None => None,
-                },
-                enabled_features: Vec::from_iter(blueprint_info.features),
-                substituted_generic_types: blueprint_info
-                    .generic_substitutions
-                    .into_iter()
-                    .map(|substitution| {
-                        TypeReferenceResolver::new(self.reader)
-                            .resolve_generic_substitution(Some(node_id), substitution)
-                            .and_then(|resolved_type| {
-                                SchemaLoader::new(self.reader).augment_with_schema(resolved_type)
-                            })
-                    })
-                    .collect::<Result<Vec<_>, _>>()?,
-            },
-        })
-    }
-
-    /// An implementation delegate of [`Self::load_instantiated_entity_meta()`] for `KeyValueStore`s.
-    fn load_kv_store_meta(
-        &self,
-        node_id: &NodeId,
-        kv_store_info: KeyValueStoreInfo,
-    ) -> Result<KeyValueStoreMeta, EngineStateBrowsingError> {
-        let KeyValueStoreGenericSubstitutions {
-            key_generic_substitution,
-            value_generic_substitution,
-            ..
-        } = kv_store_info.generic_substitutions;
-        let type_resolver = TypeReferenceResolver::new(self.reader);
-        let schema_loader = SchemaLoader::new(self.reader);
-        Ok(KeyValueStoreMeta {
-            resolved_key_type: type_resolver
-                .resolve_generic_substitution(Some(node_id), key_generic_substitution)
-                .and_then(|resolved_type| schema_loader.augment_with_schema(resolved_type))?,
-            resolved_value_type: type_resolver
-                .resolve_generic_substitution(Some(node_id), value_generic_substitution)
-                .and_then(|resolved_type| schema_loader.augment_with_schema(resolved_type))?,
-        })
-    }
-}
-
-/// An internal implementation delegate for augmenting type references with their schemas.
-struct SchemaLoader<'s, S: SubstateDatabase> {
-    reader: &'s SystemDatabaseReader<'s, S>,
-}
-
-impl<'s, S: SubstateDatabase> SchemaLoader<'s, S> {
-    /// Creates an instance sharing the given reader.
-    pub fn new(reader: &'s SystemDatabaseReader<'s, S>) -> Self {
-        Self { reader }
-    }
-
-    /// Wraps the given [`ResolvedTypeReference`] into a [`ResolvedTypeMeta`] by *eagerly* loading
-    /// the actual referenced schema.
-    /// Note: the schema seems irrelevant for many "get meta information" methods, but it is needed
-    /// to resolve human-readable type names (from which some field names are derived as well).
-    pub fn augment_with_schema(
-        &self,
-        type_reference: ResolvedTypeReference,
-    ) -> Result<ResolvedTypeMeta, EngineStateBrowsingError> {
-        Ok(ResolvedTypeMeta {
-            schema: match &type_reference {
-                ResolvedTypeReference::SchemaBased(schema_based) => {
-                    let SchemaReference {
-                        node_id,
-                        schema_hash,
-                    } = &schema_based.schema_reference;
-                    self.reader
-                        .get_schema(node_id, schema_hash)
-                        .map_err(|error| {
-                            EngineStateBrowsingError::UnexpectedEngineError(
-                                error,
-                                "when locating schema".to_string(),
-                            )
-                        })?
-                        .as_ref()
-                        .clone()
-                        .fully_update_and_into_latest_version()
-                }
-                ResolvedTypeReference::WellKnown(_) => SchemaV1::empty(),
-            },
-            type_reference,
-        })
-    }
-}
-
 /// Converts the given [`BlueprintCollectionSchema`] to a more direct representation.
 fn destructure_collection_schema(
     schema: BlueprintCollectionSchema<BlueprintPayloadDef>,
@@ -1845,54 +1622,5 @@ fn destructure_collection_schema(
         BlueprintCollectionSchema::SortedIndex(schema) => {
             (ObjectCollectionKind::SortedIndex, schema)
         }
-    }
-}
-
-/// Creates a minimal transaction intent which forces an instantiation of the given Entity.
-fn create_intent_forcing_instantiation(node_id: &NodeId) -> ValidatedPreviewIntent {
-    let address =
-        GlobalAddress::try_from(*node_id).expect("should only be reachable for global entities");
-    // Use dummy key, as for a regular preview:
-    let notary_public_key =
-        PublicKey::Secp256k1(Secp256k1PrivateKey::from_u64(1).unwrap().public_key());
-    let intent = IntentV1 {
-        header: TransactionHeaderV1 {
-            // Use dummy values, since we disable these checks anyway:
-            network_id: 0,
-            start_epoch_inclusive: Epoch::zero(),
-            end_epoch_exclusive: Epoch::zero(),
-            nonce: 0,
-            notary_public_key,
-            notary_is_signatory: true,
-            tip_percentage: 0,
-        },
-        instructions: InstructionsV1(vec![
-            // Call any basic, non-invasive method, which is enough to force instantiation:
-            // Note: the "get metadata" call below seems universal and future-proof enough, but
-            // a more elegant solution could be based on some hypothetical "ensure exists" method?
-            InstructionV1::CallMetadataMethod {
-                address: DynamicGlobalAddress::Static(address),
-                method_name: "get".to_string(),
-                args: ManifestValue::Tuple {
-                    fields: vec![ManifestValue::String {
-                        value: "dummy name".to_string(),
-                    }],
-                },
-            },
-        ]),
-        blobs: BlobsV1::default(),
-        message: MessageV1::None,
-    };
-
-    ValidatedPreviewIntent {
-        intent: intent.prepare().expect("hardcoded"),
-        encoded_instructions: manifest_encode(&intent.instructions.0).expect("hardcoded"),
-        signer_public_keys: vec![],
-        flags: PreviewFlags {
-            use_free_credit: true,
-            assume_all_signature_proofs: true,
-            skip_epoch_check: true,
-            disable_auth: true,
-        },
     }
 }

--- a/core-rust/node-common/src/jni/addressing.rs
+++ b/core-rust/node-common/src/jni/addressing.rs
@@ -159,6 +159,24 @@ extern "system" fn Java_com_radixdlt_identifiers_Address_nativeVirtualAccountAdd
 }
 
 #[no_mangle]
+extern "system" fn Java_com_radixdlt_identifiers_Address_nativeVirtualIdentityAddress(
+    env: JNIEnv,
+    _class: JClass,
+    request_payload: jbyteArray,
+) -> jbyteArray {
+    jni_sbor_coded_call(
+        &env,
+        request_payload,
+        |unchecked_public_key_bytes: [u8; Secp256k1PublicKey::LENGTH]| {
+            // Note: the bytes may represent a non-existent point on a curve (an invalid public key) -
+            // this is okay. We need to support this because there are such accounts on Olympia.
+            let public_key = Secp256k1PublicKey(unchecked_public_key_bytes);
+            ComponentAddress::virtual_identity_from_public_key(&public_key)
+        },
+    )
+}
+
+#[no_mangle]
 extern "system" fn Java_com_radixdlt_identifiers_Address_nativeGlobalFungible(
     env: JNIEnv,
     _class: JClass,

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectFieldTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectFieldTest.java
@@ -75,7 +75,9 @@ import com.radixdlt.api.core.generated.models.StreamProofsRequest;
 import com.radixdlt.api.engine_state.generated.models.*;
 import com.radixdlt.consensus.bft.Round;
 import com.radixdlt.consensus.epoch.EpochRound;
+import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.harness.predicates.NodesPredicate;
+import com.radixdlt.identifiers.Address;
 import com.radixdlt.rev2.Manifest;
 import java.util.List;
 import java.util.Map;
@@ -114,6 +116,26 @@ public final class ObjectFieldTest extends DeterministicEngineStateApiTestBase {
                               "kind", "I32",
                               "type_name", "ProposerMinuteTimestampSubstate",
                               "value", "0"))));
+    }
+  }
+
+  @Test
+  public void engine_state_api_returns_object_field_for_uninstantiated_entity() throws Exception {
+    try (var test = buildRunningServerTest(defaultConfig())) {
+      test.suppressUnusedWarning();
+
+      final var uninstantiatedAccountAddress =
+          Address.virtualAccountAddress(ECKeyPair.generateNew().getPublicKey());
+
+      final var response =
+          getObjectsApi()
+              .objectFieldPost(
+                  new ObjectFieldRequest()
+                      .entityAddress(uninstantiatedAccountAddress.encode(networkDefinition))
+                      .fieldName("deposit_rule"));
+
+      // we only care that some object is returned (the default):
+      assertThat(response.getContent().getProgrammaticJson()).isInstanceOf(Map.class);
     }
   }
 

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectMetadataEntryTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectMetadataEntryTest.java
@@ -68,6 +68,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.radixdlt.api.DeterministicEngineStateApiTestBase;
 import com.radixdlt.api.engine_state.generated.models.*;
+import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.identifiers.Address;
 import org.junit.Test;
 
 public final class ObjectMetadataEntryTest extends DeterministicEngineStateApiTestBase {
@@ -92,6 +94,28 @@ public final class ObjectMetadataEntryTest extends DeterministicEngineStateApiTe
               new UrlMetadataValue()
                   .value("https://assets.radixdlt.com/icons/icon-package_owner_badge.png")
                   .type(MetadataValueType.URL));
+    }
+  }
+
+  @Test
+  public void engine_state_api_return_object_metadata_entry_supports_uninstantiated()
+      throws Exception {
+    try (var test = buildRunningServerTest(defaultConfig())) {
+      test.suppressUnusedWarning();
+
+      final var uninstantiatedAccountAddress =
+          Address.virtualAccountAddress(ECKeyPair.generateNew().getPublicKey());
+
+      final var metadataValue =
+          getAttachedModulesApi()
+              .objectAttachedModulesMetadataEntryPost(
+                  new ObjectMetadataEntryRequest()
+                      .entityAddress(uninstantiatedAccountAddress.encode(networkDefinition))
+                      .key("owner_badge"))
+              .getContent();
+
+      // Hard to assert on the exact owner badge of a generated key, but we expect SOME value:
+      assertThat(metadataValue).isInstanceOf(NonFungibleLocalIdMetadataValue.class);
     }
   }
 }

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectMetadataIteratorTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectMetadataIteratorTest.java
@@ -69,6 +69,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.radixdlt.api.DeterministicEngineStateApiTestBase;
 import com.radixdlt.api.engine_state.generated.models.MetadataEntryKey;
 import com.radixdlt.api.engine_state.generated.models.ObjectMetadataIteratorRequest;
+import com.radixdlt.crypto.ECKeyPair;
+import com.radixdlt.identifiers.Address;
 import org.junit.Test;
 
 public final class ObjectMetadataIteratorTest extends DeterministicEngineStateApiTestBase {
@@ -91,6 +93,28 @@ public final class ObjectMetadataIteratorTest extends DeterministicEngineStateAp
               .toList();
 
       assertThat(metadataKeys).containsExactly("name", "description", "icon_url", "tags");
+    }
+  }
+
+  @Test
+  public void engine_state_api_object_metadata_iterator_supports_uninstantiated() throws Exception {
+    try (var test = buildRunningServerTest(defaultConfig())) {
+      test.suppressUnusedWarning();
+
+      final var uninstantiatedAccountAddress =
+          Address.virtualAccountAddress(ECKeyPair.generateNew().getPublicKey());
+
+      final var metadataKeys =
+          getAttachedModulesApi()
+              .objectAttachedModulesMetadataIteratorPost(
+                  new ObjectMetadataIteratorRequest()
+                      .entityAddress(uninstantiatedAccountAddress.encode(networkDefinition)))
+              .getPage()
+              .stream()
+              .map(MetadataEntryKey::getKey)
+              .toList();
+
+      assertThat(metadataKeys).containsExactly("owner_badge", "owner_keys");
     }
   }
 }

--- a/core/src/test/java/com/radixdlt/api/engine_state/ObjectRoyaltyTest.java
+++ b/core/src/test/java/com/radixdlt/api/engine_state/ObjectRoyaltyTest.java
@@ -70,8 +70,10 @@ import com.google.common.collect.ImmutableList;
 import com.radixdlt.api.DeterministicEngineStateApiTestBase;
 import com.radixdlt.api.engine_state.generated.client.ApiException;
 import com.radixdlt.api.engine_state.generated.models.*;
+import com.radixdlt.crypto.ECKeyPair;
 import com.radixdlt.genesis.GenesisBuilder;
 import com.radixdlt.genesis.GenesisConsensusManagerConfig;
+import com.radixdlt.identifiers.Address;
 import com.radixdlt.rev2.Decimal;
 import org.junit.Test;
 
@@ -161,6 +163,29 @@ public final class ObjectRoyaltyTest extends DeterministicEngineStateApiTestBase
                   .name("method_with_usd_package_royalty")
                   .packageRoyaltyAmount(usd(1))
                   .componentRoyaltyAmount(usd(4)));
+    }
+  }
+
+  @Test
+  public void engine_state_api_returns_object_royalty_of_uninstantiated_entity() throws Exception {
+    try (var test = buildRunningServerTest(defaultConfig())) {
+      test.suppressUnusedWarning();
+
+      var uninstantiatedIdentityAddress =
+          Address.virtualIdentityAddress(ECKeyPair.generateNew().getPublicKey());
+      var methodRoyalties =
+          getAttachedModulesApi()
+              .objectAttachedModulesRoyaltyPost(
+                  new ObjectRoyaltyRequest()
+                      .entityAddress(uninstantiatedIdentityAddress.encode(networkDefinition)))
+              .getMethodRoyalties();
+
+      assertThat(methodRoyalties)
+          .containsExactly(
+              new ObjectMethodRoyalty()
+                  .name("securify")
+                  .packageRoyaltyAmount(null)
+                  .componentRoyaltyAmount(null));
     }
   }
 


### PR DESCRIPTION
## Summary

Addresses https://radixdlt.atlassian.net/browse/NTM-72.

## Details

Previously the uninstantiated entities were only supported by `/entity/info` endpoint, via a piece of custom code (catch the "NodeId not found" case, force instantiation, load data from staged store).
After this change, this is now done for all endpoints. Doing this required moving the "force instantiation" mechanism to a preparatory step before the actual (possibly multiple) loads needed by the endpoint - hence, the business "loaders" now have a common factory responsible for that (== see the meat of this PR at `EngineStateLoaderFactory`).

## Testing

Added tests for all applicable endpoints which should see data of uninstantiated entity.