### PR TITLE
Replace URL with String as the key

### DIFF
--- a/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
+++ b/core/src/main/java/com/radixdlt/p2p/hostip/NetworkQueryHostIp.java
@@ -128,6 +128,10 @@ final class NetworkQueryHostIp {
   private final OkHttpClient okHttpClient;
   private final Supplier<VotedResult> result = Suppliers.memoize(this::get);
 
+  NetworkQueryHostIp() {
+    this(DEFAULT_QUERY_URLS);
+  }
+
   NetworkQueryHostIp(Collection<String> urls) {
     if (urls.isEmpty()) {
       throw new IllegalArgumentException("At least one URL must be specified");
@@ -140,20 +144,24 @@ final class NetworkQueryHostIp {
     return this.hosts.size();
   }
 
+  List<String> hosts() {
+    return this.hosts;
+  }
+
   public VotedResult queryNetworkHosts() {
     return result.get();
   }
 
   VotedResult get() {
     // Make sure we don't DoS the first one on the list
-    Collections.shuffle(this.hosts);
-    log.debug("Using hosts {}", this.hosts);
+    Collections.shuffle(this.hosts());
+    log.debug("Using hosts {}", this.hosts());
     final Map<HostIp, AtomicInteger> successCounts = Maps.newHashMap();
     final ImmutableMap.Builder<String, Result<HostIp, IOException>> queryResults =
         ImmutableMap.builder();
     int maxCount = 0;
     Optional<HostIp> maxResult = Optional.empty();
-    for (String url : this.hosts) {
+    for (String url : this.hosts()) {
       final Result<HostIp, IOException> result = query(url);
       queryResults.put(url, result);
       if (result.isSuccess()) {


### PR DESCRIPTION
The equals() implementation of URL resolves the hostname into an IP address. When multiple URLs are mapped into the same IP (especially with 1.1.1.1 DNS server), it will cause the following exception:

```
java.lang.IllegalArgumentException: Multiple entries with same key: https://ifconfig.co/ip=Success(x.x.x.x) and https://www.trackip.net/ip=Success(x.x.x.x)
        at com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:377)
        at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:371)
        at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:241)
        at com.google.common.collect.RegularImmutableMap.fromEntryArrayCheckingBucketOverflow(RegularImmutableMap.java:132)
        at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:94)
        at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:573)
        at com.google.common.collect.ImmutableMap$Builder.buildOrThrow(ImmutableMap.java:601)
        at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:588)
        at com.radixdlt.p2p.hostip.NetworkQueryHostIp.get(NetworkQueryHostIp.java:191)
```
