### PR TITLE
Improving self IP resolver's headers

### DIFF
--- a/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
+++ b/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
@@ -69,7 +69,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.google.common.net.HostAndPort;
 import com.radixdlt.lang.Result;
 import com.radixdlt.utils.properties.RuntimeProperties;
 import java.io.IOException;
@@ -184,14 +183,18 @@ final class NetworkQueryHostIp {
       final var request =
           new Request.Builder()
               .url(url)
-              .header("User-Agent", "curl/7.58.0")
-              .header("Accept", "*/*")
+              .header("User-Agent", "Mozilla/5.0")
+              .header("Accept", "text/plain,text/html")
+              .header("Accept-Encoding", "deflate,gzip,identity")
+              .header("Accept-Language", "en-GB,en-US")
               .get()
               .build();
       final var call = okHttpClient.newCall(request);
       try (var response = call.execute()) {
-        final var responseText = response.body().string().trim();
-        return Result.success(new HostIp(HostAndPort.fromHost(responseText).getHost()));
+        if (!response.isSuccessful()) {
+          return Result.error(new IOException("Not a success: %s".formatted(response)));
+        }
+        return Result.success(new HostIp(response.body().string().trim()));
       }
     } catch (IOException ex) {
       return Result.error(ex);

--- a/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
+++ b/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
@@ -67,9 +67,12 @@ package com.radixdlt.p2p.hostip;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
+import com.radixdlt.lang.Result;
 import com.radixdlt.utils.properties.RuntimeProperties;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -92,7 +95,9 @@ import org.apache.logging.log4j.Logger;
 final class NetworkQueryHostIp {
   private static final Logger log = LogManager.getLogger();
 
-  public record Result(Optional<HostIp> maybeHostIp, ImmutableList<URL> hostsQueried) {}
+  public record VotedResult(
+      Optional<HostIp> conclusiveHostIp,
+      ImmutableMap<URL, Result<HostIp, IOException>> individualQueryResults) {}
 
   @VisibleForTesting static final String QUERY_URLS_PROPERTY = "network.host_ip_query_urls";
 
@@ -125,7 +130,7 @@ final class NetworkQueryHostIp {
 
   private final List<URL> hosts;
   private final OkHttpClient okHttpClient;
-  private final Supplier<Result> result = Suppliers.memoize(this::get);
+  private final Supplier<VotedResult> result = Suppliers.memoize(this::get);
 
   NetworkQueryHostIp(Collection<URL> urls) {
     if (urls.isEmpty()) {
@@ -139,54 +144,57 @@ final class NetworkQueryHostIp {
     return this.hosts.size();
   }
 
-  public Result queryNetworkHosts() {
+  public VotedResult queryNetworkHosts() {
     return result.get();
   }
 
-  Result get() {
+  VotedResult get() {
     return publicIp((count() + 1) / 2); // Round up
   }
 
-  Result publicIp(int threshold) {
+  VotedResult publicIp(int threshold) {
     // Make sure we don't DoS the first one on the list
     Collections.shuffle(this.hosts);
     log.debug("Using hosts {}", this.hosts);
-    final Map<HostAndPort, AtomicInteger> ips = Maps.newHashMap();
-    final ImmutableList.Builder<URL> hostsQueried = ImmutableList.builder();
+    final Map<HostIp, AtomicInteger> successCounts = Maps.newHashMap();
+    final ImmutableMap.Builder<URL, Result<HostIp, IOException>> queryResults =
+        ImmutableMap.builder();
     for (URL url : this.hosts) {
-      HostAndPort q = query(url);
-      if (q != null) {
-        hostsQueried.add(url);
-        int newValue = ips.computeIfAbsent(q, k -> new AtomicInteger()).incrementAndGet();
-        if (newValue >= threshold) {
-          log.debug("Found address {}", q);
-          return new Result(Optional.of(new HostIp(q.getHost())), hostsQueried.build());
+      final Result<HostIp, IOException> result = query(url);
+      queryResults.put(url, result);
+      final Optional<HostIp> success = result.toOptional();
+      if (success.isPresent()) {
+        int newCount =
+            successCounts
+                .computeIfAbsent(success.get(), k -> new AtomicInteger())
+                .incrementAndGet();
+        if (newCount >= threshold) {
+          log.debug("Found address {}", success.get());
+          return new VotedResult(success, queryResults.build());
         }
       }
     }
     log.debug("No suitable address found");
-    return new Result(Optional.empty(), hostsQueried.build());
+    return new VotedResult(Optional.empty(), queryResults.build());
   }
 
-  HostAndPort query(URL url) {
+  Result<HostIp, IOException> query(URL url) {
     try {
-      final var response =
-          okHttpClient
-              .newCall(
-                  new Request.Builder()
-                      .url(url)
-                      .header(
-                          "User-Agent", "curl/7.58.0") // User agent is required by some services
-                      .header(
-                          "Accept", "*/*") // Similarly, this seems to be required by some services
-                      .get()
-                      .build())
-              .execute();
-      return HostAndPort.fromHost(response.body().string().trim());
-    } catch (Exception ex) {
-      // We don't want any single query to throw an uncaught exception
-      // (e.g. if they return an invalid response), so we're just catching all here.
-      return null;
+      // Some services simply require the headers we set here:
+      final var request =
+          new Request.Builder()
+              .url(url)
+              .header("User-Agent", "curl/7.58.0")
+              .header("Accept", "*/*")
+              .get()
+              .build();
+      final var call = okHttpClient.newCall(request);
+      try (var response = call.execute()) {
+        final var responseText = response.body().string().trim();
+        return Result.success(new HostIp(HostAndPort.fromHost(responseText).getHost()));
+      }
+    } catch (IOException ex) {
+      return Result.error(ex);
     }
   }
 

--- a/core/src/main/java/com/radixdlt/p2p/hostip/StandardHostIp.java
+++ b/core/src/main/java/com/radixdlt/p2p/hostip/StandardHostIp.java
@@ -98,14 +98,14 @@ public final class StandardHostIp {
     } else if (configuredHostIps.size() == 0) {
       final var networkQueryResult = NetworkQueryHostIp.create(properties).queryNetworkHosts();
 
-      if (networkQueryResult.maybeHostIp().isPresent()) {
+      if (networkQueryResult.conclusiveHostIp().isPresent()) {
         // All good, we have an IP address from network query
         log.info(
             "Host's public IP address has been acquired from an external oracle (services queried:"
                 + " {}). Consider setting a `network.host_ip` property instead to lessen reliance"
                 + " on external services.",
-            networkQueryResult.hostsQueried());
-        return networkQueryResult.maybeHostIp().orElseThrow();
+            networkQueryResult.individualQueryResults());
+        return networkQueryResult.conclusiveHostIp().orElseThrow();
       } else {
         throw new RuntimeException(
             String.format(
@@ -113,7 +113,7 @@ public final class StandardHostIp {
                     + "Make sure you set your `network.host_ip` property. "
                     + "An attempt was made to acquire it from an external oracle, "
                     + "but that also failed (services queried: %s).",
-                networkQueryResult.hostsQueried()));
+                networkQueryResult.individualQueryResults()));
       }
     } else {
       // We've got a configured IP and possibly also an IP address from an external oracle
@@ -134,7 +134,7 @@ public final class StandardHostIp {
       } else {
         // Non-local address was configured, so let's query the oracle and see if it matches
         final var networkQueryResult = NetworkQueryHostIp.create(properties).queryNetworkHosts();
-        if (networkQueryResult.maybeHostIp().stream()
+        if (networkQueryResult.conclusiveHostIp().stream()
             .anyMatch(hostIpFromNetwork -> !hostIpFromNetwork.equals(configuredHostIp))) {
           log.warn(
               "An IP address that was configured for this node ({}) differs from a public IP "
@@ -143,8 +143,8 @@ public final class StandardHostIp {
                   + "Make sure your `network.host_ip` property or "
                   + "`RADIXDLT_HOST_IP_ADDRESS` environment variable are set correctly.",
               configuredHostIp,
-              networkQueryResult.maybeHostIp().orElseThrow(),
-              networkQueryResult.hostsQueried());
+              networkQueryResult.conclusiveHostIp().orElseThrow(),
+              networkQueryResult.individualQueryResults());
         }
 
         log.info("Using a configured host IP address: {}", configuredHostIp);

--- a/core/src/test/java/com/radixdlt/p2p/hostip/NetworkQueryHostIpTest.java
+++ b/core/src/test/java/com/radixdlt/p2p/hostip/NetworkQueryHostIpTest.java
@@ -111,19 +111,16 @@ public class NetworkQueryHostIpTest {
   }
 
   @Test
-  public void testCollectionNotEmptyQueryFailed() throws IOException {
-    HttpURLConnection conn = mock(HttpURLConnection.class);
-    doReturn(404).when(conn).getResponseCode();
-    URL url = mock(URL.class);
-    doReturn(conn).when(url).openConnection();
-    NetworkQueryHostIp nqhip = NetworkQueryHostIp.create(List.of(url));
+  public void testCollectionNotEmptyQueryNotSuccessful() throws IOException {
+    NetworkQueryHostIp nqhip = NetworkQueryHostIp.create(List.of(makeUrl(404, "not found")));
     Optional<HostIp> host = nqhip.queryNetworkHosts().conclusiveHostIp();
     assertFalse(host.isPresent());
   }
 
   @Test
-  public void testCollectionNotEmptyQueryFailed2() throws IOException {
+  public void testCollectionNotEmptyQueryIoException() throws IOException {
     URL url = mock(URL.class);
+    doReturn("https://mock.url/with-io-problems").when(url).toString();
     doThrow(new IOException("test exception")).when(url).openConnection();
     NetworkQueryHostIp nqhip = NetworkQueryHostIp.create(List.of(url));
     Optional<HostIp> host = nqhip.queryNetworkHosts().conclusiveHostIp();
@@ -134,18 +131,24 @@ public class NetworkQueryHostIpTest {
   public void testCollectionAllDifferent() throws IOException {
     List<URL> urls =
         List.of(
-            makeUrl("127.0.0.1"), makeUrl("127.0.0.2"), makeUrl("127.0.0.3"), makeUrl("127.0.0.4"));
+            makeUrl(200, "127.0.0.1"),
+            makeUrl(200, "127.0.0.2"),
+            makeUrl(200, "127.0.0.3"),
+            makeUrl(200, "127.0.0.4"));
     NetworkQueryHostIp nqhip = NetworkQueryHostIp.create(urls);
     Optional<HostIp> host = nqhip.queryNetworkHosts().conclusiveHostIp();
     assertFalse(host.isPresent());
   }
 
-  private static URL makeUrl(String data) throws IOException {
-    ByteArrayInputStream input = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
+  private static URL makeUrl(int status, String body) throws IOException {
     HttpURLConnection conn = mock(HttpURLConnection.class);
-    doReturn(input).when(conn).getInputStream();
+    doReturn(status).when(conn).getResponseCode();
+    doReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)))
+        .when(conn)
+        .getInputStream();
     URL url = mock(URL.class);
     doReturn(conn).when(url).openConnection();
+    doReturn("https://mock.url/?result=%s".formatted(body)).when(url).toString();
     return url;
   }
 }

--- a/core/src/test/java/com/radixdlt/p2p/hostip/NetworkQueryHostIpTest.java
+++ b/core/src/test/java/com/radixdlt/p2p/hostip/NetworkQueryHostIpTest.java
@@ -117,7 +117,7 @@ public class NetworkQueryHostIpTest {
     URL url = mock(URL.class);
     doReturn(conn).when(url).openConnection();
     NetworkQueryHostIp nqhip = NetworkQueryHostIp.create(List.of(url));
-    Optional<HostIp> host = nqhip.queryNetworkHosts().maybeHostIp();
+    Optional<HostIp> host = nqhip.queryNetworkHosts().conclusiveHostIp();
     assertFalse(host.isPresent());
   }
 
@@ -126,7 +126,7 @@ public class NetworkQueryHostIpTest {
     URL url = mock(URL.class);
     doThrow(new IOException("test exception")).when(url).openConnection();
     NetworkQueryHostIp nqhip = NetworkQueryHostIp.create(List.of(url));
-    Optional<HostIp> host = nqhip.queryNetworkHosts().maybeHostIp();
+    Optional<HostIp> host = nqhip.queryNetworkHosts().conclusiveHostIp();
     assertFalse(host.isPresent());
   }
 
@@ -136,7 +136,7 @@ public class NetworkQueryHostIpTest {
         List.of(
             makeUrl("127.0.0.1"), makeUrl("127.0.0.2"), makeUrl("127.0.0.3"), makeUrl("127.0.0.4"));
     NetworkQueryHostIp nqhip = NetworkQueryHostIp.create(urls);
-    Optional<HostIp> host = nqhip.queryNetworkHosts().maybeHostIp();
+    Optional<HostIp> host = nqhip.queryNetworkHosts().conclusiveHostIp();
     assertFalse(host.isPresent());
   }
 


### PR DESCRIPTION
## Summary

Discovered while at https://github.com/radixdlt/babylon-node/pull/999.

We were getting too many HTTP 406 responses from IP-echoing services. Tweaking headers helped.
I also improved the error-surfacing there.

## Details

This only `cherry-pick`s 3 commits from `main`.