### PR TITLE
tweak: API schema changes require interface sign-off

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,6 @@
 # SECURITY-SENSITIVE
 /.github/ @radixdlt/protocol-security-approvers
 *.lock @radixdlt/protocol-security-approvers
+
+# API INTERFACES
+*api-schema.yaml @radixdlt/interfaces-github-approvers


### PR DESCRIPTION
## Summary

Changes to the api schema files requires sign-off from the interfaces team, to check observance against the API change policies.

## Testing

N/A

## Changelog

N/A