### PR TITLE
Use the public IP address that is reported the most

### DIFF
--- a/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
+++ b/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
@@ -84,7 +84,8 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import okhttp3.*;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -171,14 +172,21 @@ final class NetworkQueryHostIp {
       }
     }
     if (successCounts.isEmpty()) {
-      log.warn("No suitable address found");
+      log.warn(
+          "Attempts to resolve this node's public IP address with external resolution services"
+              + " failed at every attempt. Perhaps this node cannot connect to the internet?");
     }
     if (successCounts.size() > 1) {
       String votes =
           successCounts.keySet().stream()
               .map(key -> key + "=" + successCounts.get(key))
               .collect(Collectors.joining(", ", "{", "}"));
-      log.warn("More than 1 IP address found: " + votes);
+      log.warn(
+          String.format(
+              "Attempts to resolve this node's public IP address with external resolution services"
+                  + " resulted in more than one distinct IP address. The node will continue by"
+                  + " using the most common: %s. The full list of resolved addresses is: %s",
+              maxResult.get(), votes));
     }
     return new VotedResult(maxResult, queryResults.build());
   }

--- a/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
+++ b/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
@@ -83,6 +83,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import okhttp3.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -168,6 +169,16 @@ final class NetworkQueryHostIp {
           maxResult = result.toOptional();
         }
       }
+    }
+    if (successCounts.isEmpty()) {
+      log.warn("No suitable address found");
+    }
+    if (successCounts.size() > 1) {
+      String votes =
+          successCounts.keySet().stream()
+              .map(key -> key + "=" + successCounts.get(key))
+              .collect(Collectors.joining(", ", "{", "}"));
+      log.warn("More than 1 IP address found: " + votes);
     }
     return new VotedResult(maxResult, queryResults.build());
   }


### PR DESCRIPTION
## Summary

Use the public IP address that is reported the most by the sources, to work around error:

```
An IP address of this node hasn't been configured. Make sure you set your `network.host_ip` property. An attempt was made to acquire it from an external oracle, but that also failed (services queried: [https://ifconfig.me/, https://ipv4.icanhazip.com/, https://www.trackip.net/ip, https://myexternalip.com/raw, https://ipecho.net/plain, https://ifconfig.co/ip, https://checkip.amazonaws.com/]).
```