### PR TITLE
Pin Rust version to `1.80.1`

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: RDXWorks-actions/toolchain@master
       with:
         # IMPORTANT: This version should match the version in radixdlt-scrypto on respective branch
-        toolchain: 1.77.2
+        toolchain: 1.80.1
         default: true
         target: ${{inputs.cross-compile-to-windows == 'true' && 'x86_64-pc-windows-msvc' || ''}}
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,40 @@
+name: 'Setup build environment'
+description: 'Common GH action to setup job environment'
+inputs:
+  cross-compile-to-windows:
+    description: "If 'true' then do some additional build environment setup"
+    required: false
+    default: "false" # or "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Rust toolchain
+      uses: RDXWorks-actions/toolchain@master
+      with:
+        # IMPORTANT: This version should match the version in radixdlt-scrypto on respective branch
+        toolchain: 1.77.2
+        default: true
+        target: ${{inputs.cross-compile-to-windows == 'true' && 'x86_64-pc-windows-msvc' || ''}}
+
+    - name: Set up JDK 17
+      if: ${{ inputs.cross-compile-to-windows == 'false' }}
+      uses: RDXWorks-actions/setup-java@main
+      with:
+        distribution: 'zulu'
+        java-version: '17'
+
+    - name: Install libclang-dev
+      if: ${{ inputs.cross-compile-to-windows == 'false' }}
+      run: sudo apt-get update -y && sudo apt-get install -y libclang-dev
+      shell: bash
+
+    ## Steps for cross-compilation to Windows
+    - name: Update clang version to 17
+      if: ${{ inputs.cross-compile-to-windows == 'true' }}
+      run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 17 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-17 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-17 /usr/bin/clang++ && sudo apt-get install -y libclang-dev llvm llvm-dev
+      shell: bash
+    - name: Install cargo-xwin
+      if: ${{ inputs.cross-compile-to-windows == 'true' }}
+      run: cargo install cargo-xwin --version 0.17.1 --locked
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,17 +109,8 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - uses: RDXWorks-actions/rust-toolchain@master
-        with:
-          toolchain: 1.77.2
-          default: true
-      - name: Set up JDK 17
-        uses: RDXWorks-actions/setup-java@main
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-      - name: Install libclang-dev
-        run: sudo apt-get update -y && sudo apt-get install -y libclang-dev
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
       - name: Cache SonarCloud packages
         uses: RDXWorks-actions/cache@main
         with:
@@ -168,7 +159,7 @@ jobs:
           name: distZip
           retention-days: 7
       - uses: ./.github/actions/fetch-secrets
-        with: 
+        with:
           role_name: "${{ secrets.COMMON_SECRETS_ROLE_ARN }}"
           app_name: "babylon-node"
           step_name: "build"
@@ -189,15 +180,8 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - uses: RDXWorks-actions/rust-toolchain@master
-        with:
-          toolchain: 1.77.2
-          default: true
-      - name: Set up JDK 17
-        uses: RDXWorks-actions/setup-java@main
-        with:
-          distribution: 'zulu'
-          java-version: '17'
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
       - name: Cache Gradle packages
         uses: RDXWorks-actions/cache@main
         with:
@@ -214,17 +198,8 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - uses: RDXWorks-actions/rust-toolchain@master
-        with:
-          toolchain: 1.77.2
-          default: true
-      - name: Set up JDK 17
-        uses: RDXWorks-actions/setup-java@main
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-      - name: Install libclang-dev
-        run: sudo apt-get update -y && sudo apt-get install -y libclang-dev
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
       - name: Cache Gradle packages
         uses: RDXWorks-actions/cache@main
         with:
@@ -243,17 +218,8 @@ jobs:
         with:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
-      - uses: RDXWorks-actions/rust-toolchain@master
-        with:
-          toolchain: 1.77.2
-          default: true
-      - name: Set up JDK 17
-        uses: RDXWorks-actions/setup-java@main
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-      - name: Install libclang-dev
-        run: sudo apt-get update -y && sudo apt-get install -y libclang-dev
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
       - name: Cache Gradle packages
         uses: RDXWorks-actions/cache@main
         with:
@@ -271,15 +237,10 @@ jobs:
       - uses: RDXWorks-actions/checkout@main
         with:
           fetch-depth: 1
-      - uses: RDXWorks-actions/rust-toolchain@master
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
         with:
-          toolchain: 1.77.2
-          default: true
-          targets: x86_64-pc-windows-msvc
-      - name: Update clang version to 17
-        run: sudo apt remove clang-14 && sudo apt autoclean && sudo apt autoremove && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 17 && sudo ls /usr/bin/ | grep clang && sudo ln -sf /usr/bin/clang-17 /usr/bin/clang && sudo ln -sf /usr/bin/clang++-17 /usr/bin/clang++ && sudo apt-get install -y libclang-dev llvm llvm-dev
-      - name: Install cargo-xwin
-        run: cargo install cargo-xwin --version 0.17.1 --locked
+          cross-compile-to-windows: "true"
       - name: cross compile to windows
         run: pushd core-rust; cargo xwin build --release --target x86_64-pc-windows-msvc
       - name: Publish corerust.dll


### PR DESCRIPTION
Changes:
- Move GH environment setup to shared action
- Pin Rust version to `1.80.1` (as in radixdlt-scrypto `develop` branch)