### PR TITLE
Support longer `state_hash_tree.state_version_history_length`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 
 ## v1.3.1
 
+### Other changes
+
 * [#1063](https://github.com/radixdlt/babylon-node/pull/1063) - Permits configuring larger values of `state_hash_tree.state_version_history_length` up to `9,223,372,036,854,775,807`, although we currently advise against running with full history; due to very large disk usage.
 
 ## v1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 ## v1.3.1
 
-* Permits configuring larger values of `state_hash_tree.state_version_history_length` up to `9,223,372,036,854,775,807`, although we currently advise against running with full history; due to very large disk usage.
+* [#1063](https://github.com/radixdlt/babylon-node/pull/1063) - Permits configuring larger values of `state_hash_tree.state_version_history_length` up to `9,223,372,036,854,775,807`, although we currently advise against running with full history; due to very large disk usage.
 
 ## v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 
 # v1.3.x - [Cuttlefish](https://docs.radixdlt.com/docs/cuttlefish)
 
+## v1.3.1
+
+* Permits configuring larger values of `state_hash_tree.state_version_history_length` up to `9,223,372,036,854,775,807`, although we currently advise against running with full history; due to very large disk usage.
+
 ## v1.3.0
 
 We didn't have a formal changelog. Please see the [protocol updates](https://docs.radixdlt.com/docs/protocol-updates) section of the docs site for more information.

--- a/core/src/main/java/com/radixdlt/RadixNodeModule.java
+++ b/core/src/main/java/com/radixdlt/RadixNodeModule.java
@@ -475,7 +475,7 @@ public final class RadixNodeModule extends AbstractModule {
     // - we want to offer Merkle proofs verification up to 10 minutes after their generation.
     // Note: the legacy `state_hash_tree` name lives on here to avoid breaking configurations.
     var stateVersionHistoryLength =
-        properties.get("state_hash_tree.state_version_history_length", 60000);
+        properties.get("state_hash_tree.state_version_history_length", 60000L);
     Preconditions.checkArgument(
         stateVersionHistoryLength >= 0,
         "state version history length must not be negative: %s",


### PR DESCRIPTION
## Summary

Whilst we advise against large values for `state_hash_tree.state_version_history_length`, it appears the node doesn't even support values larger than Java's max int. This was an oversight, as the next line tries to cast it to a long.

This PR fixes this oversight, avoiding this error for any configured value between `2,147,483,647` and `9,223,372,036,854,775,807`:

```txt
Caused by: java.lang.IllegalArgumentException: There was an error when parsing configuration 'state_hash_tree.state_version_history_length' with value 'xxxxxxxxxxxx'.

```

## Testing

Existing tests pass

## Changelog

The changelog has been updated.