### PR TITLE
ci: Delete profile flag on building artifact for release

### DIFF
--- a/.github/workflows/add-artifacts-to-release.yml
+++ b/.github/workflows/add-artifacts-to-release.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build core-rust
         run: |
           cd core-rust
-          cargo build --release --profile=release --target ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }}
           echo "ls  ./target/${{ matrix.target }}/release"
           ls  ./target/${{ matrix.target }}/release/
         env:


### PR DESCRIPTION
## Summary

Workflow fails to build release artifacts, since only one flag ( or `--profile` or `--release` flags) is possible with cargo build.
`--profile` flag has been deleted.