### PR TITLE
Timer for "mempool add" operation

### DIFF
--- a/core-rust/state-manager/src/mempool/mod.rs
+++ b/core-rust/state-manager/src/mempool/mod.rs
@@ -74,7 +74,7 @@ pub enum MempoolAddSource {
     MempoolSync,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum MempoolAddError {
     PriorityThresholdNotMet {
         min_tip_percentage_required: Option<u16>,
@@ -84,7 +84,7 @@ pub enum MempoolAddError {
     Rejected(MempoolAddRejection),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MempoolAddRejection {
     pub reason: MempoolRejectionReason,
     pub against_state: AtState,


### PR DESCRIPTION
## Summary

Addresses the first point of https://radixdlt.atlassian.net/browse/NODE-658.

## Details

We already had `mempool_submission_rejected_total` counter (of errors); I promoted it to `mempool_submission_attempt` histogram timer (of errors AND successes).

## Testing

No unit tests for metrics, but local run shows ~appropriate time buckets:
<img width="928" alt="image" src="https://github.com/user-attachments/assets/4a816c4f-c898-459b-909c-8dae5a1800af">
